### PR TITLE
support sshPublicKey from LDAP

### DIFF
--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -44,6 +44,7 @@ trait SystemSettingsControllerBase extends ControllerBase {
         "additionalFilterCondition"-> trim(label("Additional filter condition", optional(text()))),
         "fullNameAttribute"        -> trim(label("Full name attribute", optional(text()))),
         "mailAttribute"            -> trim(label("Mail address attribute", optional(text()))),
+        "pubKeyAttribute"          -> trim(label("SSH Public key attribute", optional(text()))),
         "tls"                      -> trim(label("Enable TLS", optional(boolean()))),
         "ssl"                      -> trim(label("Enable SSL", optional(boolean()))),
         "keystore"                 -> trim(label("Keystore", optional(text())))

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -45,6 +45,7 @@ trait SystemSettingsService {
           ldap.additionalFilterCondition.foreach(x => props.setProperty(LdapAdditionalFilterCondition, x))
           ldap.fullNameAttribute.foreach(x => props.setProperty(LdapFullNameAttribute, x))
           ldap.mailAttribute.foreach(x => props.setProperty(LdapMailAddressAttribute, x))
+          ldap.pubKeyAttribute.foreach(x => props.setProperty(LdapPubKeyAttribute, x))
           ldap.tls.foreach(x => props.setProperty(LdapTls, x.toString))
           ldap.ssl.foreach(x => props.setProperty(LdapSsl, x.toString))
           ldap.keystore.foreach(x => props.setProperty(LdapKeystore, x))
@@ -99,6 +100,7 @@ trait SystemSettingsService {
             getOptionValue(props, LdapAdditionalFilterCondition, None),
             getOptionValue(props, LdapFullNameAttribute, None),
             getOptionValue(props, LdapMailAddressAttribute, None),
+            getOptionValue(props, LdapPubKeyAttribute, None),
             getOptionValue[Boolean](props, LdapTls, None),
             getOptionValue[Boolean](props, LdapSsl, None),
             getOptionValue(props, LdapKeystore, None)))
@@ -145,6 +147,7 @@ object SystemSettingsService {
     additionalFilterCondition: Option[String],
     fullNameAttribute: Option[String],
     mailAttribute: Option[String],
+    pubKeyAttribute: Option[String],
     tls: Option[Boolean],
     ssl: Option[Boolean],
     keystore: Option[String])
@@ -189,6 +192,7 @@ object SystemSettingsService {
   private val LdapAdditionalFilterCondition = "ldap.additional_filter_condition"
   private val LdapFullNameAttribute = "ldap.fullname_attribute"
   private val LdapMailAddressAttribute = "ldap.mail_attribute"
+  private val LdapPubKeyAttribute = "ldap.pubkey_attribute"
   private val LdapTls = "ldap.tls"
   private val LdapSsl = "ldap.ssl"
   private val LdapKeystore = "ldap.keystore"

--- a/src/main/scala/gitbucket/core/ssh/PublicKeyAuthenticator.scala
+++ b/src/main/scala/gitbucket/core/ssh/PublicKeyAuthenticator.scala
@@ -5,11 +5,25 @@ import gitbucket.core.servlet.Database
 import org.apache.sshd.server.PublickeyAuthenticator
 import org.apache.sshd.server.session.ServerSession
 import java.security.PublicKey
+import gitbucket.core.service.SystemSettingsService
+import gitbucket.core.service.AccountService
+import gitbucket.core.util.LDAPUtil
 
-class PublicKeyAuthenticator extends PublickeyAuthenticator with SshKeyService {
+class PublicKeyAuthenticator extends PublickeyAuthenticator with SshKeyService with SystemSettingsService{
 
   override def authenticate(username: String, key: PublicKey, session: ServerSession): Boolean = {
     Database() withSession { implicit session =>
+      val settings = loadSystemSettings()
+      if (settings.ldapAuthentication) {
+        AccountService.getAccountByUserName(username) match {
+          case Some(x) => 
+            LDAPUtil.authenticatePubkey(settings.ldap.get, username, key) match {
+              case Right(true) => return true
+              case _ => ;
+            }
+          case _ => System.out.println("user not exist =" + username);
+        }
+      }
       getPublicKeys(username).exists { sshKey =>
         SshUtil.str2PublicKey(sshKey.publicKey) match {
           case Some(publicKey) => key.equals(publicKey)

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -198,6 +198,15 @@
                 <span id="error-ldap_mailAttribute" class="error"></span>
               </div>
             </div>
+
+            <div class="control-group">
+              <label class="control-label" for="ldapPubKeyAttribute">SSH Public key attribute</label>
+              <div class="controls">
+                <input type="text" id="ldapPubKeyAttribute" name="ldap.pubKeyAttribute" value="@settings.ldap.map(_.pubKeyAttribute)"/>
+                <span id="error-ldap_pubKeyAttribute" class="error"></span>
+              </div>
+            </div>
+
             <div class="control-group">
               <div class="controls">
                 <label class="checkbox">


### PR DESCRIPTION
LDAP server can provide user ssh publickey as sshPublicKey attribute.
it convenient, if PublicKeyAuthenticator support find publickey from LDAP.

I tried modify gitbucket and success it for me.

I did,
- add "SSH Public key attribute" field on System Setting LDAP section.  
  usually put "sshPublicKey"
- change PublicKeyAuthenticator
- add some method LDAPUtil

please advise these codes are effectual?

Thank you.　(Issue#910)

![pubkeyfromldap](https://cloud.githubusercontent.com/assets/11532107/9954602/65a14b84-5e25-11e5-9aba-be8947da60dc.jpg)
