### PR TITLE
Fix sidemenu styles not to affect other elements

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/preview.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/preview.scala.html
@@ -15,7 +15,7 @@
 @import gitbucket.core._
 @import gitbucket.core.view.helpers._
 <div class="tabbable">
-  <ul class="nav nav-tabs fill-width pull-left" style="@*margin-top: 12px; *@margin-bottom: 10px;">
+  <ul class="nav nav-tabs fill-width" style="@*margin-top: 12px; *@margin-bottom: 10px;">
     <li class="active"><a href="#tab@uid" data-toggle="tab">Write</a></li>
     <li><a href="#tab@(uid+1)" data-toggle="tab" id="preview@uid">Preview</a></li>
   </ul>

--- a/src/main/twirl/gitbucket/core/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/menu.scala.html
@@ -64,7 +64,7 @@
 </div>
 <hr style="margin-bottom: 20px;"/>
 <div class="container body">
-  <div style="width: @if(expand){170px} else {40px};" class="pull-right">
+  <div style="width: @if(expand){170px} else {40px};">
     <ul class="sidemenu">
       <li style="height: 12px"><div class="gradient pull-left" style="height: 12px"></div></li>
       @sidemenu(""       , "code"   , "code" , "Code")

--- a/src/main/twirl/gitbucket/core/wiki/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/compare.scala.html
@@ -10,7 +10,7 @@
 @html.main(s"Compare Revisions - ${repository.owner}/${repository.name}", Some(repository)){
   @helper.html.information(info)
   @html.menu("wiki", repository){
-    <ul class="nav nav-tabs fill-width pull-left">
+    <ul class="nav nav-tabs fill-width">
       <li>
         <h1 class="wiki-title"><span class="muted">Compare Revisions</span></h1>
       </li>

--- a/src/main/twirl/gitbucket/core/wiki/edit.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/edit.scala.html
@@ -5,7 +5,7 @@
 @import gitbucket.core.view.helpers._
 @html.main(s"${if(pageName.isEmpty) "New Page" else pageName} - ${repository.owner}/${repository.name}", Some(repository)){
   @html.menu("wiki", repository){
-    <ul class="nav nav-tabs fill-width pull-left">
+    <ul class="nav nav-tabs fill-width">
       <li>
         <h1 class="wiki-title"><span class="muted">Editing</span> @if(pageName.isEmpty){New Page} else {@pageName}</h1>
       </li>
@@ -21,7 +21,7 @@
     </ul>
     <form action="@url(repository)/wiki/@if(page.isEmpty){_new} else {_edit}" method="POST" validate="true">
       <span id="error-pageName" class="error"></span>
-      <input type="text" name="pageName" value="@pageName" class="form-control input-lg" style="width: 900px; font-weight: bold;" placeholder="Input a page name."/>
+      <input type="text" name="pageName" value="@pageName" class="form-control input-lg" style="width: 900px; font-weight: bold; margin-bottom: 12px;" placeholder="Input a page name."/>
       @helper.html.preview(
         repository         = repository,
         content            = page.map(_.content).getOrElse(""),

--- a/src/main/twirl/gitbucket/core/wiki/history.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/history.scala.html
@@ -5,7 +5,7 @@
 @import gitbucket.core.view.helpers._
 @html.main(s"History - ${repository.owner}/${repository.name}", Some(repository)){
   @html.menu("wiki", repository){
-    <ul class="nav nav-tabs fill-width pull-left">
+    <ul class="nav nav-tabs fill-width">
       <li>
         <h1 class="wiki-title">
           @if(pageName.isEmpty){

--- a/src/main/twirl/gitbucket/core/wiki/page.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/page.scala.html
@@ -10,7 +10,7 @@
 @import gitbucket.core.service.WikiService._
 @html.main(s"${pageName} - ${repository.owner}/${repository.name}", Some(repository)){
   @html.menu("wiki", repository){
-    <ul class="nav nav-tabs fill-width pull-left">
+    <ul class="nav nav-tabs fill-width">
       <li>
         <h1 class="wiki-title">@pageName</h1>
         <div class="small">

--- a/src/main/twirl/gitbucket/core/wiki/pages.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/pages.scala.html
@@ -5,7 +5,7 @@
 @import gitbucket.core.view.helpers._
 @html.main(s"Pages - ${repository.owner}/${repository.name}", Some(repository)){
   @html.menu("wiki", repository){
-    <ul class="nav nav-tabs fill-width pull-left">
+    <ul class="nav nav-tabs fill-width">
       <li>
         <h1 class="wiki-title"><span class="muted">Pages</span></h1>
       </li>

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -260,6 +260,7 @@ div.pagination {
 
 div.body {
   margin-bottom: 40px;
+  position: relative;
 }
 
 span.error {
@@ -518,8 +519,14 @@ a.btn-danger:hover .octicon {
 /* Side Menu */
 /****************************************************************************/
 ul.sidemenu {
-  margin-left: 0px;
-  padding-left: 0px;
+  width: 40px;
+  position: absolute;
+  right: 15px;
+  top: 0;
+  padding-left: 0;
+  background-image: -webkit-linear-gradient(left, #f6f6f6 0%, #fff 8px);
+  background-image: linear-gradient(to right, #f6f6f6 0%, #fff 8px);
+  box-shadow: inset 1px 0 0 #eee;
 }
 
 ul.sidemenu a {
@@ -529,6 +536,15 @@ ul.sidemenu a {
 
 ul.sidemenu a:hover {
   text-decoration: none;
+}
+
+
+ul.sidemenu li {
+  border-left: 1px solid #eee;
+  margin-left: 0;
+  border-right: 2px solid white;
+  list-style-type: none;
+  font-size: 90%;
 }
 
 ul.sidemenu li.active {
@@ -542,25 +558,11 @@ ul.sidemenu li.active a {
   background-color: #fff;
 }
 
-ul.sidemenu {
-  background-image: -webkit-linear-gradient(left, #f6f6f6 0%, #fff 8px);
-  background-image: linear-gradient(to right, #f6f6f6 0%, #fff 8px);
-  box-shadow: inset 1px 0 0 #eee;
-}
-
 ul.sidemenu div.margin {
   width: 5px;
   height: 30px;
   margin-right: 4px;
   border-left: 1px solid white;
-}
-
-ul.sidemenu li {
-  border-left: 1px solid #eee;
-  margin-left:0px;
-  border-right: 2px solid white;
-  list-style-type: none;
-  font-size: 90%;
 }
 
 ul.sidemenu span.badge {


### PR DESCRIPTION
Remove unnecessary floating and re-layout sidemenu not to affect wiki textarea/preview.

textarea
![2016-01-20 23 43 01](https://cloud.githubusercontent.com/assets/2328540/12452479/efa5cab8-bfd1-11e5-8622-c93e127f5103.png)

preview
![2016-01-20 23 43 46](https://cloud.githubusercontent.com/assets/2328540/12452483/f3c125ca-bfd1-11e5-91ca-8138c94aab99.png)
