### PR TITLE
Change link text to 'Older'

### DIFF
--- a/src/main/twirl/repo/commits.scala.html
+++ b/src/main/twirl/repo/commits.scala.html
@@ -61,6 +61,6 @@
   }
   <div class="btn-group">
     <button class="btn" onclick="location.href='?page=@{page - 1}'"@if(page <= 1){ disabled="true"}>&lt; Newer</button>
-    <button class="btn" onclick="location.href='?page=@{page + 1}'"@if(!hasNext){ disabled="true"}>Order &gt;</button>
+    <button class="btn" onclick="location.href='?page=@{page + 1}'"@if(!hasNext){ disabled="true"}>Older &gt;</button>
   </div>   
 }


### PR DESCRIPTION
Updates the link text for previous commits to read 'Older' and not 'Order'.
