### PR TITLE
Easily extended systems as greasemonkey / user scripts.

### DIFF
--- a/src/main/scala/app/SystemSettingsController.scala
+++ b/src/main/scala/app/SystemSettingsController.scala
@@ -49,7 +49,8 @@ trait SystemSettingsControllerBase extends ControllerBase {
         "mailAttribute"            -> trim(label("Mail address attribute", optional(text()))),
         "tls"                      -> trim(label("Enable TLS", optional(boolean()))),
         "keystore"                 -> trim(label("Keystore", optional(text())))
-    )(Ldap.apply))
+    )(Ldap.apply)),
+    "siteScriptUrl"            -> trim(label("siteScriptUrl", optional(text())))
   )(SystemSettings.apply).verifying { settings =>
     if(settings.ssh && settings.baseUrl.isEmpty){
       Seq("baseUrl" -> "Base URL is required if SSH access is enabled.")

--- a/src/main/scala/service/SystemSettingsService.scala
+++ b/src/main/scala/service/SystemSettingsService.scala
@@ -45,6 +45,7 @@ trait SystemSettingsService {
           ldap.keystore.foreach(x => props.setProperty(LdapKeystore, x))
         }
       }
+      settings.siteScriptUrl.foreach(x => props.setProperty(SiteScriptUrl, x))
       using(new java.io.FileOutputStream(GitBucketConf)){ out =>
         props.store(out, null)
       }
@@ -95,7 +96,8 @@ trait SystemSettingsService {
             getOptionValue(props, LdapKeystore, None)))
         } else {
           None
-        }
+        },
+        getOptionValue[String](props, SiteScriptUrl, None)
       )
     }
   }
@@ -115,7 +117,8 @@ object SystemSettingsService {
     sshPort: Option[Int],
     smtp: Option[Smtp],
     ldapAuthentication: Boolean,
-    ldap: Option[Ldap]){
+    ldap: Option[Ldap],
+    siteScriptUrl: Option[String]){
     def baseUrl(request: HttpServletRequest): String = baseUrl.getOrElse {
       defining(request.getRequestURL.toString){ url =>
         url.substring(0, url.length - (request.getRequestURI.length - request.getContextPath.length))
@@ -175,6 +178,7 @@ object SystemSettingsService {
   private val LdapMailAddressAttribute = "ldap.mail_attribute"
   private val LdapTls = "ldap.tls"
   private val LdapKeystore = "ldap.keystore"
+  private val SiteScriptUrl = "site_script_url"
 
   private def getValue[A: ClassTag](props: java.util.Properties, key: String, default: A): A =
     defining(props.getProperty(key)){ value =>

--- a/src/main/twirl/admin/system.scala.html
+++ b/src/main/twirl/admin/system.scala.html
@@ -235,6 +235,22 @@
               </div>
             </div>
           </div>
+          <!--====================================================================-->
+          <!-- Site script -->
+          <!--====================================================================-->
+          <hr>
+          <label><span class="strong">Site script url</span> (e.g. <code>http://localhost/root/site-scripts/blob/master/site-script.js?raw=true</code>)</label>
+          <fieldset>
+              <div class="controls">
+                <input type="text" name="siteScriptUrl" id="siteScriptUrl" style="width: 400px" value="@settings.siteScriptUrl"/>
+                <span id="error-siteScriptUrl" class="error"></span>
+              </div>
+          </fieldset>
+          <p class="muted">
+            The site script is a javascript file that embeded on footer of all pages.<br />
+            For example, <code>`&lt;script src="http://localhost/root/site-scripts/blob/master/site-script.js?raw=true" &gt;&lt;/script&gt;`</code><br />
+            You can extend GitBucket by it.<br />
+          </p>
         </div>
       </div>
       <fieldset>

--- a/src/main/twirl/main.scala.html
+++ b/src/main/twirl/main.scala.html
@@ -93,5 +93,8 @@
         }
       });
     </script>
+    @settings.siteScriptUrl.map { url =>
+      <script src="@url"></script>
+    }
   </body>
 </html>

--- a/src/test/scala/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/view/AvatarImageProviderSpec.scala
@@ -101,7 +101,8 @@ class AvatarImageProviderSpec extends Specification with Mockito {
       sshPort                  = None,
       smtp                     = None,
       ldapAuthentication       = false,
-      ldap                     = None)
+      ldap                     = None,
+      siteScriptUrl            = None)
 
   /**
    * Adapter to test AvatarImageProviderImpl.


### PR DESCRIPTION
Administrator set site-script url, and footer of all pages has this url as script src.
Site script will work in the same way as Greasmonkey.

Administrator if you have their own repository, it can be used as a script file storage that you can easily manage the history and permissions.