### PR TITLE
Limit maximum width of image

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1446,6 +1446,10 @@ div.wiki-sidebar {
   margin-top: 20px;
 }
 
+div.wiki-sidebar img {
+  max-width: 100%;
+}
+
 div.wiki-sidebar-dotted {
   background-color: white;
   border: 1px dashed #ddd;
@@ -1876,6 +1880,10 @@ div.markdown-body li {
 div.markdown-body p {
   margin: 15px 0;
   line-height: 1.5;
+}
+
+div.markdown-body img {
+  max-width: 100%;
 }
 
 div.markdown-body pre {


### PR DESCRIPTION
Fixed a problem that image width could be larger than the parent box.

![screenshot](https://cloud.githubusercontent.com/assets/4208984/12536853/8c7ba40a-c2f4-11e5-96fb-e569502aad2f.png)

NOTES

1. Although most of markdown contents are wrapped with CSS class ```markdown-body```, only wiki Sidebar contents is not. I was not sure I should add ```markdown-body``` class to ```div.wiki-sidebar``` or not, so I just defined CSS style for ```div.wiki-sidebar img```. 

    ```html
    <div class="wiki-sidebar">
        <a href="/group/hoge/wiki/_Sidebar/_edit" style="text-decoration: none;"><span class="octicon octicon-pencil pull-right"></span></a>
        <p><img src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Logo.png" alt="GitHub"></p>
    </div>
     ```

1. GitHub generates both ```<a>``` and ```<img>``` element for an image in Issue comment, but only ```<img>``` element in Wiki page. On the other hand, GitBucket always generates ```<img>``` element only. To follow GitHub's behavior, maybe I have to add an option to ```GitBucketMarkdRenderer``` to switch the output of ```image()``` method. I thought it is not so important for now, because a web browser can open the image in original size.
