### PR TITLE
Specify ContentType

### DIFF
--- a/src/main/scala/app/ControllerBase.scala
+++ b/src/main/scala/app/ControllerBase.scala
@@ -22,6 +22,10 @@ abstract class ControllerBase extends ScalatraFilter
 
   implicit val jsonFormats = DefaultFormats
 
+  before() {
+    contentType = "text/html"
+  }
+
   override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
     val httpRequest  = request.asInstanceOf[HttpServletRequest]
     val httpResponse = response.asInstanceOf[HttpServletResponse]


### PR DESCRIPTION
Internet Explorer sometimes sends funny accept heade as below.
`Accept: image/gif, image/jpeg, image/pjpeg, image/pjpeg, application/x-shockwave-flash, */*`

In such situation, Content-Type header in response becomes `application/x-shockwave-flash`,
and Internet Explorer renders nothing.

So, gitbucket should specify Content-Type header.
