### PR TITLE
Remove superfluous context.path

### DIFF
--- a/src/main/scala/app/PullRequestsController.scala
+++ b/src/main/scala/app/PullRequestsController.scala
@@ -98,7 +98,7 @@ trait PullRequestsControllerBase extends ControllerBase {
         pulls.html.mergeguide(
           checkConflictInPullRequest(owner, name, pullreq.branch, pullreq.requestUserName, name, pullreq.requestBranch, issueId),
           pullreq,
-          s"${baseUrl}${context.path}/git/${pullreq.requestUserName}/${pullreq.requestRepositoryName}.git")
+          s"${baseUrl}/git/${pullreq.requestUserName}/${pullreq.requestRepositoryName}.git")
       }
     } getOrElse NotFound
   })


### PR DESCRIPTION
It was generating URLs that look like http://server.example.com/gitbucket/gitbucket/git/user/repo.git (notice the extra "/gitbucket"?) when the WAR was deployed in Tomcat.

If you look in the rest of the file for `baseUrl`, you'll see it's used without `context.path` to generate URLs.
