### PR TITLE
retrieve LDAP emails as lowercase to avoid confusion

### DIFF
--- a/src/main/scala/view/AvatarImageProvider.scala
+++ b/src/main/scala/view/AvatarImageProvider.scala
@@ -15,13 +15,13 @@ trait AvatarImageProvider { self: RequestCache =>
 
     val src = getAccountByUserName(userName).map { account =>
       if(account.image.isEmpty && getSystemSettings().gravatar){
-        s"""http://www.gravatar.com/avatar/${StringUtil.md5(account.mailAddress)}?s=${size}"""
+        s"""http://www.gravatar.com/avatar/${StringUtil.md5(account.mailAddress.toLowerCase())}?s=${size}"""
       } else {
         s"""${context.path}/${userName}/_avatar"""
       }
     } getOrElse {
       if(mailAddress.nonEmpty && getSystemSettings().gravatar){
-        s"""http://www.gravatar.com/avatar/${StringUtil.md5(mailAddress)}?s=${size}"""
+        s"""http://www.gravatar.com/avatar/${StringUtil.md5(mailAddress.toLowerCase())}?s=${size}"""
       } else {
         s"""${context.path}/${userName}/_avatar"""
       }


### PR DESCRIPTION
Our LDAP has my email address in the system with capital characters.  This is causing my gravatar to not be found.  I tried entering my email address with the capitalization into my gravatar account. Gravatar only takes email accounts as lowercase. So instead of retrieving the LDAP email address as-is, we should make it lowercase. Capitalized email addresses dont make good sense anyways.
