### PR TITLE
A sidebar and footer for the wiki

### DIFF
--- a/src/main/scala/gitbucket/core/controller/WikiController.scala
+++ b/src/main/scala/gitbucket/core/controller/WikiController.scala
@@ -39,7 +39,8 @@ trait WikiControllerBase extends ControllerBase {
     getWikiPage(repository.owner, repository.name, "Home").map { page =>
       html.page("Home", page, getWikiPageList(repository.owner, repository.name),
         repository, hasWritePermission(repository.owner, repository.name, context.loginAccount),
-        getWikiPage(repository.owner, repository.name, "_Sidebar"))
+        getWikiPage(repository.owner, repository.name, "_Sidebar"),
+        getWikiPage(repository.owner, repository.name, "_Footer"))
     } getOrElse redirect(s"/${repository.owner}/${repository.name}/wiki/Home/_edit")
   })
   
@@ -49,7 +50,8 @@ trait WikiControllerBase extends ControllerBase {
     getWikiPage(repository.owner, repository.name, pageName).map { page =>
       html.page(pageName, page, getWikiPageList(repository.owner, repository.name),
         repository, hasWritePermission(repository.owner, repository.name, context.loginAccount),
-        getWikiPage(repository.owner, repository.name, "_Sidebar"))
+        getWikiPage(repository.owner, repository.name, "_Sidebar"),
+        getWikiPage(repository.owner, repository.name, "_Footer"))
     } getOrElse redirect(s"/${repository.owner}/${repository.name}/wiki/${StringUtil.urlEncode(pageName)}/_edit")
   })
   
@@ -203,7 +205,7 @@ trait WikiControllerBase extends ControllerBase {
       }
   }
 
-  private def notReservedPageName(value: String) = value != "_Sidebar"
+  private def notReservedPageName(value: String) = ! (Array[String]("_Sidebar","_Footer") contains value)
 
   private def conflictForNew: Constraint = new Constraint(){
     override def validate(name: String, value: String, messages: Messages): Option[String] = {

--- a/src/main/scala/gitbucket/core/controller/WikiController.scala
+++ b/src/main/scala/gitbucket/core/controller/WikiController.scala
@@ -38,7 +38,8 @@ trait WikiControllerBase extends ControllerBase {
   get("/:owner/:repository/wiki")(referrersOnly { repository =>
     getWikiPage(repository.owner, repository.name, "Home").map { page =>
       html.page("Home", page, getWikiPageList(repository.owner, repository.name),
-        repository, hasWritePermission(repository.owner, repository.name, context.loginAccount))
+        repository, hasWritePermission(repository.owner, repository.name, context.loginAccount),
+        getWikiSideBar(repository.owner, repository.name))
     } getOrElse redirect(s"/${repository.owner}/${repository.name}/wiki/Home/_edit")
   })
   
@@ -47,7 +48,8 @@ trait WikiControllerBase extends ControllerBase {
 
     getWikiPage(repository.owner, repository.name, pageName).map { page =>
       html.page(pageName, page, getWikiPageList(repository.owner, repository.name),
-        repository, hasWritePermission(repository.owner, repository.name, context.loginAccount))
+        repository, hasWritePermission(repository.owner, repository.name, context.loginAccount),
+        getWikiSideBar(repository.owner, repository.name))
     } getOrElse redirect(s"/${repository.owner}/${repository.name}/wiki/${StringUtil.urlEncode(pageName)}/_edit")
   })
   
@@ -124,7 +126,11 @@ trait WikiControllerBase extends ControllerBase {
         updateLastActivityDate(repository.owner, repository.name)
         recordEditWikiPageActivity(repository.owner, repository.name, loginAccount.userName, form.pageName, commitId)
       }
-      redirect(s"/${repository.owner}/${repository.name}/wiki/${StringUtil.urlEncode(form.pageName)}")
+      if(notReservedPageName(form.pageName)) {
+        redirect(s"/${repository.owner}/${repository.name}/wiki/${StringUtil.urlEncode(form.pageName)}")
+      } else {
+        redirect(s"/${repository.owner}/${repository.name}/wiki")
+      }
     }
   })
   
@@ -140,7 +146,11 @@ trait WikiControllerBase extends ControllerBase {
       updateLastActivityDate(repository.owner, repository.name)
       recordCreateWikiPageActivity(repository.owner, repository.name, loginAccount.userName, form.pageName)
 
-      redirect(s"/${repository.owner}/${repository.name}/wiki/${StringUtil.urlEncode(form.pageName)}")
+      if(notReservedPageName(form.pageName)) {
+        redirect(s"/${repository.owner}/${repository.name}/wiki/${StringUtil.urlEncode(form.pageName)}")
+      } else {
+        redirect(s"/${repository.owner}/${repository.name}/wiki")
+      }
     }
   })
   
@@ -186,12 +196,14 @@ trait WikiControllerBase extends ControllerBase {
     override def validate(name: String, value: String, messages: Messages): Option[String] =
       if(value.exists("\\/:*?\"<>|".contains(_))){
         Some(s"${name} contains invalid character.")
-      } else if(value.startsWith("_") || value.startsWith("-")){
+      } else if(notReservedPageName(value) && (value.startsWith("_") || value.startsWith("-"))){
         Some(s"${name} starts with invalid character.")
       } else {
         None
       }
   }
