### PR TITLE
Add SSH clone url option when enabled SSH access

### DIFF
--- a/src/main/twirl/repo/guide.scala.html
+++ b/src/main/twirl/repo/guide.scala.html
@@ -7,21 +7,37 @@
     @if(!hasWritePermission){
       <h3>This is an empty repository</h3>
     } else {
+      <h3><strong>Quick setup</strong> — if you've done this kind of thing before</h3>
+      <div class="empty-repo-options">
+        via <a href="@repository.httpUrl" class="git-protocol-selector">HTTP</a>
+      @if(settings.ssh && loginAccount.isDefined){
+         or
+         <a href="@repository.sshUrl(settings.sshPort.getOrElse(service.SystemSettingsService.DefaultSshPort), loginAccount.get.userName)" class="git-protocol-selector">SSH</a>
+      }
+      </div>
       <h3 style="margin-top: 30px;">Create a new repository on the command line</h3>
       <pre>
       touch README.md
       git init
       git add README.md
       git commit -m "first commit"
-      git remote add origin @repository.httpUrl
+      git remote add origin <span class="live-clone-url">@repository.httpUrl</span>
       git push -u origin master
       </pre>
 
       <h3 style="margin-top: 30px;">Push an existing repository from the command line</h3>
       <pre>
-      git remote add origin @repository.httpUrl
+      git remote add origin <span class="live-clone-url">@repository.httpUrl</span>
       git push -u origin master
       </pre>
+      <script>
+      $(function(){
+        $('.git-protocol-selector').click(function(e){
+          e.preventDefault();
+          $('.live-clone-url').text($(e.target).attr('href'));
+        });
+      });
+      </script>
     }
   }
 }


### PR DESCRIPTION
I just added an option on guide page and make the repo url accessable after enabled SSH access.
Any ideas to improve this patch?
