### PR TITLE
Extend API to allow CRUD labels

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiLabel.scala
+++ b/src/main/scala/gitbucket/core/api/ApiLabel.scala
@@ -1,0 +1,21 @@
+package gitbucket.core.api
+
+import gitbucket.core.model.Label
+import gitbucket.core.util.RepositoryName
+
+/**
+  * https://developer.github.com/v3/issues/labels/
+  */
+case class ApiLabel(
+  name: String,
+  color: String)(repositoryName: RepositoryName){
+  var url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/labels/${name}")
+}
+
+object ApiLabel{
+  def apply(label:Label, repositoryName: RepositoryName): ApiLabel =
+    ApiLabel(
+      name = label.labelName,
+      color = label.color
+    )(repositoryName)
+}

--- a/src/main/scala/gitbucket/core/api/CreateALabel.scala
+++ b/src/main/scala/gitbucket/core/api/CreateALabel.scala
@@ -1,0 +1,18 @@
+package gitbucket.core.api
+
+/**
+  * https://developer.github.com/v3/issues/labels/#create-a-label
+  * api form
+  */
+case class CreateALabel(
+    name: String,
+    color: String
+) {
+  def isValid: Boolean = {
+    name.length<=100 &&
+      !name.startsWith("_") &&
+      !name.startsWith("-") &&
+      color.length==6 &&
+      color.matches("[a-fA-F0-9+_.]+")
+  }
+}

