### PR TITLE
Add path and branch name to the page title

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/blob.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/blob.scala.html
@@ -7,7 +7,7 @@
   isBlame: Boolean)(implicit context: gitbucket.core.controller.Context)
 @import context._
 @import gitbucket.core.view.helpers._
-@html.main(s"${repository.owner}/${repository.name}", Some(repository)) {
+@html.main(s"${(repository.name :: pathList).mkString("/")} at ${encodeRefName(branch)} - ${repository.owner}/${repository.name}", Some(repository)) {
   @html.menu("code", repository){
     <div class="head">
       <div class="pull-right hide-if-blame"><div class="btn-group">

--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -13,7 +13,7 @@
 @import gitbucket.core.view.helpers._
 @html.main(
   if(pathList.isEmpty){
-    if(branch == "master"){
+    if(branch == repository.repository.defaultBranch){
       s"${repository.owner}/${repository.name}"
     } else {
       s"${repository.owner}/${repository.name} at ${encodeRefName(branch)}"

--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -11,7 +11,16 @@
   error: Option[Any] = None)(implicit context: gitbucket.core.controller.Context)
 @import context._
 @import gitbucket.core.view.helpers._
-@html.main(s"${repository.owner}/${repository.name}", Some(repository)) {
+@html.main(
+  if(pathList.isEmpty){
+    if(branch == "master"){
+      s"${repository.owner}/${repository.name}"
+    } else {
+      s"${repository.owner}/${repository.name} at ${encodeRefName(branch)}"
+    }
+  } else {
+    s"${(repository.name :: pathList).mkString("/")} at ${encodeRefName(branch)} - ${repository.owner}/${repository.name}"
+  }, Some(repository)) {
   @html.menu("code", repository, Some(branch), pathList.isEmpty, groupNames.isEmpty, info, error){
     <div class="head">
       <div class="pull-right"><div class="btn-group">


### PR DESCRIPTION
This PR adds file path and branch name to the page title. For example, _"dotfiles/.vim/ftdetect at master -  moccos/dotfiles"_.

Rules are the same as GitHub:
- _repo-name/file-name at branch-name - repo-owner/repo-name_ for files
- _repo-name/path/to/dir at branch-name - repo-owner/repo-name_ for directories
- _repo-owner/repo-name_ for project root
 - Append branch name only if it is not "master"