### PR TITLE
Fix a problem to redirect wikipage named by multi-byte characters

### DIFF
--- a/src/main/scala/app/SignInController.scala
+++ b/src/main/scala/app/SignInController.scala
@@ -3,6 +3,7 @@ package app
 import service._
 import jp.sf.amateras.scalatra.forms._
 import util.Implicits._
+import util.StringUtil._
 import util.Keys
 
 class SignInController extends SignInControllerBase with SystemSettingsService with AccountService
@@ -47,7 +48,7 @@ trait SignInControllerBase extends ControllerBase { self: SystemSettingsService 
       if(redirectUrl.replaceFirst("/$", "") == request.getContextPath){
         redirect("/")
       } else {
-        redirect(redirectUrl)
+        redirect(urlEncode(redirectUrl).replaceAll("%2F", "/"))
       }
     }.getOrElse {
       redirect("/")


### PR DESCRIPTION
In some specific case, redirect path (created from route params) is incorrect.

(from src/main/scala/app/SignInController.scala)

```
 46     session.getAndRemove[String](Keys.Session.Redirect).map { redirectUrl =>
```

`redirectUrl` is expected to be encoded,
but scalatra decodes route params by rl.UrlCodingUtils via ScalatraBase.UriDecoder.

In this result, we can't redirect wikipage named by multi-byte characters.

Demo:
- from http://cdn-ak.f.st-hatena.com/images/fotolife/s/smly/20131019/20131019134651.png
- to http://cdn-ak.f.st-hatena.com/images/fotolife/s/smly/20131019/20131019134652.png

To avoid this problem, I add dirty workaround to encode redirect path.
