### PR TITLE
Fix bug dot not skip migration when first init

### DIFF
--- a/src/main/scala/servlet/AutoUpdateListener.scala
+++ b/src/main/scala/servlet/AutoUpdateListener.scala
@@ -73,7 +73,8 @@ object AutoUpdate {
     },
     Version(1, 2),
     Version(1, 1),
-    Version(1, 0)
+    Version(1, 0),
+    Version(0, 0)
   )
   
   /**


### PR DESCRIPTION
This pull request fixed this error. (master branch, not in 1.6)
this but related 4afbfcb016db0ef6c5e8eb4d3fe1df989fd1fdea. (refs #106)

```
HTTP ERROR 500

Problem accessing /. Reason:

    ???? "ACTIVITY" ????????
Table "ACTIVITY" not found; SQL statement:
select x2.x3, x2.x4, x2.x5, x2.x6, x2.x7, x2.x8, x2.x9, x2.x10 from (select x11.x12 as x3, x11.x13 as x4, x11.x14 as x5, x11.x15 as x6, x11.x16 as x7, x11.x17 as x8, x11.x18 as x9, x11.x19 as x10 from (select x20."ACTIVITY_ID" as x12, x20."USER_NAME" as x13, x20."REPOSITORY_NAME" as x14, x20."ACTIVITY_USER_NAME" as x15, x20."ACTIVITY_TYPE" as x16, x20."MESSAGE" as x17, x20."ADDITIONAL_INFO" as x18, x20."ACTIVITY_DATE" as x19 from "ACTIVITY" x20) x11 inner join (select x21."USER_NAME" as x22, x21."REPOSITORY_NAME" as x23, x21."PRIVATE" as x24 from "REPOSITORY" x21) x25 on (x11.x13 = x25.x22) and (x11.x14 = x25.x23) where x25.x24 = ? order by x11.x12 desc limit 30) x2 [42102-171]

Caused by:

org.h2.jdbc.JdbcSQLException: ???? "ACTIVITY" ????????
Table "ACTIVITY" not found; SQL statement:
select x2.x3, x2.x4, x2.x5, x2.x6, x2.x7, x2.x8, x2.x9, x2.x10 from (select x11.x12 as x3, x11.x13 as x4, x11.x14 as x5, x11.x15 as x6, x11.x16 as x7, x11.x17 as x8, x11.x18 as x9, x11.x19 as x10 from (select x20."ACTIVITY_ID" as x12, x20."USER_NAME" as x13, x20."REPOSITORY_NAME" as x14, x20."ACTIVITY_USER_NAME" as x15, x20."ACTIVITY_TYPE" as x16, x20."MESSAGE" as x17, x20."ADDITIONAL_INFO" as x18, x20."ACTIVITY_DATE" as x19 from "ACTIVITY" x20) x11 inner join (select x21."USER_NAME" as x22, x21."REPOSITORY_NAME" as x23, x21."PRIVATE" as x24 from "REPOSITORY" x21) x25 on (x11.x13 = x25.x22) and (x11.x14 = x25.x23) where x25.x24 = ? order by x11.x12 desc limit 30) x2 [42102-171]
    at org.h2.message.DbException.getJdbcSQLException(DbException.java:329)
    at org.h2.message.DbException.get(DbException.java:169)
    at org.h2.message.DbException.get(DbException.java:146)
    at org.h2.command.Parser.readTableOrView(Parser.java:4782)
    at org.h2.command.Parser.readTableFilter(Parser.java:1091)
    at org.h2.command.Parser.parseSelectSimpleFromPart(Parser.java:1697)
    at org.h2.command.Parser.parseSelectSimple(Parser.java:1804)
    at org.h2.command.Parser.parseSelectSub(Parser.java:1691)
    at org.h2.command.Parser.parseSelectUnion(Parser.java:1534)
    at org.h2.command.Parser.readTableFilter(Parser.java:1033)
    at org.h2.command.Parser.parseSelectSimpleFromPart(Parser.java:1697)
```

How to reproduce
1. `rm -rf $HOME/gitbucket`
2. `./sbt.sh ~container:start`
