### PR TITLE
Fix Content-Type.

### DIFF
--- a/src/main/scala/app/AccountController.scala
+++ b/src/main/scala/app/AccountController.scala
@@ -69,6 +69,7 @@ trait AccountControllerBase extends AccountManagementControllerBase with FlashMa
       contentType = FileUtil.getMimeType(image)
       new java.io.File(getUserUploadDir(userName), image)
     } getOrElse {
+      response.characterEncoding = None
       contentType = "image/png"
       Thread.currentThread.getContextClassLoader.getResourceAsStream("noimage.png")
     }

--- a/src/main/scala/app/RepositoryViewerController.scala
+++ b/src/main/scala/app/RepositoryViewerController.scala
@@ -95,6 +95,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
 
       if(raw){
         // Download
+        response.characterEncoding = None
         contentType = "application/octet-stream"
         JGitUtil.getContent(git, objectId, false).get
       } else {
@@ -192,7 +193,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       val zipFile = new File(workDir, (if(revision.length == 40) revision.substring(0, 10) else revision) + ".zip")
       FileUtil.createZipFile(zipFile, cloneDir)
       
-      contentType = "application/octet-stream"
+      response.characterEncoding = None
+      contentType = "application/zip"
       zipFile
     } else {
       BadRequest

--- a/src/main/scala/app/WikiController.scala
+++ b/src/main/scala/app/WikiController.scala
@@ -131,6 +131,7 @@ trait WikiControllerBase extends ControllerBase {
   get("/:owner/:repository/wiki/_blob/*")(referrersOnly { repository =>
     getFileContent(repository.owner, repository.name, multiParams("splat").head).map { content =>
         contentType = "application/octet-stream"
+        response.characterEncoding = None
         content
     } getOrElse NotFound
   })


### PR DESCRIPTION
Fix content type in response header.
- change from `application/octet-stream` to `application/zip` for downloading zip.
- remove `;charset=UTF-8` for non-text resources.