+
+  private def notReservedPageName(value: String) = value != "_Sidebar"
 
   private def conflictForNew: Constraint = new Constraint(){
     override def validate(name: String, value: String, messages: Messages): Option[String] = {

--- a/src/main/scala/gitbucket/core/controller/WikiController.scala
+++ b/src/main/scala/gitbucket/core/controller/WikiController.scala
@@ -39,7 +39,7 @@ trait WikiControllerBase extends ControllerBase {
     getWikiPage(repository.owner, repository.name, "Home").map { page =>
       html.page("Home", page, getWikiPageList(repository.owner, repository.name),
         repository, hasWritePermission(repository.owner, repository.name, context.loginAccount),
-        getWikiSideBar(repository.owner, repository.name))
+        getWikiPage(repository.owner, repository.name, "_Sidebar"))
     } getOrElse redirect(s"/${repository.owner}/${repository.name}/wiki/Home/_edit")
   })
   
@@ -49,7 +49,7 @@ trait WikiControllerBase extends ControllerBase {
     getWikiPage(repository.owner, repository.name, pageName).map { page =>
       html.page(pageName, page, getWikiPageList(repository.owner, repository.name),
         repository, hasWritePermission(repository.owner, repository.name, context.loginAccount),
-        getWikiSideBar(repository.owner, repository.name))
+        getWikiPage(repository.owner, repository.name, "_Sidebar"))
     } getOrElse redirect(s"/${repository.owner}/${repository.name}/wiki/${StringUtil.urlEncode(pageName)}/_edit")
   })
   

--- a/src/main/scala/gitbucket/core/service/WikiService.scala
+++ b/src/main/scala/gitbucket/core/service/WikiService.scala
@@ -72,20 +72,6 @@ trait WikiService {
   }
 
   /**
-   * Returns the wiki sidebar page.
-   */
-  def getWikiSideBar(owner: String, repository: String): Option[WikiPageInfo] = {
-    using(Git.open(Directory.getWikiRepositoryDir(owner, repository))){ git =>
-      if(!JGitUtil.isEmpty(git)){
-        JGitUtil.getFileList(git, "master", ".").find(_.name == "_Sidebar.md").map { file =>
-          WikiPageInfo(file.name, StringUtil.convertFromByteArray(git.getRepository.open(file.id).getBytes),
-                       file.author, file.time, file.commitId)
-        }
-      } else None
-    }
-  }
-
-  /**
    * Returns the content of the specified file.
    */
   def getFileContent(owner: String, repository: String, path: String): Option[Array[Byte]] =

--- a/src/main/twirl/gitbucket/core/wiki/page.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/page.scala.html
@@ -2,7 +2,8 @@
   page: gitbucket.core.service.WikiService.WikiPageInfo,
   pages: List[String],
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
-  hasWritePermission: Boolean)(implicit context: gitbucket.core.controller.Context)
+  hasWritePermission: Boolean,
+  sidebar: Option[gitbucket.core.service.WikiService.WikiPageInfo])(implicit context: gitbucket.core.controller.Context)
 @import context._
 @import gitbucket.core.view.helpers._
 @import gitbucket.core.service.WikiService._
@@ -26,10 +27,14 @@
     </ul>
     <div style="width: 200px;" class="pull-right">
       @defining(15){ max =>
-        <div class="box-header">
-          <span class="strong">Pages</span> <span class="label">@pages.length</span>
-        </div>
-        <div class="box-content-bottom" style="padding: 0px;">
+        <a id="show-pages-index" style="text-decoration: none;" href="javascript:void(0);">
+          <div class="wiki-index-header">
+            <span id="triangle-down" class="octicon octicon-triangle-down"></span>
+            <span id="triangle-right" class="octicon octicon-triangle-right" style="display: none;"></span>
+            <span class="strong">Pages</span> <span class="label">@pages.length</span>
+          </div>
+        </a>
+        <div id="pages-index" class="wiki-index-content">
           @pages.zipWithIndex.map { case (page, i) =>
             <div class="box-content-row page-link" style="border: none; @if(i > max - 1){display:none;}">
               <a href="@url(repository)/wiki/@urlEncode(page)" class="strong">@page</a>
@@ -41,6 +46,25 @@
             </div>
           }
         </div>
+      }
+      @sidebar.map { sidebarPage =>
+        <div class="wiki-sidebar">
+          @if(hasWritePermission){
+            <a href="@url(repository)/wiki/_Sidebar/_edit" style="text-decoration: none;">
+              <span class="octicon octicon-pencil" style="position: relative; float: right;"></span>
+            </a>
+          }
+          @markdown(sidebarPage.content, repository, true, false, false, false, pages)
+        </div>
+      }.getOrElse{
+        @if(hasWritePermission){
+          <a class="button-link" href="@url(repository)/wiki/_Sidebar/_edit" style="text-decoration: none;">
+            <div class="wiki-sidebar" style="text-align:center;">
+              <i class="octicon octicon-plus" style="font-size: 16px;"></i>
+               Add a custom sidebar
+            </div>
+          </a>
+        }
       }
       <div class="small">
         <strong>Clone this wiki locally</strong>
