### PR TITLE
(fixes #1062) Remove a wrong link

### DIFF
--- a/src/main/twirl/gitbucket/core/issues/labels/list.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/labels/list.scala.html
@@ -28,7 +28,7 @@
             <td style="padding: 20px; background-color: #eee; text-align: center;">
               No labels to show.
               @if(hasWritePermission){
-                <a href="@url(repository)/issues/labels/new">Create a new label.</a>
+                Click on the "New Label" button above to create one.
               }
             </td>
           </tr>


### PR DESCRIPTION
Before: 
![current-version](https://cloud.githubusercontent.com/assets/234142/12483186/de21652a-c096-11e5-9eaa-7582cdffa9fa.gif)

After:
![patched-version](https://cloud.githubusercontent.com/assets/234142/12483193/e5826eb8-c096-11e5-8ae5-f0c563000c75.png)
