### PR TITLE
Load Gravatar images always through HTTPS

### DIFF
--- a/src/main/scala/view/AvatarImageProvider.scala
+++ b/src/main/scala/view/AvatarImageProvider.scala
@@ -17,7 +17,7 @@ trait AvatarImageProvider { self: RequestCache =>
       // by user name
       getAccountByUserName(userName).map { account =>
         if(account.image.isEmpty && getSystemSettings().gravatar){
-          s"""http://www.gravatar.com/avatar/${StringUtil.md5(account.mailAddress.toLowerCase)}?s=${size}"""
+          s"""https://www.gravatar.com/avatar/${StringUtil.md5(account.mailAddress.toLowerCase)}?s=${size}"""
         } else {
           s"""${context.path}/${account.userName}/_avatar"""
         }
@@ -28,13 +28,13 @@ trait AvatarImageProvider { self: RequestCache =>
       // by mail address
       getAccountByMailAddress(mailAddress).map { account =>
         if(account.image.isEmpty && getSystemSettings().gravatar){
-          s"""http://www.gravatar.com/avatar/${StringUtil.md5(account.mailAddress.toLowerCase)}?s=${size}"""
+          s"""https://www.gravatar.com/avatar/${StringUtil.md5(account.mailAddress.toLowerCase)}?s=${size}"""
         } else {
           s"""${context.path}/${account.userName}/_avatar"""
         }
       } getOrElse {
         if(getSystemSettings().gravatar){
-          s"""http://www.gravatar.com/avatar/${StringUtil.md5(mailAddress.toLowerCase)}?s=${size}"""
+          s"""https://www.gravatar.com/avatar/${StringUtil.md5(mailAddress.toLowerCase)}?s=${size}"""
         } else {
           s"""${context.path}/_unknown/_avatar"""
         }

--- a/src/test/scala/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/view/AvatarImageProviderSpec.scala
@@ -17,7 +17,7 @@ class AvatarImageProviderSpec extends Specification {
       val provider = new AvatarImageProviderImpl(Some(createAccount(None)), createSystemSettings(true))
 
       provider.toHtml("user", 20).toString mustEqual
-        "<img src=\"http://www.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=20\" class=\"avatar\" style=\"width: 20px; height: 20px;\" />"
+        "<img src=\"https://www.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=20\" class=\"avatar\" style=\"width: 20px; height: 20px;\" />"
     }
 
     "show uploaded image even if gravatar integration is enabled" in {
@@ -38,7 +38,7 @@ class AvatarImageProviderSpec extends Specification {
       val provider = new AvatarImageProviderImpl(None, createSystemSettings(true))
 
       provider.toHtml("user", 20, "hoge@hoge.com").toString mustEqual
-        "<img src=\"http://www.gravatar.com/avatar/4712f9b0e63f56ad952ad387eaa23b9c?s=20\" class=\"avatar\" style=\"width: 20px; height: 20px;\" />"
+        "<img src=\"https://www.gravatar.com/avatar/4712f9b0e63f56ad952ad387eaa23b9c?s=20\" class=\"avatar\" style=\"width: 20px; height: 20px;\" />"
     }
 
     "show unknown image for unknown user if gravatar integration is enabled" in {


### PR DESCRIPTION
This patch will force to load Gravatar images always through HTTPS which
will fix the problem with mixed content when accessing the page through
HTTPS.

The problem is that if an HTTPS page includes HTTP content, the HTTP
portion can be read or modified by attackers, even though the main page
is served over HTTPS.
