### PR TITLE
Update the features list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Features
 --------
 The current version of GitBucket provides a basic features below:
 
-- Public / Private Git repository (http access only)
+- Public / Private Git repository (http and ssh access)
 - Repository viewer and online file editing
 - Repository search (Code and Issues)
 - Wiki


### PR DESCRIPTION
The version 1.12 release note announces the addition of the SSH protocol for repository access, but the feature list still states "Public / Private Git repository (http access only)".
