### PR TITLE
Upgrade c3p0 and tweak default config to avoid Tomcat issues

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -63,7 +63,7 @@ object MyBuild extends Build {
       "org.eclipse.jetty" % "jetty-webapp" % "8.1.16.v20140903" % "container;provided",
       "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container;provided;test" artifacts Artifact("javax.servlet", "jar", "jar"),
       "junit" % "junit" % "4.12" % "test",
-      "com.mchange" % "c3p0" % "0.9.5",
+      "com.mchange" % "c3p0" % "0.9.5.2",
       "com.typesafe" % "config" % "1.2.1",
       "com.typesafe.akka" %% "akka-actor" % "2.3.10",
       "com.enragedginger" %% "akka-quartz-scheduler" % "1.3.0-akka-2.3.x"  exclude("c3p0","c3p0")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,5 @@
+c3p0 {
+  privilegeSpawnedThreads=true
+  contextClassLoaderSource=library
+}
+


### PR DESCRIPTION
Adds a standard typesafe-config reference.conf file that sets c3p0
config to prevents Tomcat memory leaks on hot-redeploy/shutdown.

See
   http://www.mchange.com/projects/c3p0/#configuring_to_avoid_memory_leaks_on_redeploy
   http://www.mchange.com/projects/c3p0/#tomcat-specific

This new config can be overridden in an application.conf or
c3p0.properties file.

( See http://www.mchange.com/projects/c3p0/#configuration_precedence )

Updates c3p0 version to c3p0-0.9.5.2, which fixes that leads to
unnecessary String allocation when logging via slf4j.