### PR TITLE
Use a shebang (#!/bin/sh) to run sbt.sh

### DIFF
--- a/sbt.sh
+++ b/sbt.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 java -Dsbt.log.noformat=true -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m -Xmx512M -Xss2M -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -jar `dirname $0`/sbt-launch-0.13.5.jar "$@"


### PR DESCRIPTION
If no shebang provided in a shell file, it will be executed by default shell.

However this script is not compatible with Fish Shell, so use sh to execute it.
