### PR TITLE
Fix a problem in making link to commit in activities

### DIFF
--- a/src/main/twirl/helper/activities.scala.html
+++ b/src/main/twirl/helper/activities.scala.html
@@ -24,10 +24,12 @@
               if(i == 3){
                 <div>...</div>
               } else {
-                <div>
-                   <a href={s"${path}/${activity.userName}/${activity.repositoryName}/commit/${commit.substring(0, 40)}"} class="monospace">{commit.substring(0, 7)}</a>
-                    <span>{commit.substring(41)}</span>
-                </div>
+                if(commit.nonEmpty){
+                  <div>
+                     <a href={s"${path}/${activity.userName}/${activity.repositoryName}/commit/${commit. substring(0, 40)}"} class="monospace">{commit.substring(0, 7)}</a>
+                     <span>{commit.substring(41)}</span>
+                  </div>
+                }
               }
             }}
           </div>


### PR DESCRIPTION
When I push local change that is cutting a new branch having no commit, app display follow StackTrace.

<pre>
HTTP Status 500 - String index out of range: 40

type Exception report

message String index out of range: 40

description The server encountered an internal error that prevented it from fulfilling this request.

exception

java.lang.StringIndexOutOfBoundsException: String index out of range: 40
    java.lang.String.substring(String.java:1907)
    helper.html.activities$$anonfun$apply$1$$anonfun$apply$2.apply(activities.template.scala:80)
    helper.html.activities$$anonfun$apply$1$$anonfun$apply$2.apply(activities.template.scala:75)
    scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
...
</pre>


Fix that error by refference to [Ignore error in activity timeline caused by invalid data. · 3546a5d · takezoe/gitbucket](https://github.com/takezoe/gitbucket/commit/3546a5d392206a1e343de33cfaa5546b19957a3d)
