### PR TITLE
Enable contrib init file and RPM's spec file to run on RHEL 6/CentOS 6 a...

### DIFF
--- a/contrib/linux/redhat/README.md
+++ b/contrib/linux/redhat/README.md
@@ -1,0 +1,15 @@
+# Contrib Notes #
+
+RPM spec file and init script for Red Hat Enterprise Linux 6.x. 
+
+To create RPM:
+1. Edit `../../gitbucket.conf` to suit.
+2. Edit `gitbucket.init` to suit.
+3. Edit `gitbucket.spec` to suit.
+4. Place `gitbucket.spec` to rpm/SPECS/.
+5. Place `gitbucket.init` and `gitbucket.war` to rpm/SOURCES/.
+6. Execute `rpmbuild -ba rpm/SPECS/gitbucket.spec`
+
+This rpm runs gitbucket not as root user but as gitbucket user.
+This rpm creates user and group named `gitbucket` at installation.
+This rpm make chkconfig of gitbucket to be on.

--- a/contrib/linux/redhat/gitbucket.init
+++ b/contrib/linux/redhat/gitbucket.init
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# RedHat: /etc/rc.d/init.d/gitbucket
+#
+# Starts the GitBucket server
+#
+# chkconfig: 345 60 40
+# description: Run GitBucket server
+# processname: java
+
+[ -f /etc/rc.d/init.d/functions ] && source /etc/rc.d/init.d/functions  # RedHat
+
+# Default values
+GITBUCKET_HOME=/var/lib/gitbucket
+GITBUCKET_WAR_FILE=/usr/share/gitbucket/lib/gitbucket.war
+
+# Pull in cq settings
+[ -f /etc/sysconfig/gitbucket ] && source /etc/sysconfig/gitbucket # RedHat
+[ -f gitbucket.conf ] && source gitbucket.conf  # For all systems
+
+# Location of the log and PID file
+LOG_FILE=$GITBUCKET_LOG_DIR/run.log
+
+RED='\033[1m\E[37;41m'
+GREEN='\033[1m\E[37;42m'
+OFF='\E[0m'
+
+RETVAL=0
+
+start() {
+	echo -n $"Starting GitBucket server: "
+
+  START_OPTS=
+	if [ $GITBUCKET_PORT ]; then
+		START_OPTS="${START_OPTS} --port=${GITBUCKET_PORT}"
+	fi
+	if [ $GITBUCKET_PREFIX ]; then
+		START_OPTS="${START_OPTS} --prefix=${GITBUCKET_PREFIX}"
+	fi
+	if [ $GITBUCKET_HOST ]; then
+		START_OPTS="${START_OPTS} --host=${GITBUCKET_HOST}"
+	fi
+
+	GITBUCKET_HOME="${GITBUCKET_HOME}" daemon --user=gitbucket java $GITBUCKET_JVM_OPTS -jar $GITBUCKET_WAR_FILE $START_OPTS >>$LOG_FILE 2>&1 &
+  sleep 3
+  pgrep -f $GITBUCKET_WAR_FILE >> $LOG_FILE 2>&1
+  RETVAL=$?
+
+	if [ $RETVAL -eq 0 ] ; then
+		success "Success"
+	else
+		failure "Exit code $RETVAL"
+	fi
+
+	echo
+	return $RETVAL
+}
+
+
+stop() {
+	echo -n $"Stopping GitBucket server: "
+
+	# Run the Java process
+	pkill -f $GITBUCKET_WAR_FILE >>$LOG_FILE 2>&1
+	RETVAL=$?
+
+	if [ $RETVAL -eq 0 ] ; then
+		success "GitBucket stopping"
+	else
+		failure "GitBucket stopping"
+	fi
+
+	echo
+	return $RETVAL
+}
+
+
+restart() {
+	stop
+	start
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart)
+		restart
+		;;
+	status)
+    pgrep -f $GITBUCKET_WAR_FILE >> $LOG_FILE 2>&1
+		RETVAL=$?
+    if [ $RETVAL -eq 0 ]; then
+      echo $"GitBucket is running...."
+    else
+      echo $"GitBucket is stopped"
+    fi
+		;;
+	*)
+		echo $"Usage: $0 [start|stop|restart|status]"
+		RETVAL=2
+esac
+
+exit $RETVAL
+

