### PR TITLE
Ensure display file content of specified commit

### DIFF
--- a/src/main/scala/app/RepositoryViewerController.scala
+++ b/src/main/scala/app/RepositoryViewerController.scala
@@ -213,7 +213,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       case branch if(path == branch || path.startsWith(branch + "/")) => branch
     } orElse repository.tags.collectFirst {
       case tag if(path == tag.name || path.startsWith(tag.name + "/")) => tag.name
-    } orElse Some(path) get
+    } orElse Some(path.split("/")(0)) get
 
     (id, path.substring(id.length).replaceFirst("^/", ""))
   }


### PR DESCRIPTION
fix this error

```
HTTP ERROR 500

Problem accessing /root/gitbucket/blob/71751ae4bc7a4a2fedcfb3a6b4a19d62e90642d1/src/main/scala/service/IssuesService.scala. Reason:

    Server Error

Caused by:

java.lang.NullPointerException
    at org.eclipse.jgit.lib.ObjectIdOwnerMap.get(ObjectIdOwnerMap.java:131)
    at org.eclipse.jgit.revwalk.RevWalk.parseAny(RevWalk.java:807)
    at util.JGitUtil$.getRevCommitFromId(JGitUtil.scala:144)
    at app.RepositoryViewerControllerBase$$anonfun$7$$anonfun$apply$8$$anonfun$apply$9.apply(RepositoryViewerController.scala:79)
    at app.RepositoryViewerControllerBase$$anonfun$7$$anonfun$apply$8$$anonfun$apply$9.apply(RepositoryViewerController.scala:78)
    at util.JGitUtil$.withGit(JGitUtil.scala:129)
    at util.JGitUtil$.withGit(JGitUtil.scala:121)
    at app.RepositoryViewerControllerBase$$anonfun$7$$anonfun$apply$8.apply(RepositoryViewerController.scala:78)
    at app.RepositoryViewerControllerBase$$anonfun$7$$anonfun$apply$8.apply(RepositoryViewerController.scala:74)
```

I think splitPath should be split by / when specified commit.
