### PR TITLE
Fix some mixed content problems

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,6 @@
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="/css/main.css">
 
 </head>


### PR DESCRIPTION
These problems manifest themselves with HTTPS Everywhere installed, and will become much more obvious when GitHub turns on SSL for GitHub Pages by default (assuming they do so).
