### PR TITLE
Display user's full name in header link

### DIFF
--- a/src/main/twirl/main.scala.html
+++ b/src/main/twirl/main.scala.html
@@ -53,6 +53,7 @@
                 <input type="hidden" name="repository" value="@repository.name"/>
               }
               @if(loginAccount.isDefined){
+                <!-- TODO: we should fallback to userName if fullName is empty or null -->
                 <a href="@url(loginAccount.get.userName)" class="username menu">@avatar(loginAccount.get.userName, 20) @loginAccount.get.fullName</a>
                 <a class="dropdown-toggle menu" data-toggle="dropdown" href="#"><i class="icon-plus"></i><span class="caret" style="vertical-align: middle;"></span></a>
                 <ul class="dropdown-menu">


### PR DESCRIPTION
We're recording users' full names but aren't showing it to them in the header.  This pull request remedies this.
## Manual testing
1. Sign in as **root**
2. Edit the profile and set the "Full Name" field to **I am root**
3. Sign out.
4. Sign in as **root** again.
5. Look in the header: ![i am root](https://f.cloud.github.com/assets/297515/2348259/c611fe58-a555-11e3-8a2f-5792fcc92d00.png)

Mission accomplished!
