### PR TITLE
fix repo editor fails to preview

### DIFF
--- a/src/main/twirl/repo/editor.scala.html
+++ b/src/main/twirl/repo/editor.scala.html
@@ -127,7 +127,8 @@ $(function(){
       $.post('@url(repository)/_preview', {
         content        : editor.getValue(),
         enableWikiLink : false,
-        enableRefsLink : false
+        enableRefsLink : false,
+        enableTaskList : false
       }, function(data){
         $('#preview').empty().append(
           $('<div class="markdown-body" style="padding-left: 16px; padding-right: 16px;">').html(data));


### PR DESCRIPTION
Editing and previewing text files on Web UI  causes an exception below and fails to preview.

```
java.util.NoSuchElementException: key not found: enableTaskList
```

`_preview` seems to require `enableTaskList` param but js in editor.html does not include it.
