### PR TITLE
Fix UnsupportedOperationException

### DIFF
--- a/src/main/scala/service/IssuesService.scala
+++ b/src/main/scala/service/IssuesService.scala
@@ -158,10 +158,11 @@ trait IssuesService {
    */
   private def searchIssueQuery(repos: Seq[(String, String)], condition: IssueSearchCondition, filterUser: Map[String, String]) =
     Query(Issues) filter { t1 =>
-      (condition.repo
+      condition.repo
           .map { _.split('/') match { case array => Seq(array(0) -> array(1)) } }
           .getOrElse (repos)
-          .map { case (owner, repository) => t1.byRepository(owner, repository) } reduceLeft ( _ || _ ) ) &&
+          .map { case (owner, repository) => t1.byRepository(owner, repository) }
+          .foldLeft[Column[Boolean]](false) ( _ || _ ) &&
       (t1.closed           is (condition.state == "closed").bind) &&
       (t1.milestoneId      is condition.milestoneId.get.get.bind, condition.milestoneId.flatten.isDefined) &&
       (t1.milestoneId      isNull, condition.milestoneId == Some(None)) &&


### PR DESCRIPTION
Create new user and access to dashboard/issues/repos.

```
HTTP ERROR 500

Problem accessing /dashboard/issues/repos. Reason:

    empty.reduceLeft
Caused by:

java.lang.UnsupportedOperationException: empty.reduceLeft
    at scala.collection.LinearSeqOptimized$class.reduceLeft(LinearSeqOptimized.scala:124)
    at scala.collection.immutable.List.reduceLeft(List.scala:84)
    at service.IssuesService$$anonfun$searchIssueQuery$1.apply(IssuesService.scala:164)
    at service.IssuesService$$anonfun$searchIssueQuery$1.apply(IssuesService.scala:160)
    at scala.slick.lifted.Query.filter(Query.scala:37)
    at service.IssuesService$class.searchIssueQuery(IssuesService.scala:160)
    at service.IssuesService$class.searchIssue(IssuesService.scala:119)
    at app.DashboardController.searchIssue(DashboardController.scala:6)
    at app.DashboardControllerBase$class.app$DashboardControllerBase$$searchIssues(DashboardController.scala:43)
    at app.DashboardControllerBase$$anonfun$1$$anonfun$apply$1.apply(DashboardController.scala:14)
...
```