--- a/src/main/scala/gitbucket/core/api/JsonFormat.scala
+++ b/src/main/scala/gitbucket/core/api/JsonFormat.scala
@@ -31,6 +31,7 @@ object JsonFormat {
     FieldSerializer[ApiPullRequest.Commit]() +
     FieldSerializer[ApiIssue]() +
     FieldSerializer[ApiComment]() +
+    FieldSerializer[ApiLabel]() +
     ApiBranchProtection.enforcementLevelSerializer
 
   def apiPathSerializer(c: Context) = new CustomSerializer[ApiPath](format =>

--- a/src/main/scala/gitbucket/core/controller/LabelsController.scala
+++ b/src/main/scala/gitbucket/core/controller/LabelsController.scala
@@ -7,7 +7,7 @@ import gitbucket.core.util.{LockUtil, RepositoryName, ReferrerAuthenticator, Col
 import gitbucket.core.util.Implicits._
 import io.github.gitbucket.scalatra.forms._
 import org.scalatra.i18n.Messages
-import org.scalatra.{UnprocessableEntity, Created, Ok}
+import org.scalatra.{NoContent, UnprocessableEntity, Created, Ok}
 
 class LabelsController extends LabelsControllerBase
   with LabelsService with IssuesService with RepositoryService with AccountService
@@ -37,9 +37,9 @@ trait LabelsControllerBase extends ControllerBase {
     * https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
     */
   get("/api/v3/repos/:owner/:repository/labels")(referrersOnly { repository =>
-    getLabels(repository.owner, repository.name).map { label =>
-      JsonFormat(ApiLabel(label, RepositoryName(repository)))
-    }
+    JsonFormat(getLabels(repository.owner, repository.name).map { label =>
+      ApiLabel(label, RepositoryName(repository))
+    })
   })
 
   /**
@@ -146,7 +146,7 @@ trait LabelsControllerBase extends ControllerBase {
     LockUtil.lock(RepositoryName(repository).fullName) {
       getLabel(repository.owner, repository.name, params("labelName")).map { label =>
         deleteLabel(repository.owner, repository.name, label.labelId)
-        Ok()
+        NoContent()
       } getOrElse NotFound()
     }
   })

--- a/src/main/scala/gitbucket/core/model/BasicTemplate.scala
+++ b/src/main/scala/gitbucket/core/model/BasicTemplate.scala
@@ -26,12 +26,16 @@ protected[model] trait TemplateComponent { self: Profile =>
 
   trait LabelTemplate extends BasicTemplate { self: Table[_] =>
     val labelId = column[Int]("LABEL_ID")
+    val labelName = column[String]("LABEL_NAME")
 
     def byLabel(owner: String, repository: String, labelId: Int) =
       byRepository(owner, repository) && (this.labelId === labelId.bind)
 
     def byLabel(userName: Column[String], repositoryName: Column[String], labelId: Column[Int]) =
       byRepository(userName, repositoryName) && (this.labelId === labelId)
+
+    def byLabel(owner: String, repository: String, labelName: String) =
+      byRepository(userName, repositoryName) && (this.labelName === labelName.bind)
   }
 
   trait MilestoneTemplate extends BasicTemplate { self: Table[_] =>

--- a/src/main/scala/gitbucket/core/model/Labels.scala
+++ b/src/main/scala/gitbucket/core/model/Labels.scala
@@ -7,7 +7,7 @@ trait LabelComponent extends TemplateComponent { self: Profile =>
 
   class Labels(tag: Tag) extends Table[Label](tag, "LABEL") with LabelTemplate {
     override val labelId = column[Int]("LABEL_ID", O AutoInc)
-    val labelName = column[String]("LABEL_NAME")
+    override val labelName = column[String]("LABEL_NAME")
     val color = column[String]("COLOR")
     def * = (userName, repositoryName, labelId, labelName, color) <> (Label.tupled, Label.unapply)
 

--- a/src/main/scala/gitbucket/core/service/LabelsService.scala
+++ b/src/main/scala/gitbucket/core/service/LabelsService.scala
@@ -12,6 +12,9 @@ trait LabelsService {
   def getLabel(owner: String, repository: String, labelId: Int)(implicit s: Session): Option[Label] =
     Labels.filter(_.byPrimaryKey(owner, repository, labelId)).firstOption
 
+  def getLabel(owner: String, repository: String, labelName: String)(implicit s: Session): Option[Label] =
+    Labels.filter(_.byLabel(owner, repository, labelName)).firstOption
+
   def createLabel(owner: String, repository: String, labelName: String, color: String)(implicit s: Session): Int =
     Labels returning Labels.map(_.labelId) += Label(
       userName       = owner,

--- a/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
+++ b/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
@@ -209,6 +209,15 @@ class JsonFormatSpec extends Specification {
     "url": "${context.baseUrl}/api/v3/repos/octocat/Hello-World/commits/$sha1/status"
   }"""
 
+  val apiLabel = ApiLabel(
+    name = "bug",
+    color = "f29513")(RepositoryName("octocat","Hello-World"))
+  val apiLabelJson = s"""{
+    "name": "bug",
+    "color": "f29513",
+    "url": "${context.baseUrl}/api/v3/repos/octocat/Hello-World/labels/bug"
+  }"""
+
   val apiIssue = ApiIssue(
       number = 1347,
       title  = "Found a bug",
@@ -410,6 +419,9 @@ class JsonFormatSpec extends Specification {
     }
     "apiCombinedCommitStatus" in {
       JsonFormat(apiCombinedCommitStatus) must beFormatted(apiCombinedCommitStatusJson)
+    }
+    "apiLabel" in {
+      JsonFormat(apiLabel) must beFormatted(apiLabelJson)
     }
     "apiIssue" in {
       JsonFormat(apiIssue) must beFormatted(apiIssueJson)

--- a/src/test/scala/gitbucket/core/service/LabelsServiceSpec.scala
+++ b/src/test/scala/gitbucket/core/service/LabelsServiceSpec.scala
@@ -1,0 +1,114 @@
+package gitbucket.core.service
+
+import gitbucket.core.model._
+
+import org.specs2.mutable.Specification
+
+class LabelsServiceSpec extends Specification with ServiceSpecBase {
+  "getLabels" should {
+    "be empty when not have any labels" in { withTestDB { implicit session =>
+      generateNewUserWithDBRepository("user1", "repo1")
+
+      generateNewUserWithDBRepository("user1", "repo2")
+      dummyService.createLabel("user1", "repo2", "label1", "000000")
+
+      generateNewUserWithDBRepository("user2", "repo1")
+      dummyService.createLabel("user2", "repo1", "label1", "000000")
+
+      dummyService.getLabels("user1", "repo1") must haveSize(0)
+    }}
+    "return contained labels" in { withTestDB { implicit session =>
+      generateNewUserWithDBRepository("user1", "repo1")
+      val labelId1 = dummyService.createLabel("user1", "repo1", "label1", "000000")
+      val labelId2 = dummyService.createLabel("user1", "repo1", "label2", "ffffff")
+
+      generateNewUserWithDBRepository("user1", "repo2")
+      dummyService.createLabel("user1", "repo2", "label1", "000000")
+
+      generateNewUserWithDBRepository("user2", "repo1")
+      dummyService.createLabel("user2", "repo1", "label1", "000000")
+
+      def getLabels = dummyService.getLabels("user1", "repo1")
+
+      getLabels must haveSize(2)
+      getLabels must_== List(
+        Label("user1", "repo1", labelId1, "label1", "000000"),
+        Label("user1", "repo1", labelId2, "label2", "ffffff"))
+    }}
+  }
+  "getLabel" should {
+    "return None when the label not exist" in { withTestDB { implicit session =>
+      generateNewUserWithDBRepository("user1", "repo1")
+
+      dummyService.getLabel("user1", "repo1", 1) must beNone
+      dummyService.getLabel("user1", "repo1", "label1") must beNone
+    }}
+    "return a label fetched by label id" in { withTestDB { implicit session =>
+      generateNewUserWithDBRepository("user1", "repo1")
+      val labelId1 = dummyService.createLabel("user1", "repo1", "label1", "000000")
+      dummyService.createLabel("user1", "repo1", "label2", "ffffff")
+
+      generateNewUserWithDBRepository("user1", "repo2")
+      dummyService.createLabel("user1", "repo2", "label1", "000000")
+
+      generateNewUserWithDBRepository("user2", "repo1")
+      dummyService.createLabel("user2", "repo1", "label1", "000000")
+
+      def getLabel = dummyService.getLabel("user1", "repo1", labelId1)
+      getLabel must_== Some(Label("user1", "repo1", labelId1, "label1", "000000"))
+    }}
+    "return a label fetched by label name" in { withTestDB { implicit session =>
+      generateNewUserWithDBRepository("user1", "repo1")
+      val labelId1 = dummyService.createLabel("user1", "repo1", "label1", "000000")
+      dummyService.createLabel("user1", "repo1", "label2", "ffffff")
+
+      generateNewUserWithDBRepository("user1", "repo2")
+      dummyService.createLabel("user1", "repo2", "label1", "000000")
+
+      generateNewUserWithDBRepository("user2", "repo1")
+      dummyService.createLabel("user2", "repo1", "label1", "000000")
+
+      def getLabel = dummyService.getLabel("user1", "repo1", "label1")
+      getLabel must_== Some(Label("user1", "repo1", labelId1, "label1", "000000"))
+    }}
+  }
+  "createLabel" should {
+    "return accurate label id" in { withTestDB { implicit session =>
+      generateNewUserWithDBRepository("user1", "repo1")
+      generateNewUserWithDBRepository("user1", "repo2")
+      generateNewUserWithDBRepository("user2", "repo1")
+      dummyService.createLabel("user1", "repo1", "label1", "000000")
+      dummyService.createLabel("user1", "repo2", "label1", "000000")
+      dummyService.createLabel("user2", "repo1", "label1", "000000")
+      val labelId = dummyService.createLabel("user1", "repo1", "label2", "000000")
+      labelId must_== 4
+      def getLabel = dummyService.getLabel("user1", "repo1", labelId)
+      getLabel must_== Some(Label("user1", "repo1", labelId, "label2", "000000"))
+    }}
+  }
+  "updateLabel" should {
+    "change target label" in { withTestDB { implicit session =>
+      generateNewUserWithDBRepository("user1", "repo1")
+      generateNewUserWithDBRepository("user1", "repo2")
+      generateNewUserWithDBRepository("user2", "repo1")
+      val labelId = dummyService.createLabel("user1", "repo1", "label1", "000000")
+      dummyService.createLabel("user1", "repo2", "label1", "000000")
+      dummyService.createLabel("user2", "repo1", "label1", "000000")
+      dummyService.updateLabel("user1", "repo1", labelId, "updated-label", "ffffff")
+      def getLabel = dummyService.getLabel("user1", "repo1", labelId)
+      getLabel must_== Some(Label("user1", "repo1", labelId, "updated-label", "ffffff"))
+    }}
+  }
+  "deleteLabel" should {
+    "remove target label" in { withTestDB { implicit session =>
+      generateNewUserWithDBRepository("user1", "repo1")
+      generateNewUserWithDBRepository("user1", "repo2")
+      generateNewUserWithDBRepository("user2", "repo1")
+      val labelId = dummyService.createLabel("user1", "repo1", "label1", "000000")
+      dummyService.createLabel("user1", "repo2", "label1", "000000")
+      dummyService.createLabel("user2", "repo1", "label1", "000000")
+      dummyService.deleteLabel("user1", "repo1", labelId)
+      dummyService.getLabel("user1", "repo1", labelId) must beNone
+    }}
+  }
+}

--- a/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
+++ b/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
@@ -38,7 +38,7 @@ trait ServiceSpecBase {
   def user(name:String)(implicit s:Session):Account = AccountService.getAccountByUserName(name).get
 
   lazy val dummyService = new RepositoryService with AccountService with IssuesService with PullRequestService
-    with CommitStatusService (){}
+    with CommitStatusService with LabelsService (){}
 
   def generateNewUserWithDBRepository(userName:String, repositoryName:String)(implicit s:Session):Account = {
     val ac = AccountService.getAccountByUserName(userName).getOrElse(generateNewAccount(userName))


### PR DESCRIPTION
Implements some API endpoints.

- [List all labels for this repository](https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository)
- [Get a single label](https://developer.github.com/v3/issues/labels/#get-a-single-label)
- [Create a label](https://developer.github.com/v3/issues/labels/#create-a-label)
- [Update a label](https://developer.github.com/v3/issues/labels/#update-a-label)
- [Delete a label](https://developer.github.com/v3/issues/labels/#delete-a-label)


These endpoints are almost compatibility of the GitHub's API.
For reason, I changed current behavior.
Currently GitBucket accepts duplicate label names.
But some endpoints required a label name,
So I added unique name validation then based on GitHub's behavior.

If the pull request is merged, I will update the Wiki entry accordingly.