### PR TITLE
these fields are accessed from multiple threads

### DIFF
--- a/src/main/scala/gitbucket/core/ssh/GitCommand.scala
+++ b/src/main/scala/gitbucket/core/ssh/GitCommand.scala
@@ -23,10 +23,10 @@ object GitCommand {
 abstract class GitCommand() extends Command {
 
   private val logger = LoggerFactory.getLogger(classOf[GitCommand])
-  protected var err: OutputStream = null
-  protected var in: InputStream = null
-  protected var out: OutputStream = null
-  protected var callback: ExitCallback = null
+  @volatile protected var err: OutputStream = null
+  @volatile protected var in: InputStream = null
+  @volatile protected var out: OutputStream = null
+  @volatile protected var callback: ExitCallback = null
 
   protected def runTask(user: String)(implicit session: Session): Unit
 


### PR DESCRIPTION
just some small issue i noticed:
these fields are accesses from at least two different threads:
the one created in start(Environment) and whoever calls the setters.
without the volatile declaration, the new thread might never see the
values passed to the setters.
