### PR TITLE
Adding LDAP StartTLS support

### DIFF
--- a/src/main/scala/app/SystemSettingsController.scala
+++ b/src/main/scala/app/SystemSettingsController.scala
@@ -34,7 +34,7 @@ trait SystemSettingsControllerBase extends ControllerBase with FlashMapSupport {
         "baseDN"                   -> trim(label("Base DN", text(required))),
         "userNameAttribute"        -> trim(label("User name attribute", text(required))),
         "mailAttribute"            -> trim(label("Mail address attribute", text(required))),
-        "tls"                      -> trim(label("Enable StartTLS", optional(boolean()))),
+        "tls"                      -> trim(label("Enable TLS", optional(boolean()))),
         "keystore"                 -> trim(label("Keystore", optional(text())))
     )(Ldap.apply))
   )(SystemSettings.apply)

--- a/src/main/scala/service/SystemSettingsService.scala
+++ b/src/main/scala/service/SystemSettingsService.scala
@@ -116,7 +116,6 @@ object SystemSettingsService {
 
   val DefaultSmtpPort = 25
   val DefaultLdapPort = 389
-  val DefaultLdapKeystore = "/var/lib/gitbucket/keystore"
 
   private val AllowAccountRegistration = "allow_account_registration"
   private val Gravatar = "gravatar"

--- a/src/main/scala/util/LDAPUtil.scala
+++ b/src/main/scala/util/LDAPUtil.scala
@@ -14,7 +14,7 @@ import scala.annotation.tailrec
 object LDAPUtil {
 
   private val LDAP_VERSION: Int = LDAPConnection.LDAP_V3
-  private val logger = LoggerFactory.getLogger("LDAPUtil")
+  private val logger = LoggerFactory.getLogger(getClass().getName())
 
   /**
    * Try authentication by LDAP using given configuration.
@@ -27,7 +27,7 @@ object LDAPUtil {
       ldapSettings.bindDN.getOrElse(""),
       ldapSettings.bindPassword.getOrElse(""),
       ldapSettings.tls.getOrElse(false),
-      ldapSettings.keystore.getOrElse(SystemSettingsService.DefaultLdapKeystore)
+      ldapSettings.keystore.getOrElse("")
     ) match {
       case Some(conn) => {
         withConnection(conn) { conn =>
@@ -48,7 +48,7 @@ object LDAPUtil {
       userDN,
       password,
       ldapSettings.tls.getOrElse(false),
-      ldapSettings.keystore.getOrElse(SystemSettingsService.DefaultLdapKeystore)
+      ldapSettings.keystore.getOrElse("")
     ) match {
       case Some(conn) => {
         withConnection(conn) { conn =>
@@ -67,9 +67,11 @@ object LDAPUtil {
       // Dynamically set Sun as the security provider
       Security.addProvider(new com.sun.net.ssl.internal.ssl.Provider())
 
-      // Dynamically set the property that JSSE uses to identify
-      // the keystore that holds trusted root certificates
-      System.setProperty("javax.net.ssl.trustStore", keystore);
+      if (keystore.compareTo("") != 0) {
+        // Dynamically set the property that JSSE uses to identify
+        // the keystore that holds trusted root certificates
+        System.setProperty("javax.net.ssl.trustStore", keystore)
+      }
     }
 
     val conn: LDAPConnection = new LDAPConnection(new LDAPJSSEStartTLSFactory())

--- a/src/main/twirl/admin/system.scala.html
+++ b/src/main/twirl/admin/system.scala.html
@@ -97,7 +97,7 @@
             <div class="control-group">
               <div class="controls">
                 <label class="checkbox">
-                  <input type="checkbox" name="ldap.tls"@if(settings.ldap.flatMap(_.tls).getOrElse(false)){ checked}/> Enable StartTLS
+                  <input type="checkbox" name="ldap.tls"@if(settings.ldap.flatMap(_.tls).getOrElse(false)){ checked}/> Enable TLS
                 </label>
               </div>
             </div>


### PR DESCRIPTION
Some LDAP server do not allow authenticate with unencrypted password.
This patch is adding the StartTLS support which takes care of the
encryption.

In order to enable the StartTLS, go to "System Settings" and select
the "Enable TLS" in the Authentication section. Then make sure
that you add your LDAP certificate into the Java keystore:

$ keytool -import \
          -file /etc/pki/tls/certs/cacert.pem \
          -alias myName \
          -keystore /var/lib/gitbucket/keystore

You can list all keys from the keystore like this:

$ keytool -list -keystore /var/lib/gitbucket/keystore