@@ -67,6 +91,24 @@ $(function(){
     $('div.page-link').show();
     $(e.target).parents('div.show-more').remove();
   });
+
+  $('#show-pages-index').click(function(e){
+    if($('#pages-index').is(":visible")){
+      $('#triangle-down').hide();
+      $('#triangle-right').show();
+      $('#pages-index').hide();
+    } else {
+      $('#triangle-right').hide();
+      $('#triangle-down').show();
+      $('#pages-index').show();
+    }
+  });
+
+  @sidebar.map { sidebarPage =>
+    $('#pages-index').hide();
+    $('#triangle-down').hide();
+    $('#triangle-right').show();
+  }
 
   @if(settings.ssh && loginAccount.isDefined){
     $('#repository-url-http').click(function(){

--- a/src/main/twirl/gitbucket/core/wiki/page.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/page.scala.html
@@ -3,7 +3,8 @@
   pages: List[String],
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
   hasWritePermission: Boolean,
-  sidebar: Option[gitbucket.core.service.WikiService.WikiPageInfo])(implicit context: gitbucket.core.controller.Context)
+  sidebar: Option[gitbucket.core.service.WikiService.WikiPageInfo],
+  footer: Option[gitbucket.core.service.WikiService.WikiPageInfo])(implicit context: gitbucket.core.controller.Context)
 @import context._
 @import gitbucket.core.view.helpers._
 @import gitbucket.core.service.WikiService._
@@ -59,7 +60,7 @@
       }.getOrElse{
         @if(hasWritePermission){
           <a class="button-link" href="@url(repository)/wiki/_Sidebar/_edit" style="text-decoration: none;">
-            <div class="wiki-sidebar" style="text-align:center;">
+            <div class="wiki-sidebar-dotted" style="text-align:center;">
               <i class="octicon octicon-plus" style="font-size: 16px;"></i>
                Add a custom sidebar
             </div>
@@ -82,6 +83,25 @@
       <div class="markdown-body">
         @markdown(page.content, repository, true, false, false, false, pages)
       </div>
+      @footer.map { footerPage =>
+        <div class="wiki-sidebar wiki-footer">
+          @if(hasWritePermission){
+            <a href="@url(repository)/wiki/_Footer/_edit" style="text-decoration: none;">
+              <span class="octicon octicon-pencil" style="position: relative; float: right;"></span>
+            </a>
+          }
+          @markdown(footerPage.content, repository, true, false, false, false, pages)
+        </div>
+      }.getOrElse{
+        @if(hasWritePermission){
+          <a class="button-link" href="@url(repository)/wiki/_Footer/_edit" style="text-decoration: none;">
+            <div class="wiki-sidebar-dotted" style="text-align:center;">
+              <i class="octicon octicon-plus" style="font-size: 16px;"></i>
+               Add a custom footer
+            </div>
+          </a>
+        }
+      }
     </div>
   }
 }

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1195,6 +1195,22 @@ div.wiki-sidebar {
   margin-top: 20px;
 }
 
+div.wiki-sidebar-dotted {
+  background-color: white;
+  border: 1px dotted #d8d8d8;
+  padding: 4px;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  margin-bottom: 20px;
+  margin-top: 20px;
+}
+
+div.wiki-footer {
+  margin-top: 50px;
+  background-color: #f5f5f5;
+  color: gray;
+}
+
 div.wiki-index-content {
   background-color: white;
   border: 1px solid #d8d8d8;

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1175,6 +1175,36 @@ a.absent {
   color: #c00;
 }
 
+div.wiki-index-header {
+  background-color: #f5f5f5;
+  color: #333333;
+  margin: 0;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border: 1px solid #d8d8d8;
+  padding: 8px 8px 8px 8px;
+}
+
+div.wiki-sidebar {
+  background-color: white;
+  border: 1px solid #d8d8d8;
+  padding: 4px;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  margin-bottom: 20px;
+  margin-top: 20px;
+}
+
+div.wiki-index-content {
+  background-color: white;
+  border: 1px solid #d8d8d8;
+  padding: 0px;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  margin-bottom: 20px;
+  border-top: none;
+}
+
 /****************************************************************************/
 /* Commit */
 /****************************************************************************/


### PR DESCRIPTION
Simple wiki pages used as a sidebar and footer (markdown file `_Sidebar.md` and `_Footer.md`) for the wiki.

Github references:
`Sidebar`: https://help.github.com/articles/creating-a-sidebar/
`Footer`: https://help.github.com/articles/creating-a-footer/

![wiki-sidebar-footer](https://cloud.githubusercontent.com/assets/47677/11631799/f85d1206-9cea-11e5-966a-f3b7b7fc9cd2.png)

- the sidebar is rendered below the pages index.
- if you click on page index "*counter*" you can collapse or expand the page list.
- the footer is rendered below the wiki page content.
- a direct link to edit the sidebar/footer.