### PR TITLE
add https param only when the conf is true

### DIFF
--- a/contrib/redhat/gitbucket.init
+++ b/contrib/redhat/gitbucket.init
@@ -39,7 +39,7 @@ start() {
 	if [ $GITBUCKET_HOST ]; then
 		START_OPTS="${START_OPTS} --host=${GITBUCKET_HOST}"
 	fi
-	if [ $GITBUCKET_HTTPS ]; then
+	if [ $GITBUCKET_HTTPS == true]; then
 		START_OPTS="${START_OPTS} --https=true"
 	fi
 


### PR DESCRIPTION
compare with the true value because otherwhise it will add the --https=true if $GITBUCKET_HTTPS is set (true or false)
