### PR TITLE
Set Content-Type to json for /api/v3/* (fix #1056)

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/ControllerBase.scala
@@ -30,6 +30,10 @@ abstract class ControllerBase extends ScalatraFilter
 
   implicit val jsonFormats = DefaultFormats
 
+  before("/api/v3/*") {
+    contentType = formats("json")
+  }
+
 // TODO Scala 2.11
 //  // Don't set content type via Accept header.
 //  override def format(implicit request: HttpServletRequest) = ""


### PR DESCRIPTION
Proposal to fix #1056. Not sure if this is the best/correct way to fix this, I'm not familiar with Scalatra's processing of HTTP requests/responses.