### PR TITLE
fix test ( add specs2-junit )

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -47,6 +47,7 @@ object MyBuild extends Build {
       "org.scalatra" %% "scalatra" % ScalatraVersion,
       "org.scalatra" %% "scalatra-specs2" % ScalatraVersion % "test",
       "org.scalatra" %% "scalatra-json" % ScalatraVersion,
+      "org.specs2" %% "specs2-junit" % "3.6.6" % "test",
       "org.json4s" %% "json4s-jackson" % "3.3.0",
       "io.github.gitbucket" %% "scalatra-forms" % "1.0.0",
       "commons-io" % "commons-io" % "2.4",


### PR DESCRIPTION
fix

```
[info]

cannot create a JUnit XML printer. Please check that specs2-junit.jar is on the classpath

org.specs2.reporter.JUnitXmlPrinter$
java.net.URLClassLoader$1.run(URLClassLoader.java:366)
java.net.URLClassLoader$1.run(URLClassLoader.java:355)
java.security.AccessController.doPrivileged(Native Method)
java.net.URLClassLoader.findClass(URLClassLoader.java:354)
java.lang.ClassLoader.loadClass(ClassLoader.java:424)
sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
java.lang.ClassLoader.loadClass(ClassLoader.java:357)
org.specs2.reflect.Classes$$anonfun$loadClassEither$1.apply(Classes.scala:148)
org.specs2.reflect.Classes$$anonfun$loadClassEither$1.apply(Classes.scala:148)
org.specs2.control.ActionT$$anonfun$safe$1.apply(ActionT.scala:88)
org.specs2.control.ActionT$$anonfun$reader$1$$anonfun$apply$6.apply(ActionT.scala:79)
org.specs2.control.Status$.safe(Status.scala:100)
org.specs2.control.StatusT$$anonfun$safe$1.apply(StatusT.scala:62)
org.specs2.control.StatusT$$anonfun$safe$1.apply(StatusT.scala:62)
scalaz.syntax.ToApplicativeOps$$anon$1.self$lzycompute(ApplicativeSyntax.scala:29)
scalaz.syntax.ToApplicativeOps$$anon$1.self(ApplicativeSyntax.scala:29)
scalaz.syntax.ToApplicativeOps$ApplicativeIdV$$anonfun$point$1.apply(ApplicativeSyntax.scala:33)
```