### PR TITLE
fix: wrong content type

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -293,7 +293,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
         if(raw){
           // Download
           JGitUtil.getContentFromId(git, objectId, true).map { bytes =>
-            RawData("application/octet-stream", bytes)
+            RawData(FileUtil.getMimeType(path), bytes)
           } getOrElse NotFound
         } else {
           html.blob(id, repository, path.split("/").toList,


### PR DESCRIPTION
In the repository viewer, Gitbucket returns Content-type as "application/octet-stream", even if the content is an image (ex. jpeg, png).
So, some browsers (at least IE) cannot display the images. (Chrome and Firefox can display the image even if Content-type is "application/octet-stream").

It seems that all the raw data are returned as "application/octet-stream" in RepositoryViewerController.scala.
I think that every content should be returned with the correct MIME-type.