### PR TITLE
Add a launch with cloudify image + link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ GitBucket
 
 GitBucket is the easily installable Github clone written with Scala.
 
+## Demo
+[![Launch with Cloudify](http://rantav.github.io/cloudify-widget-pages/img/gh-button.png)](http://rantav.github.io/cloudify-widget-pages/gitbucket.html)
+
+
 The current version of GitBucket provides a basic features below:
 
 - Public / Private Git repository (http access only)


### PR DESCRIPTION
Hi there, in this PR I'm adding a button that lets anyone launch a new live instance of GitBucket in their browser.  :smile:

When users click on the "Launch with Cloudify" button, they get a dedicated virtual machine that automatically installs GitBucket for them to play - for 20 minutes. 
Under the hood it uses Cloudify to achieve that.

I work with Gigaspaces, the company behind Cloudify to get community feedback for the new Cloudify product and we chose GitBucket as an interesting use case.

This is a proof of concept, not actual production code, so please don't just merge this PR yet... 
Although just POC, it's functional so feel free to play with it and most importantly - send feedback. 
Ideally, if you like it, I'll make it production ready and if not, I'm very much interested in getting your constructive feedback.

BTW we're enabling users to try it out directly from the your site/readme page, it's white-label.
We provide a free trial machine for 20m without any additional cost to users.

Thank you! And looking forward to getting your feedback!
