### PR TITLE
Turn off autocomplete on "Add collaborator" form

### DIFF
--- a/src/main/twirl/settings/collaborators.scala.html
+++ b/src/main/twirl/settings/collaborators.scala.html
@@ -18,7 +18,7 @@
       }
     </ul>
     @if(!isGroupRepository){
-      <form method="POST" action="@url(repository)/settings/collaborators/add" validate="true">
+      <form method="POST" action="@url(repository)/settings/collaborators/add" validate="true" autocomplete="off">
         <div>
           <span class="error" id="error-userName"></span>
         </div>


### PR DESCRIPTION
You have already created js autocomplete for that input, so it is good to turn off the browser autocomplete. If there are more forms that have custom autocomplete, this change should be applied to them, too.
