### PR TITLE
Resolves Error when deleting repository which has PR.

### DIFF
--- a/src/main/scala/service/RepositoryService.scala
+++ b/src/main/scala/service/RepositoryService.scala
@@ -46,8 +46,8 @@ trait RepositoryService { self: AccountService =>
     IssueLabels   .filter(_.byRepository(userName, repositoryName)).delete
     Labels        .filter(_.byRepository(userName, repositoryName)).delete
     IssueComments .filter(_.byRepository(userName, repositoryName)).delete
-    Issues        .filter(_.byRepository(userName, repositoryName)).delete
     PullRequests  .filter(_.byRepository(userName, repositoryName)).delete
+    Issues        .filter(_.byRepository(userName, repositoryName)).delete
     IssueId       .filter(_.byRepository(userName, repositoryName)).delete
     Milestones    .filter(_.byRepository(userName, repositoryName)).delete
     WebHooks      .filter(_.byRepository(userName, repositoryName)).delete


### PR DESCRIPTION
When someone deletes repository which has one ore more pull requests, an error is reported.

This error is caused by deleting row of ISSUE table before deleting row of PULL_REQUEST table. PULL_REQUEST table has foreign key references ISSUE table, so row of ISSUE table should be deleted after deletion of PULL_REQUEST table.
