### PR TITLE
Apply GitHub diff colors

### DIFF
--- a/src/main/webapp/assets/jsdifflib/diffview.css
+++ b/src/main/webapp/assets/jsdifflib/diffview.css
@@ -66,7 +66,7 @@ table.diff .replace {
 	background-color:#FD8
 }
 table.diff .delete {
-	background-color:#E99;
+	background-color:#FFDDDD;
 }
 table.diff .skip {
 	background-color:#EFEFEF;
@@ -74,7 +74,7 @@ table.diff .skip {
 	border-right:1px solid #BBC;
 }
 table.diff .insert {
-	background-color:#9E9
+	background-color:#DDFFDD
 }
 table.diff th.author {
 	text-align:right;


### PR DESCRIPTION
However, jsdifflib is still not a good approach. It requires dumping all the two text to the browser and do the work there. Instead, maybe the diff should be taken from the git itself and highlighting should be applied on that.

OTOH, word level diff would be good when applicable (like GitHub does).
