### PR TITLE
refs #1055 Make a header link anchor icon clickable

### DIFF
--- a/src/main/scala/gitbucket/core/view/Markdown.scala
+++ b/src/main/scala/gitbucket/core/view/Markdown.scala
@@ -68,7 +68,7 @@ object Markdown {
 
       if(enableAnchor){
         out.append(" class=\"markdown-head\">")
-        out.append("<a class=\"markdown-anchor-link\" href=\"#" + id + "\"></a>")
+        out.append("<a class=\"markdown-anchor-link\" href=\"#" + id + "\"><span class=\"octicon octicon-link\"></span></a>")
         out.append("<a class=\"markdown-anchor\" name=\"" + id + "\"></a>")
       } else {
         out.append(">")

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -2043,39 +2043,16 @@ div.markdown-body table colgroup + tbody tr:first-child td:last-child {
 }
 
 a.markdown-anchor-link {
-  position: absolute;
-  left: -18px;
-  display: none;
+  margin-left: -16px;
+  margin-right: 2px;
+  line-height: 1;
   color: #999;
-  /* From octicon style */
-  font: normal normal normal 16px/1 octicons;
-  text-decoration: none;
-  text-rendering: auto;
-}
-a.markdown-anchor-link:before { content: '\f05c'} /*  */
-
-h1 a.markdown-anchor-link {
-  top: 24px;
+  cursor: pointer;
 }
 
-h2 a.markdown-anchor-link {
-  top: 20px;
-}
-
-h3 a.markdown-anchor-link {
-  top: 12px;
-}
-
-h4 a.markdown-anchor-link {
-  top: 8px;
-}
-
-h5 a.markdown-anchor-link {
-  top: 6px;
-}
-
-h6 a.markdown-anchor-link {
-  top: 6px;
+a.markdown-anchor-link span.octicon {
+  visibility: hidden;
+  vertical-align: middle;
 }
 
 /****************************************************************************/

--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -19,14 +19,11 @@ $(function(){
   });
 
   // anchor icon for markdown
-  $('.markdown-head').mouseenter(function(e){
-    $(e.target).children('a.markdown-anchor-link').show();
+  $('.markdown-head').on('mouseenter', function(e){
+    $(this).find('span.octicon').css('visibility', 'visible');
   });
-  $('.markdown-head').mouseleave(function(e){
-    $(e.target).children('a.markdown-anchor-link').hide();
-  });
-  $('a.markdown-anchor-link').mouseleave(function(e){
-    $(e.target).hide();
+  $('.markdown-head').on('mouseleave', function(e){
+    $(this).find('span.octicon').css('visibility', 'hidden');
   });
 
   // syntax highlighting by google-code-prettify


### PR DESCRIPTION
Enlarge clickable area of ```<a>``` element like GitHub to fix #1055 problem.

![screenshot](https://cloud.githubusercontent.com/assets/4208984/12584378/96025d1a-c48a-11e5-867d-64dbea9c54ae.png)

NOTE:

* In previous implementation, the size of link icon is 16x16. However, suggested implementation is 14x14 because GitBucket globally specifies the size for `.octicon` class. Should I change the link icon size to 16x16 only in this context?