--- a/contrib/linux/redhat/gitbucket.spec
+++ b/contrib/linux/redhat/gitbucket.spec
@@ -1,6 +1,6 @@
 Name:		gitbucket
 Summary:	GitHub clone written with Scala.
-Version:	1.7
+Version:	2.6
 Release:	1%{?dist}
 License:	Apache
 URL:		https://github.com/takezoe/gitbucket
@@ -26,6 +26,25 @@ GitBucket is the easily installable GitHub clone written with Scala.
 %{__install} -m 0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 touch %{buildroot}%{_localstatedir}/log/%{name}/run.log
 
+%pre
+/usr/sbin/groupadd -r gitbucket &> /dev/null || :
+/usr/sbin/useradd -g gitbucket -s /bin/false -r -c "GitBucket GitHub clone" -d %{_sharedstatedir}/%{name} gitbucket &> /dev/null || :
+
+%post
+/sbin/chkconfig --add gitbucket
+
+%preun
+if [ "$1" = 0 ]; then
+  /sbin/service gitbucket stop > /dev/null 2>&1
+  /sbin/chkconfig --del gitbucket
+fi
+exit 0
+
+%postun
+if [ "$1" -ge 1 ]; then
+  /sbin/service gitbucket restart > /dev/null 2>&1
+fi
+exit 0
 
 %clean
 [ "%{buildroot}" != / ] && %{__rm} -rf "%{buildroot}"
@@ -34,12 +53,28 @@ touch %{buildroot}%{_localstatedir}/log/%{name}/run.log
 %files
 %defattr(-,root,root,-)
 %{_datarootdir}/%{name}/lib/%{name}.war
-%{_sysconfdir}/init.d/%{name}
-%config %{_sysconfdir}/sysconfig/%{name}
-%{_localstatedir}/log/%{name}/run.log
+%config %{_sysconfdir}/init.d/%{name}
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+%attr(0755,gitbucket,gitbucket) %{_sharedstatedir}/%{name}
+%attr(0750,gitbucket,gitbucket) %{_localstatedir}/log/%{name}
 
 
 %changelog
+* Mon Nov 24 2014 Toru Takahashi <torutk at gmail.com>
+- Version bump to v2.6
+
+* Sun Nov 09 2014 Toru Takahashi <torutk at gmail.com>
+- Version bump to v2.5
+
+* Sun Oct 26 2014 Toru Takahashi <torutk at gmail.com>
+- Version bump to v2.4.1
+
+* Mon Jul 21 2014 Toru Takahashi <torutk at gmail.com>
+- execute as gitbucket user
+
+* Sun Jul 20 2014 Toru Takahashi <torutk at gmail.com>
+- Version bump to v2.1.
+
 * Mon Oct 28 2013 Jiri Tyr <jiri_DOT_tyr at gmail.com>
 - Version bump to v1.7.
 


### PR DESCRIPTION
It is happy if I can use a gitbucket RPM package on RHEL 6/CentOS 6, and can run a gitbucket process as non root user.

Current gitbucket repository have a minimum feature RPM spec file: contrib/linux/redhat/gitbucket.spec,
init script file: contrib/gitbucket.ini.

The gitbucket.spec file and gitbucket.init file enable the gitbucket process to run as root user.
And the current gitbucket.init script file cannot run on RHEL 6/CentOS 6 by error.
So, I modified the gitbucket.spec file, and created gitbucket.init script file for only RHEL 6/CentOS 6.
