### PR TITLE
separate ssh url configuration from http baseurl

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/ControllerBase.scala
@@ -3,6 +3,7 @@ package gitbucket.core.controller
 import gitbucket.core.api.ApiError
 import gitbucket.core.model.Account
 import gitbucket.core.service.{AccountService, SystemSettingsService}
+import gitbucket.core.service.RepositoryService.{RepositoryInfo, RepositoryUrls}
 import gitbucket.core.util.ControlUtil._
 import gitbucket.core.util.Directory._
 import gitbucket.core.util.Implicits._
@@ -184,7 +185,8 @@ case class Context(settings: SystemSettingsService.SystemSettings, loginAccount:
   val currentPath = request.getRequestURI.substring(request.getContextPath.length)
   val baseUrl = settings.baseUrl(request)
   val host = new java.net.URL(baseUrl).getHost
-  val repoBase = RepoBase(baseUrl, settings.sshAddress)
+  val urls = (repositoryInfo:RepositoryInfo) => new RepositoryUrls(baseUrl, settings.sshAddress, repositoryInfo.owner, repositoryInfo.name)
+  val wikiUrls = (repositoryInfo:RepositoryInfo) => new RepositoryUrls(baseUrl, settings.sshAddress, repositoryInfo.owner, repositoryInfo.name + ".wiki")
   val platform = request.getHeader("User-Agent") match {
     case null => null
     case agent if agent.contains("Mac") => "mac"

--- a/src/main/scala/gitbucket/core/controller/ControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/ControllerBase.scala
@@ -184,10 +184,7 @@ case class Context(settings: SystemSettingsService.SystemSettings, loginAccount:
   val currentPath = request.getRequestURI.substring(request.getContextPath.length)
   val baseUrl = settings.baseUrl(request)
   val host = new java.net.URL(baseUrl).getHost
-  val repoBase = RepoBase(
-    baseUrl,
-    if (settings.ssh) Some(SshAddress(host, settings.sshPortOrDefault)) else None
- )
+  val repoBase = RepoBase(baseUrl, settings.sshAddress)
   val platform = request.getHeader("User-Agent") match {
     case null => null
     case agent if agent.contains("Mac") => "mac"

--- a/src/main/scala/gitbucket/core/controller/ControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/ControllerBase.scala
@@ -180,11 +180,14 @@ abstract class ControllerBase extends ScalatraFilter
  * Context object for the current request.
  */
 case class Context(settings: SystemSettingsService.SystemSettings, loginAccount: Option[Account], request: HttpServletRequest){
-
   val path = settings.baseUrl.getOrElse(request.getContextPath)
   val currentPath = request.getRequestURI.substring(request.getContextPath.length)
   val baseUrl = settings.baseUrl(request)
   val host = new java.net.URL(baseUrl).getHost
+  val repoBase = RepoBase(
+    baseUrl,
+    if (settings.ssh) Some(SshAddress(host, settings.sshPortOrDefault)) else None
+ )
   val platform = request.getHeader("User-Agent") match {
     case null => null
     case agent if agent.contains("Mac") => "mac"

--- a/src/main/scala/gitbucket/core/controller/DashboardController.scala
+++ b/src/main/scala/gitbucket/core/controller/DashboardController.scala
@@ -94,7 +94,7 @@ trait DashboardControllerBase extends ControllerBase {
 
     val userName  = context.loginAccount.get.userName
     val condition = getOrCreateCondition(Keys.Session.DashboardIssues, filter, userName)
-    val userRepos = getUserRepositories(userName, context.baseUrl, true).map(repo => repo.owner -> repo.name)
+    val userRepos = getUserRepositories(userName, true).map(repo => repo.owner -> repo.name)
     val page      = IssueSearchCondition.page(request)
 
     html.issues(

--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -29,8 +29,8 @@ trait IndexControllerBase extends ControllerBase {
     val loginAccount = context.loginAccount
     if(loginAccount.isEmpty) {
         html.index(getRecentActivities(),
-            getVisibleRepositories(loginAccount, context.baseUrl, withoutPhysicalInfo = true),
-            loginAccount.map{ account => getUserRepositories(account.userName, context.baseUrl, withoutPhysicalInfo = true) }.getOrElse(Nil)
+            getVisibleRepositories(loginAccount, withoutPhysicalInfo = true),
+            loginAccount.map{ account => getUserRepositories(account.userName, withoutPhysicalInfo = true) }.getOrElse(Nil)
         )
     } else {
         val loginUserName = loginAccount.get.userName
@@ -40,8 +40,8 @@ trait IndexControllerBase extends ControllerBase {
         visibleOwnerSet ++= loginUserGroups
 
         html.index(getRecentActivitiesByOwners(visibleOwnerSet),
-            getVisibleRepositories(loginAccount, context.baseUrl, withoutPhysicalInfo = true),
-            loginAccount.map{ account => getUserRepositories(account.userName, context.baseUrl, withoutPhysicalInfo = true) }.getOrElse(Nil) 
+            getVisibleRepositories(loginAccount, withoutPhysicalInfo = true),
+            loginAccount.map{ account => getUserRepositories(account.userName, withoutPhysicalInfo = true) }.getOrElse(Nil) 
         )
     }
   }

--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -560,8 +560,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     html.forked(
       getRepository(
         repository.repository.originUserName.getOrElse(repository.owner),
-        repository.repository.originRepositoryName.getOrElse(repository.name),
-        context.baseUrl),
+        repository.repository.originRepositoryName.getOrElse(repository.name)),
       getForkedRepositories(
         repository.repository.originUserName.getOrElse(repository.owner),
         repository.repository.originRepositoryName.getOrElse(repository.name)),

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -74,7 +74,7 @@ trait SystemSettingsControllerBase extends ControllerBase {
 
     if(form.ssh && !SshServer.isActive && form.baseUrl.isDefined){
       SshServer.start(
-        form.sshPort.getOrElse(SystemSettingsService.DefaultSshPort),
+        form.sshPortOrDefault,
         form.baseUrl.get)
     } else if(!form.ssh && SshServer.isActive){
       SshServer.stop()

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -23,6 +23,7 @@ trait SystemSettingsControllerBase extends ControllerBase {
     "notification"             -> trim(label("Notification", boolean())),
     "activityLogLimit"         -> trim(label("Limit of activity logs", optional(number()))),
     "ssh"                      -> trim(label("SSH access", boolean())),
+    "sshHost"                  -> trim(label("SSH host", optional(text()))),
     "sshPort"                  -> trim(label("SSH port", optional(number()))),
     "useSMTP"                  -> trim(label("SMTP", boolean())),
     "smtp"                     -> optionalIfNotChecked("useSMTP", mapping(
@@ -50,9 +51,14 @@ trait SystemSettingsControllerBase extends ControllerBase {
         "keystore"                 -> trim(label("Keystore", optional(text())))
     )(Ldap.apply))
   )(SystemSettings.apply).verifying { settings =>
-    if(settings.ssh && settings.baseUrl.isEmpty){
-      Seq("baseUrl" -> "Base URL is required if SSH access is enabled.")
-    } else Nil
+    Vector(
+      if(settings.ssh && settings.baseUrl.isEmpty){
+        Some("baseUrl" -> "Base URL is required if SSH access is enabled.")
+      } else None,
+      if(settings.ssh && settings.sshHost.isEmpty){
+        Some("sshHost" -> "SSH host is required if SSH access is enabled.")
+      } else None
+    ).flatten
   }
 
   private val pluginForm = mapping(

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -68,16 +68,13 @@ trait SystemSettingsControllerBase extends ControllerBase {
   post("/admin/system", form)(adminOnly { form =>
     saveSystemSettings(form)
 
-    if(form.ssh && SshServer.isActive && context.settings.sshPort != form.sshPort){
+    if (form.sshAddress != context.settings.sshAddress) {
       SshServer.stop()
-    }
-
-    if(form.ssh && !SshServer.isActive && form.baseUrl.isDefined){
-      SshServer.start(
-        form.sshPortOrDefault,
-        form.baseUrl.get)
-    } else if(!form.ssh && SshServer.isActive){
-      SshServer.stop()
+       for {
+         sshAddress <- form.sshAddress
+         baseUrl    <- form.baseUrl
+       }
+       SshServer.start(sshAddress, baseUrl)
     }
 
     flash += "info" -> "System settings has been updated."

--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -194,10 +194,9 @@ trait RepositoryService { self: AccountService =>
    * 
    * @param userName the user name of the repository owner
    * @param repositoryName the repository name
-   * @param baseUrl the base url of this application
    * @return the repository information
    */
-  def getRepository(userName: String, repositoryName: String, baseUrl: String)(implicit s: Session): Option[RepositoryInfo] = {
+  def getRepository(userName: String, repositoryName: String)(implicit s: Session): Option[RepositoryInfo] = {
     (Repositories filter { t => t.byRepository(userName, repositoryName) } firstOption) map { repository =>
       // for getting issue count and pull request count
       val issues = Issues.filter { t =>
@@ -207,7 +206,6 @@ trait RepositoryService { self: AccountService =>
       new RepositoryInfo(
         JGitUtil.getRepositoryInfo(repository.userName, repository.repositoryName),
         repository,
-        baseUrl,
         issues.count(_ == false),
         issues.count(_ == true),
         getForkedCount(
@@ -235,7 +233,7 @@ trait RepositoryService { self: AccountService =>
     }.list
   }
 
-  def getUserRepositories(userName: String, baseUrl: String, withoutPhysicalInfo: Boolean = false)
+  def getUserRepositories(userName: String, withoutPhysicalInfo: Boolean = false)
                          (implicit s: Session): List[RepositoryInfo] = {
     Repositories.filter { t1 =>
       (t1.userName === userName.bind) ||
@@ -248,7 +246,6 @@ trait RepositoryService { self: AccountService =>
           JGitUtil.getRepositoryInfo(repository.userName, repository.repositoryName)
         },
         repository,
-        baseUrl,
         getForkedCount(
           repository.originUserName.getOrElse(repository.userName),
           repository.originRepositoryName.getOrElse(repository.repositoryName)
@@ -262,13 +259,12 @@ trait RepositoryService { self: AccountService =>
    * If repositoryUserName is given then filters results by repository owner.
    *
    * @param loginAccount the logged in account
-   * @param baseUrl the base url of this application
    * @param repositoryUserName the repository owner (if None then returns all repositories which are visible for logged in user)
    * @param withoutPhysicalInfo if true then the result does not include physical repository information such as commit count,
    *                            branches and tags
    * @return the repository information which is sorted in descending order of lastActivityDate.
    */
-  def getVisibleRepositories(loginAccount: Option[Account], baseUrl: String, repositoryUserName: Option[String] = None,
+  def getVisibleRepositories(loginAccount: Option[Account], repositoryUserName: Option[String] = None,
                              withoutPhysicalInfo: Boolean = false)
                             (implicit s: Session): List[RepositoryInfo] = {
     (loginAccount match {
@@ -291,7 +287,6 @@ trait RepositoryService { self: AccountService =>
           JGitUtil.getRepositoryInfo(repository.userName, repository.repositoryName)
         },
         repository,
-        baseUrl,
         getForkedCount(
           repository.originUserName.getOrElse(repository.userName),
           repository.originRepositoryName.getOrElse(repository.repositoryName)
@@ -401,7 +396,7 @@ object RepositoryService {
     /**
      * Creates instance with issue count and pull request count.
      */
-    def this(repo: JGitUtil.RepositoryInfo, model: Repository, baseUrl:String, issueCount: Int, pullCount: Int, forkedCount: Int, managers: Seq[String]) =
+    def this(repo: JGitUtil.RepositoryInfo, model: Repository, issueCount: Int, pullCount: Int, forkedCount: Int, managers: Seq[String]) =
       this(
         repo.owner, repo.name, model,
         issueCount, pullCount,
@@ -410,7 +405,7 @@ object RepositoryService {
     /**
      * Creates instance without issue count and pull request count.
      */
-    def this(repo: JGitUtil.RepositoryInfo, model: Repository, baseUrl:String, forkedCount: Int, managers: Seq[String]) =
+    def this(repo: JGitUtil.RepositoryInfo, model: Repository, 	forkedCount: Int, managers: Seq[String]) =
       this(
         repo.owner, repo.name, model,
         0, 0,

--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -1,8 +1,9 @@
 package gitbucket.core.service
 
+import gitbucket.core.service.SystemSettingsService.SshAddress
 import gitbucket.core.model.{Collaborator, Repository, Account}
 import gitbucket.core.model.Profile._
-import gitbucket.core.util.{JGitUtil, RepoBase}
+import gitbucket.core.util.JGitUtil
 import profile.simple._
 
 trait RepositoryService { self: AccountService =>
@@ -391,8 +392,6 @@ object RepositoryService {
     issueCount: Int, pullCount: Int, commitCount: Int, forkedCount: Int,
     branchList: Seq[String], tags: Seq[JGitUtil.TagInfo], managers: Seq[String]) {
 
-    def urls(repoBase:RepoBase):RepositoryUrls = new RepositoryUrls(repoBase, owner, name)
-
     /**
      * Creates instance with issue count and pull request count.
      */
@@ -412,13 +411,13 @@ object RepositoryService {
         repo.commitCount, forkedCount, repo.branchList, repo.tags, managers)
   }
 
-  final class RepositoryUrls(repoBase:RepoBase, owner:String, name:String) {
+  final class RepositoryUrls(baseUrl:String, sshAddress:Option[SshAddress], owner:String, name:String) {
     def httpUrl:String =
-      s"${repoBase.baseUrl}/git/${owner}/${name}.git"
+      s"${baseUrl}/git/${owner}/${name}.git"
 
     // BETTER make this return an Option and use it in the gui
     def sshUrl(userName: String):String =
-      repoBase.sshAddress.fold("")(adr => s"ssh://${userName}@${adr.host}:${adr.port}/${owner}/${name}.git")
+      sshAddress.fold("")(adr => s"ssh://${userName}@${adr.host}:${adr.port}/${owner}/${name}.git")
 
     def sshOpenRepoUrl(platform: String, userName: String) =
       openRepoUrl(platform, sshUrl(userName))

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -1,6 +1,7 @@
 package gitbucket.core.service
 
 import gitbucket.core.util.{Directory, ControlUtil}
+import gitbucket.core.util.Implicits._
 import Directory._
 import ControlUtil._
 import SystemSettingsService._
@@ -131,11 +132,7 @@ object SystemSettingsService {
     smtp: Option[Smtp],
     ldapAuthentication: Boolean,
     ldap: Option[Ldap]){
-    def baseUrl(request: HttpServletRequest): String = baseUrl.getOrElse {
-      defining(request.getRequestURL.toString){ url =>
-        url.substring(0, url.length - (request.getRequestURI.length - request.getContextPath.length))
-      }
-    }.stripSuffix("/")
+    def baseUrl(request: HttpServletRequest): String = baseUrl.fold(request.baseUrl)(_.stripSuffix("/"))
     def sshPortOrDefault:Int = sshPort.getOrElse(DefaultSshPort)
   }
 

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -1,6 +1,6 @@
 package gitbucket.core.service
 
-import gitbucket.core.util.{Directory, ControlUtil, SshAddress}
+import gitbucket.core.util.{Directory, ControlUtil}
 import gitbucket.core.util.Implicits._
 import Directory._
 import ControlUtil._
@@ -167,6 +167,10 @@ object SystemSettingsService {
     ssl: Option[Boolean],
     fromAddress: Option[String],
     fromName: Option[String])
+
+  case class SshAddress(
+    host:String,
+    port:Int)
 
   val DefaultSshPort = 29418
   val DefaultSmtpPort = 25

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -136,6 +136,7 @@ object SystemSettingsService {
         url.substring(0, url.length - (request.getRequestURI.length - request.getContextPath.length))
       }
     }.stripSuffix("/")
+    def sshPortOrDefault:Int = sshPort.getOrElse(DefaultSshPort)
   }
 
   case class Ldap(

--- a/src/main/scala/gitbucket/core/service/WebHookService.scala
+++ b/src/main/scala/gitbucket/core/service/WebHookService.scala
@@ -161,7 +161,7 @@ trait WebHookPullRequestService extends WebHookService {
         baseOwner <- users.get(repository.owner)
         headOwner <- users.get(pullRequest.requestUserName)
         issueUser <- users.get(issue.openedUserName)
-        headRepo  <- getRepository(pullRequest.requestUserName, pullRequest.requestRepositoryName, baseUrl)
+        headRepo  <- getRepository(pullRequest.requestUserName, pullRequest.requestRepositoryName)
       } yield {
         WebHookPullRequestPayload(
           action         = action,
@@ -200,7 +200,7 @@ trait WebHookPullRequestService extends WebHookService {
     import WebHookService._
     for{
       ((issue, issueUser, pullRequest, baseOwner, headOwner), webHooks) <- getPullRequestsByRequestForWebhook(requestRepository.owner, requestRepository.name, requestBranch)
-      baseRepo <- getRepository(pullRequest.userName, pullRequest.repositoryName, baseUrl)
+      baseRepo <- getRepository(pullRequest.userName, pullRequest.repositoryName)
     } yield {
       val payload = WebHookPullRequestPayload(
         action         = action,
@@ -229,7 +229,7 @@ trait WebHookPullRequestReviewCommentService extends WebHookService {
         baseOwner <- users.get(repository.owner)
         headOwner <- users.get(pullRequest.requestUserName)
         issueUser <- users.get(issue.openedUserName)
-        headRepo  <- getRepository(pullRequest.requestUserName, pullRequest.requestRepositoryName, baseUrl)
+        headRepo  <- getRepository(pullRequest.requestUserName, pullRequest.requestRepositoryName)
       } yield {
         WebHookPullRequestReviewCommentPayload(
           action         = action,

--- a/src/main/scala/gitbucket/core/service/WikiService.scala
+++ b/src/main/scala/gitbucket/core/service/WikiService.scala
@@ -41,7 +41,7 @@ object WikiService {
   def httpUrl(repository: RepositoryInfo) = repository.httpUrl.replaceFirst("\\.git\\Z", ".wiki.git")
 
   def sshUrl(repository: RepositoryInfo, settings: SystemSettingsService.SystemSettings, userName: String) =
-    repository.sshUrl(settings.sshPort.getOrElse(SystemSettingsService.DefaultSshPort), userName).replaceFirst("\\.git\\Z", ".wiki.git")
+    repository.sshUrl(settings.sshPortOrDefault, userName).replaceFirst("\\.git\\Z", ".wiki.git")
 }
 
 trait WikiService {

--- a/src/main/scala/gitbucket/core/service/WikiService.scala
+++ b/src/main/scala/gitbucket/core/service/WikiService.scala
@@ -38,10 +38,11 @@ object WikiService {
    */
   case class WikiPageHistoryInfo(name: String, committer: String, message: String, date: Date)
 
-  def httpUrl(repository: RepositoryInfo) = repository.httpUrl.replaceFirst("\\.git\\Z", ".wiki.git")
+  def httpUrl(repoBase:RepoBase, repository: RepositoryInfo) =
+    repository.urls(repoBase).httpUrl.replaceFirst("\\.git\\Z", ".wiki.git")
 
-  def sshUrl(repository: RepositoryInfo, settings: SystemSettingsService.SystemSettings, userName: String) =
-    repository.sshUrl(settings.sshPortOrDefault, userName).replaceFirst("\\.git\\Z", ".wiki.git")
+  def sshUrl(repoBase:RepoBase, repository: RepositoryInfo, userName: String) =
+    repository.urls(repoBase).sshUrl(userName).replaceFirst("\\.git\\Z", ".wiki.git")
 }
 
 trait WikiService {

--- a/src/main/scala/gitbucket/core/service/WikiService.scala
+++ b/src/main/scala/gitbucket/core/service/WikiService.scala
@@ -1,6 +1,7 @@
 package gitbucket.core.service
 
 import java.util.Date
+import gitbucket.core.service.SystemSettingsService.SshAddress
 import gitbucket.core.model.Account
 import gitbucket.core.util._
 import gitbucket.core.util.ControlUtil._
@@ -38,9 +39,6 @@ object WikiService {
    * @param date the commit date
    */
   case class WikiPageHistoryInfo(name: String, committer: String, message: String, date: Date)
-
-  def urls(repoBase:RepoBase, repository: RepositoryInfo):RepositoryUrls =
-    new RepositoryUrls(repoBase, repository.owner, repository.name + ".wiki")
 }
 
 trait WikiService {

--- a/src/main/scala/gitbucket/core/service/WikiService.scala
+++ b/src/main/scala/gitbucket/core/service/WikiService.scala
@@ -14,6 +14,7 @@ import org.eclipse.jgit.patch._
 import org.eclipse.jgit.api.errors.PatchFormatException
 import scala.collection.JavaConverters._
 import RepositoryService.RepositoryInfo
+import RepositoryService.RepositoryUrls
 
 object WikiService {
   
@@ -38,11 +39,8 @@ object WikiService {
    */
   case class WikiPageHistoryInfo(name: String, committer: String, message: String, date: Date)
 
-  def httpUrl(repoBase:RepoBase, repository: RepositoryInfo) =
-    repository.urls(repoBase).httpUrl.replaceFirst("\\.git\\Z", ".wiki.git")
-
-  def sshUrl(repoBase:RepoBase, repository: RepositoryInfo, userName: String) =
-    repository.urls(repoBase).sshUrl(userName).replaceFirst("\\.git\\Z", ".wiki.git")
+  def urls(repoBase:RepoBase, repository: RepositoryInfo):RepositoryUrls =
+    new RepositoryUrls(repoBase, repository.owner, repository.name + ".wiki")
 }
 
 trait WikiService {

--- a/src/main/scala/gitbucket/core/servlet/BasicAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/BasicAuthenticationFilter.scala
@@ -74,7 +74,7 @@ class BasicAuthenticationFilter extends Filter with RepositoryService with Accou
 
     request.paths match {
       case Array(_, repositoryOwner, repositoryName, _*) =>
-        getRepository(repositoryOwner, repositoryName.replaceFirst("\\.wiki\\.git$|\\.git$", ""), "") match {
+        getRepository(repositoryOwner, repositoryName.replaceFirst("\\.wiki\\.git$|\\.git$", "")) match {
           case Some(repository) => {
             if(!isUpdating && !repository.repository.isPrivate && settings.allowAnonymousAccess){
               chain.doFilter(request, response)

--- a/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
@@ -160,7 +160,7 @@ class CommitLogHook(owner: String, repository: String, pusher: String, baseUrl: 
             countIssue(IssueSearchCondition(state = "open"), false, owner -> repository) +
             countIssue(IssueSearchCondition(state = "closed"), false, owner -> repository)
 
-          val repositoryInfo = getRepository(owner, repository, baseUrl).get
+          val repositoryInfo = getRepository(owner, repository).get
 
           // Extract new commit and apply issue comment
           val defaultBranch = repositoryInfo.repository.defaultBranch

--- a/src/main/scala/gitbucket/core/ssh/GitCommand.scala
+++ b/src/main/scala/gitbucket/core/ssh/GitCommand.scala
@@ -124,7 +124,7 @@ class DefaultGitReceivePack(owner: String, repoName: String, baseUrl: String) ex
   }
 }
 
-class PluginGitUploadPack(repoName: String, baseUrl: String, routing: GitRepositoryRouting) extends GitCommand
+class PluginGitUploadPack(repoName: String, routing: GitRepositoryRouting) extends GitCommand
     with SystemSettingsService {
 
   override protected def runTask(user: String)(implicit session: Session): Unit = {
@@ -139,7 +139,7 @@ class PluginGitUploadPack(repoName: String, baseUrl: String, routing: GitReposit
   }
 }
 
-class PluginGitReceivePack(repoName: String, baseUrl: String, routing: GitRepositoryRouting) extends GitCommand
+class PluginGitReceivePack(repoName: String, routing: GitRepositoryRouting) extends GitCommand
     with SystemSettingsService {
 
   override protected def runTask(user: String)(implicit session: Session): Unit = {
@@ -163,8 +163,8 @@ class GitCommandFactory(baseUrl: String) extends CommandFactory {
     logger.debug(s"command: $command")
 
     command match {
-      case SimpleCommandRegex ("upload" , repoName) if(pluginRepository(repoName)) => new PluginGitUploadPack (repoName, baseUrl, routing(repoName))
-      case SimpleCommandRegex ("receive", repoName) if(pluginRepository(repoName)) => new PluginGitReceivePack(repoName, baseUrl, routing(repoName))
+      case SimpleCommandRegex ("upload" , repoName) if(pluginRepository(repoName)) => new PluginGitUploadPack (repoName, routing(repoName))
+      case SimpleCommandRegex ("receive", repoName) if(pluginRepository(repoName)) => new PluginGitReceivePack(repoName, routing(repoName))
       case DefaultCommandRegex("upload" , owner, repoName) => new DefaultGitUploadPack (owner, repoName, baseUrl)
       case DefaultCommandRegex("receive", owner, repoName) => new DefaultGitReceivePack(owner, repoName, baseUrl)
       case _ => new UnknownCommand(command)

--- a/src/main/scala/gitbucket/core/ssh/GitCommand.scala
+++ b/src/main/scala/gitbucket/core/ssh/GitCommand.scala
@@ -87,11 +87,11 @@ abstract class DefaultGitCommand(val owner: String, val repoName: String) extend
 }
 
 
-class DefaultGitUploadPack(owner: String, repoName: String, baseUrl: String) extends DefaultGitCommand(owner, repoName)
+class DefaultGitUploadPack(owner: String, repoName: String) extends DefaultGitCommand(owner, repoName)
     with RepositoryService with AccountService {
 
   override protected def runTask(user: String)(implicit session: Session): Unit = {
-    getRepository(owner, repoName.replaceFirst("\\.wiki\\Z", ""), baseUrl).foreach { repositoryInfo =>
+    getRepository(owner, repoName.replaceFirst("\\.wiki\\Z", "")).foreach { repositoryInfo =>
       if(!repositoryInfo.repository.isPrivate || isWritableUser(user, repositoryInfo)){
         using(Git.open(getRepositoryDir(owner, repoName))) { git =>
           val repository = git.getRepository
@@ -107,7 +107,7 @@ class DefaultGitReceivePack(owner: String, repoName: String, baseUrl: String) ex
     with RepositoryService with AccountService {
 
   override protected def runTask(user: String)(implicit session: Session): Unit = {
-    getRepository(owner, repoName.replaceFirst("\\.wiki\\Z", ""), baseUrl).foreach { repositoryInfo =>
+    getRepository(owner, repoName.replaceFirst("\\.wiki\\Z", "")).foreach { repositoryInfo =>
       if(isWritableUser(user, repositoryInfo)){
         using(Git.open(getRepositoryDir(owner, repoName))) { git =>
           val repository = git.getRepository
@@ -165,7 +165,7 @@ class GitCommandFactory(baseUrl: String) extends CommandFactory {
     command match {
       case SimpleCommandRegex ("upload" , repoName) if(pluginRepository(repoName)) => new PluginGitUploadPack (repoName, routing(repoName))
       case SimpleCommandRegex ("receive", repoName) if(pluginRepository(repoName)) => new PluginGitReceivePack(repoName, routing(repoName))
-      case DefaultCommandRegex("upload" , owner, repoName) => new DefaultGitUploadPack (owner, repoName, baseUrl)
+      case DefaultCommandRegex("upload" , owner, repoName) => new DefaultGitUploadPack (owner, repoName)
       case DefaultCommandRegex("receive", owner, repoName) => new DefaultGitReceivePack(owner, repoName, baseUrl)
       case _ => new UnknownCommand(command)
     }

--- a/src/main/scala/gitbucket/core/ssh/NoShell.scala
+++ b/src/main/scala/gitbucket/core/ssh/NoShell.scala
@@ -1,7 +1,7 @@
 package gitbucket.core.ssh
 
 import gitbucket.core.service.SystemSettingsService
-import gitbucket.core.util.SshAddress
+import gitbucket.core.service.SystemSettingsService.SshAddress
 import org.apache.sshd.common.Factory
 import org.apache.sshd.server.{Environment, ExitCallback, Command}
 import java.io.{OutputStream, InputStream}

--- a/src/main/scala/gitbucket/core/ssh/NoShell.scala
+++ b/src/main/scala/gitbucket/core/ssh/NoShell.scala
@@ -15,7 +15,7 @@ class NoShell extends Factory[Command] with SystemSettingsService {
 
     override def start(env: Environment): Unit = {
       val user = env.getEnv.get("USER")
-      val port = loadSystemSettings().sshPort.getOrElse(SystemSettingsService.DefaultSshPort)
+      val port = loadSystemSettings().sshPortOrDefault
       val message =
         """
           | Welcome to

--- a/src/main/scala/gitbucket/core/ssh/SshServerListener.scala
+++ b/src/main/scala/gitbucket/core/ssh/SshServerListener.scala
@@ -60,7 +60,7 @@ class SshServerListener extends ServletContextListener with SystemSettingsServic
         case None =>
           logger.error("Could not start SshServer because the baseUrl is not configured.")
         case Some(baseUrl) =>
-          SshServer.start(settings.sshPort.getOrElse(SystemSettingsService.DefaultSshPort), baseUrl)
+          SshServer.start(settings.sshPortOrDefault, baseUrl)
       }
     }
   }

--- a/src/main/scala/gitbucket/core/ssh/SshServerListener.scala
+++ b/src/main/scala/gitbucket/core/ssh/SshServerListener.scala
@@ -5,7 +5,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.servlet.{ServletContextEvent, ServletContextListener}
 
 import gitbucket.core.service.SystemSettingsService
-import gitbucket.core.util.{Directory, SshAddress}
+import gitbucket.core.service.SystemSettingsService.SshAddress
+import gitbucket.core.util.{Directory}
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/gitbucket/core/ssh/SshServerListener.scala
+++ b/src/main/scala/gitbucket/core/ssh/SshServerListener.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.servlet.{ServletContextEvent, ServletContextListener}
 
 import gitbucket.core.service.SystemSettingsService
-import gitbucket.core.util.Directory
+import gitbucket.core.util.{Directory, SshAddress}
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider
 import org.slf4j.LoggerFactory
 
@@ -14,20 +14,20 @@ object SshServer {
   private val server = org.apache.sshd.server.SshServer.setUpDefaultServer()
   private val active = new AtomicBoolean(false)
 
-  private def configure(port: Int, baseUrl: String) = {
-    server.setPort(port)
+  private def configure(sshAddress: SshAddress, baseUrl: String) = {
+    server.setPort(sshAddress.port)
     val provider = new SimpleGeneratorHostKeyProvider(new File(s"${Directory.GitBucketHome}/gitbucket.ser"))
     provider.setAlgorithm("RSA")
     provider.setOverwriteAllowed(false)
     server.setKeyPairProvider(provider)
     server.setPublickeyAuthenticator(new PublicKeyAuthenticator)
     server.setCommandFactory(new GitCommandFactory(baseUrl))
-    server.setShellFactory(new NoShell)
+    server.setShellFactory(new NoShell(sshAddress))
   }
 
-  def start(port: Int, baseUrl: String) = {
+  def start(sshAddress: SshAddress, baseUrl: String) = {
     if(active.compareAndSet(false, true)){
-      configure(port, baseUrl)
+      configure(sshAddress, baseUrl)
       server.start()
       logger.info(s"Start SSH Server Listen on ${server.getPort}")
     }
@@ -55,20 +55,18 @@ class SshServerListener extends ServletContextListener with SystemSettingsServic
 
   override def contextInitialized(sce: ServletContextEvent): Unit = {
     val settings = loadSystemSettings()
-    if(settings.ssh){
-      settings.baseUrl match {
-        case None =>
-          logger.error("Could not start SshServer because the baseUrl is not configured.")
-        case Some(baseUrl) =>
-          SshServer.start(settings.sshPortOrDefault, baseUrl)
-      }
+    if (settings.sshAddress.isDefined && settings.baseUrl.isEmpty) {
+    	logger.error("Could not start SshServer because the baseUrl is not configured.")
     }
+    for {
+      sshAddress <- settings.sshAddress
+      baseUrl    <- settings.baseUrl
+    }
+    SshServer.start(sshAddress, baseUrl)
   }
 
   override def contextDestroyed(sce: ServletContextEvent): Unit = {
-    if(loadSystemSettings().ssh){
-      SshServer.stop()
-    }
+    SshServer.stop()
   }
 
 }

--- a/src/main/scala/gitbucket/core/util/Authenticator.scala
+++ b/src/main/scala/gitbucket/core/util/Authenticator.scala
@@ -36,7 +36,7 @@ trait OwnerAuthenticator { self: ControllerBase with RepositoryService with Acco
   private def authenticate(action: (RepositoryInfo) => Any) = {
     {
       defining(request.paths){ paths =>
-        getRepository(paths(0), paths(1), baseUrl).map { repository =>
+        getRepository(paths(0), paths(1)).map { repository =>
           context.loginAccount match {
             case Some(x) if(x.isAdmin) => action(repository)
             case Some(x) if(repository.owner == x.userName) => action(repository)
@@ -95,7 +95,7 @@ trait CollaboratorsAuthenticator { self: ControllerBase with RepositoryService =
   private def authenticate(action: (RepositoryInfo) => Any) = {
     {
       defining(request.paths){ paths =>
-        getRepository(paths(0), paths(1), baseUrl).map { repository =>
+        getRepository(paths(0), paths(1)).map { repository =>
           context.loginAccount match {
             case Some(x) if(x.isAdmin) => action(repository)
             case Some(x) if(paths(0) == x.userName) => action(repository)
@@ -118,7 +118,7 @@ trait ReferrerAuthenticator { self: ControllerBase with RepositoryService =>
   private def authenticate(action: (RepositoryInfo) => Any) = {
     {
       defining(request.paths){ paths =>
-        getRepository(paths(0), paths(1), baseUrl).map { repository =>
+        getRepository(paths(0), paths(1)).map { repository =>
           if(!repository.repository.isPrivate){
             action(repository)
           } else {
@@ -145,7 +145,7 @@ trait ReadableUsersAuthenticator { self: ControllerBase with RepositoryService =
   private def authenticate(action: (RepositoryInfo) => Any) = {
     {
       defining(request.paths){ paths =>
-        getRepository(paths(0), paths(1), baseUrl).map { repository =>
+        getRepository(paths(0), paths(1)).map { repository =>
           context.loginAccount match {
             case Some(x) if(x.isAdmin) => action(repository)
             case Some(x) if(!repository.repository.isPrivate) => action(repository)

--- a/src/main/scala/gitbucket/core/util/Implicits.scala
+++ b/src/main/scala/gitbucket/core/util/Implicits.scala
@@ -75,6 +75,11 @@ object Implicits {
 
     def gitRepositoryPath: String = request.getRequestURI.replaceFirst("^/git/", "/")
 
+    def baseUrl:String = {
+      val url = request.getRequestURL.toString
+      val len = url.length - (request.getRequestURI.length - request.getContextPath.length)
+      url.substring(0, len).stripSuffix("/")
+    }
   }
 
   implicit class RichSession(session: HttpSession){

--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -32,14 +32,13 @@ object JGitUtil {
    *
    * @param owner the user name of the repository owner
    * @param name the repository name
-   * @param url the repository URL
    * @param commitCount the commit count. If the repository has over 1000 commits then this property is 1001.
    * @param branchList the list of branch names
    * @param tags the list of tags
    */
-  case class RepositoryInfo(owner: String, name: String, url: String, commitCount: Int, branchList: List[String], tags: List[TagInfo]){
-    def this(owner: String, name: String, baseUrl: String) = {
-      this(owner, name, s"${baseUrl}/git/${owner}/${name}.git", 0, Nil, Nil)
+  case class RepositoryInfo(owner: String, name: String, commitCount: Int, branchList: List[String], tags: List[TagInfo]){
+    def this(owner: String, name: String) = {
+      this(owner, name, 0, Nil, Nil)
     }
   }
 
@@ -174,14 +173,14 @@ object JGitUtil {
   /**
    * Returns the repository information. It contains branch names and tag names.
    */
-  def getRepositoryInfo(owner: String, repository: String, baseUrl: String): RepositoryInfo = {
+  def getRepositoryInfo(owner: String, repository: String): RepositoryInfo = {
     using(Git.open(getRepositoryDir(owner, repository))){ git =>
       try {
         // get commit count
         val commitCount = git.log.all.call.iterator.asScala.map(_ => 1).take(10001).sum
 
         RepositoryInfo(
-          owner, repository, s"${baseUrl}/git/${owner}/${repository}.git",
+          owner, repository,
           // commit count
           commitCount,
           // branches
@@ -197,7 +196,7 @@ object JGitUtil {
       } catch {
         // not initialized
         case e: NoHeadException => RepositoryInfo(
-          owner, repository, s"${baseUrl}/git/${owner}/${repository}.git", 0, Nil, Nil)
+          owner, repository, 0, Nil, Nil)
 
       }
     }

--- a/src/main/scala/gitbucket/core/util/RepoBase.scala
+++ b/src/main/scala/gitbucket/core/util/RepoBase.scala
@@ -1,0 +1,3 @@
+package gitbucket.core.util
+
+case class RepoBase(baseUrl:String, sshAddress:Option[SshAddress])

--- a/src/main/scala/gitbucket/core/util/RepoBase.scala
+++ b/src/main/scala/gitbucket/core/util/RepoBase.scala
@@ -1,5 +1,0 @@
-package gitbucket.core.util
-
-import gitbucket.core.service.SystemSettingsService.SshAddress
-
-case class RepoBase(baseUrl:String, sshAddress:Option[SshAddress])

--- a/src/main/scala/gitbucket/core/util/RepoBase.scala
+++ b/src/main/scala/gitbucket/core/util/RepoBase.scala
@@ -1,3 +1,5 @@
 package gitbucket.core.util
 
+import gitbucket.core.service.SystemSettingsService.SshAddress
+
 case class RepoBase(baseUrl:String, sshAddress:Option[SshAddress])

--- a/src/main/scala/gitbucket/core/util/SshAddress.scala
+++ b/src/main/scala/gitbucket/core/util/SshAddress.scala
@@ -1,3 +1,0 @@
-package gitbucket.core.util
-
-case class SshAddress(host:String, port:Int)

--- a/src/main/scala/gitbucket/core/util/SshAddress.scala
+++ b/src/main/scala/gitbucket/core/util/SshAddress.scala
@@ -1,0 +1,3 @@
+package gitbucket.core.util
+
+case class SshAddress(host:String, port:Int)

--- a/src/main/scala/gitbucket/core/view/Markdown.scala
+++ b/src/main/scala/gitbucket/core/view/Markdown.scala
@@ -60,7 +60,7 @@ object Markdown {
                                 pages: List[String])
                                (implicit val context: Context) extends Renderer(options) with LinkConverter with RequestCache {
 
-    private val repositoryUrls = repository.urls(context.repoBase)
+    private val repositoryUrls = context.urls(repository)
 
     override  def heading(text: String, level: Int, raw: String): String = {
       val id = generateAnchorName(text)

--- a/src/main/scala/gitbucket/core/view/Markdown.scala
+++ b/src/main/scala/gitbucket/core/view/Markdown.scala
@@ -60,6 +60,8 @@ object Markdown {
                                 pages: List[String])
                                (implicit val context: Context) extends Renderer(options) with LinkConverter with RequestCache {
 
+    private val repositoryUrls = repository.urls(context.repoBase)
+
     override  def heading(text: String, level: Int, raw: String): String = {
       val id = generateAnchorName(text)
       val out = new StringBuilder()
@@ -135,7 +137,7 @@ object Markdown {
           (link, link)
         }
 
-        val url = repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/" + StringUtil.urlEncode(page)
+        val url = repositoryUrls.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/" + StringUtil.urlEncode(page)
         if(pages.contains(page)){
           "<a href=\"" + url + "\">" + escape(label) + "</a>"
         } else {
@@ -157,14 +159,14 @@ object Markdown {
         } else if(context.currentPath.contains("/tree/")){
           val paths = context.currentPath.split("/")
           val branch = if(paths.length > 3) paths.drop(4).mkString("/") else repository.repository.defaultBranch
-          repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/blob/" + branch + "/" + url + (if(isImage) "?raw=true" else "")
+          repositoryUrls.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/blob/" + branch + "/" + url + (if(isImage) "?raw=true" else "")
         } else {
           val paths = context.currentPath.split("/")
           val branch = if(paths.length > 3) paths.last else repository.repository.defaultBranch
-          repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/blob/" + branch + "/" + url + (if(isImage) "?raw=true" else "")
+          repositoryUrls.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/blob/" + branch + "/" + url + (if(isImage) "?raw=true" else "")
         }
       } else {
-        repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/_blob/" + url
+        repositoryUrls.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/_blob/" + url
       }
     }
 

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -111,15 +111,24 @@
               Enable SSH access to git repository
             </label>
           </fieldset>
-          <div class="form-group ssh">
-            <label class="control-label col-md-3" for="sshPort">SSH Port</label>
-            <div class="col-md-9">
-              <input type="text" id="sshPort" name="sshPort" class="form-control" value="@settings.sshPort"/>
-              <span id="error-sshPort" class="error"></span>
+          <div class="ssh">
+            <div class="form-group">
+              <label class="control-label col-md-3" for="sshHost">SSH Host</label>
+              <div class="col-md-9">
+                <input type="text" id="sshHost" name="sshHost" class="form-control" value="@settings.sshHost"/>
+                <span id="error-sshHost" class="error"></span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="control-label col-md-3" for="sshPort">SSH Port</label>
+              <div class="col-md-9">
+                <input type="text" id="sshPort" name="sshPort" class="form-control" value="@settings.sshPort"/>
+                <span id="error-sshPort" class="error"></span>
+              </div>
             </div>
           </div>
           <p class="muted">
-            Base URL is required if SSH access is enabled.
+             Base URL is required if SSH access is enabled.
           </p>
           <!--====================================================================-->
           <!-- Authentication -->

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -37,7 +37,7 @@
     <script src="@assets/vendors/jquery-hotkeys/jquery.hotkeys.js"></script>
     @repository.map { repository =>
       @if(!repository.repository.isPrivate){
-        <meta name="go-import" content="@context.baseUrl.replaceFirst("^https?://", "")/@repository.owner/@repository.name git @repository.httpUrl" />
+        <meta name="go-import" content="@context.baseUrl.replaceFirst("^https?://", "")/@repository.owner/@repository.name git @repository.urls(repoBase).httpUrl" />
       }
     }
   </head>

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -37,7 +37,7 @@
     <script src="@assets/vendors/jquery-hotkeys/jquery.hotkeys.js"></script>
     @repository.map { repository =>
       @if(!repository.repository.isPrivate){
-        <meta name="go-import" content="@context.baseUrl.replaceFirst("^https?://", "")/@repository.owner/@repository.name git @repository.urls(repoBase).httpUrl" />
+        <meta name="go-import" content="@context.baseUrl.replaceFirst("^https?://", "")/@repository.owner/@repository.name git @context.urls(repository).httpUrl" />
       }
     }
   </head>

--- a/src/main/twirl/gitbucket/core/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/menu.scala.html
@@ -80,8 +80,8 @@
       <div class="small">
         <strong id="repository-url-proto">HTTP</strong> <span class="mute">clone URL</span>
       </div>
-      @helper.html.copy("repository-url-copy", repository.urls(repoBase).httpUrl){
-        <input type="text" value="@repository.urls(repoBase).httpUrl" id="repository-url" class="form-control input-sm" readonly>
+      @helper.html.copy("repository-url-copy", context.urls(repository).httpUrl){
+        <input type="text" value="@context.urls(repository).httpUrl" id="repository-url" class="form-control input-sm" readonly>
       }
       @if(settings.ssh && loginAccount.isDefined){
         <div class="small">
@@ -91,7 +91,7 @@
       @id.map { id =>
         @if(context.platform != "linux" && context.platform != null){
         <div style="margin-top: 10px;">
-          <a href="@repository.urls(repoBase).httpOpenRepoUrl(context.platform)" id="repository-clone-url" class="btn btn-sm btn-default btn-block"><i class="octicon octicon-desktop-download"></i>&nbsp;&nbsp;Clone in Desktop</a>
+          <a href="@context.urls(repository).httpOpenRepoUrl(context.platform)" id="repository-clone-url" class="btn btn-sm btn-default btn-block"><i class="octicon octicon-desktop-download"></i>&nbsp;&nbsp;Clone in Desktop</a>
         </div>
         }
         <div style="margin-top: 10px;">
@@ -184,15 +184,15 @@ $(function(){
   @if(settings.ssh && loginAccount.isDefined){
     $('#repository-url-http').click(function(){
       $('#repository-url-proto').text('HTTP');
-      $('#repository-url').val('@repository.urls(repoBase).httpUrl');
-      $('#repository-clone-url').attr('href', '@repository.urls(repoBase).httpOpenRepoUrl(context.platform)')
+      $('#repository-url').val('@context.urls(repository).httpUrl');
+      $('#repository-clone-url').attr('href', '@context.urls(repository).httpOpenRepoUrl(context.platform)')
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
 
     $('#repository-url-ssh').click(function(){
       $('#repository-url-proto').text('SSH');
-      $('#repository-url').val('@repository.urls(repoBase).sshUrl(loginAccount.get.userName)');
-      $('#repository-clone-url').attr('href', '@repository.urls(repoBase).sshOpenRepoUrl(context.platform, loginAccount.get.userName)');
+      $('#repository-url').val('@context.urls(repository).sshUrl(loginAccount.get.userName)');
+      $('#repository-clone-url').attr('href', '@context.urls(repository).sshOpenRepoUrl(context.platform, loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
   }

--- a/src/main/twirl/gitbucket/core/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/menu.scala.html
@@ -191,8 +191,8 @@ $(function(){
 
     $('#repository-url-ssh').click(function(){
       $('#repository-url-proto').text('SSH');
-      $('#repository-url').val('@repository.sshUrl(settings.sshPort.getOrElse(SystemSettingsService.DefaultSshPort), loginAccount.get.userName)');
-      $('#repository-clone-url').attr('href', '@repository.sshOpenRepoUrl(context.platform, settings.sshPort.getOrElse(SystemSettingsService.DefaultSshPort), loginAccount.get.userName)');
+      $('#repository-url').val('@repository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)');
+      $('#repository-clone-url').attr('href', '@repository.sshOpenRepoUrl(context.platform, settings.sshPortOrDefault, loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
   }

--- a/src/main/twirl/gitbucket/core/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/menu.scala.html
@@ -80,8 +80,8 @@
       <div class="small">
         <strong id="repository-url-proto">HTTP</strong> <span class="mute">clone URL</span>
       </div>
-      @helper.html.copy("repository-url-copy", repository.httpUrl){
-        <input type="text" value="@repository.httpUrl" id="repository-url" class="form-control input-sm" readonly>
+      @helper.html.copy("repository-url-copy", repository.urls(repoBase).httpUrl){
+        <input type="text" value="@repository.urls(repoBase).httpUrl" id="repository-url" class="form-control input-sm" readonly>
       }
       @if(settings.ssh && loginAccount.isDefined){
         <div class="small">
@@ -91,7 +91,7 @@
       @id.map { id =>
         @if(context.platform != "linux" && context.platform != null){
         <div style="margin-top: 10px;">
-          <a href="@repository.httpOpenRepoUrl(context.platform)" id="repository-clone-url" class="btn btn-sm btn-default btn-block"><i class="octicon octicon-desktop-download"></i>&nbsp;&nbsp;Clone in Desktop</a>
+          <a href="@repository.urls(repoBase).httpOpenRepoUrl(context.platform)" id="repository-clone-url" class="btn btn-sm btn-default btn-block"><i class="octicon octicon-desktop-download"></i>&nbsp;&nbsp;Clone in Desktop</a>
         </div>
         }
         <div style="margin-top: 10px;">
@@ -184,15 +184,15 @@ $(function(){
   @if(settings.ssh && loginAccount.isDefined){
     $('#repository-url-http').click(function(){
       $('#repository-url-proto').text('HTTP');
-      $('#repository-url').val('@repository.httpUrl');
-      $('#repository-clone-url').attr('href', '@repository.httpOpenRepoUrl(context.platform)')
+      $('#repository-url').val('@repository.urls(repoBase).httpUrl');
+      $('#repository-clone-url').attr('href', '@repository.urls(repoBase).httpOpenRepoUrl(context.platform)')
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
 
     $('#repository-url-ssh').click(function(){
       $('#repository-url-proto').text('SSH');
-      $('#repository-url').val('@repository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)');
-      $('#repository-clone-url').attr('href', '@repository.sshOpenRepoUrl(context.platform, settings.sshPortOrDefault, loginAccount.get.userName)');
+      $('#repository-url').val('@repository.urls(repoBase).sshUrl(loginAccount.get.userName)');
+      $('#repository-clone-url').attr('href', '@repository.urls(repoBase).sshOpenRepoUrl(context.platform, loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
   }

--- a/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
@@ -100,21 +100,21 @@
                 you can perform a manual merge on the command line.
               </p>
             }
-            @helper.html.copy("repository-url-copy", forkedRepository.httpUrl, true){
+            @helper.html.copy("repository-url-copy", forkedRepository.urls(repoBase).httpUrl, true){
               <div class="btn-group" data-toggle="buttons-radio">
                 <button class="btn btn-small active" type="button" id="repository-url-http">HTTP</button>
                 @if(settings.ssh && loginAccount.isDefined){
                   <button class="btn btn-small" type="button" id="repository-url-ssh" style="border-radius: 0px;">SSH</button>
                 }
               </div>
-              <input type="text" style="width: 500px;" value="@forkedRepository.httpUrl" id="repository-url" readonly />
+              <input type="text" style="width: 500px;" value="@forkedRepository.urls(repoBase).httpUrl" id="repository-url" readonly />
             }
             <div>
               <p>
                 <span class="strong">Step 1:</span> From your project repository, check out a new branch and test the changes.
               </p>
               @defining(s"git checkout -b ${pullreq.requestUserName}-${pullreq.requestBranch} ${pullreq.branch}\n" +
-                        s"git pull ${forkedRepository.httpUrl} ${pullreq.requestBranch}"){ command =>
+                        s"git pull ${forkedRepository.urls(repoBase).httpUrl} ${pullreq.requestBranch}"){ command =>
                 @helper.html.copy("merge-command-copy-1", command){
                   <pre style="width: 600px; float: left; font-size: 12px; border-radius: 3px 0px 3px 3px;" id="merge-command">@Html(command)</pre>
                 }
@@ -174,24 +174,24 @@ $(function(){
   @if(settings.ssh && loginAccount.isDefined){
     $('#repository-url-http').click(function(){
       // Update URL box
-      $('#repository-url').val('@forkedRepository.httpUrl');
+      $('#repository-url').val('@forkedRepository.urls(repoBase).httpUrl');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
       // Update command guidance
       $('#merge-command').text($('#merge-command').text().replace(
-        '@forkedRepository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)',
-        '@forkedRepository.httpUrl'
+        '@forkedRepository.urls(repoBase).sshUrl(loginAccount.get.userName)',
+        '@forkedRepository.urls(repoBase).httpUrl'
       ));
       $('#merge-command-copy-1').attr('data-clipboard-text', $('#merge-command').text());
     });
 
     $('#repository-url-ssh').click(function(){
       // Update URL box
-      $('#repository-url').val('@forkedRepository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)');
+      $('#repository-url').val('@forkedRepository.urls(repoBase).sshUrl(loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
       // Update command guidance
       $('#merge-command').text($('#merge-command').text().replace(
-        '@forkedRepository.httpUrl',
-        '@forkedRepository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)'
+        '@forkedRepository.urls(repoBase).httpUrl',
+        '@forkedRepository.urls(repoBase).sshUrl(loginAccount.get.userName)'
       ));
       $('#merge-command-copy-1').attr('data-clipboard-text', $('#merge-command').text());
     });

--- a/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
@@ -100,21 +100,21 @@
                 you can perform a manual merge on the command line.
               </p>
             }
-            @helper.html.copy("repository-url-copy", forkedRepository.urls(repoBase).httpUrl, true){
+            @helper.html.copy("repository-url-copy", context.urls(forkedRepository).httpUrl, true){
               <div class="btn-group" data-toggle="buttons-radio">
                 <button class="btn btn-small active" type="button" id="repository-url-http">HTTP</button>
                 @if(settings.ssh && loginAccount.isDefined){
                   <button class="btn btn-small" type="button" id="repository-url-ssh" style="border-radius: 0px;">SSH</button>
                 }
               </div>
-              <input type="text" style="width: 500px;" value="@forkedRepository.urls(repoBase).httpUrl" id="repository-url" readonly />
+              <input type="text" style="width: 500px;" value="@context.urls(forkedRepository).httpUrl" id="repository-url" readonly />
             }
             <div>
               <p>
                 <span class="strong">Step 1:</span> From your project repository, check out a new branch and test the changes.
               </p>
               @defining(s"git checkout -b ${pullreq.requestUserName}-${pullreq.requestBranch} ${pullreq.branch}\n" +
-                        s"git pull ${forkedRepository.urls(repoBase).httpUrl} ${pullreq.requestBranch}"){ command =>
+                        s"git pull ${context.urls(forkedRepository).httpUrl} ${pullreq.requestBranch}"){ command =>
                 @helper.html.copy("merge-command-copy-1", command){
                   <pre style="width: 600px; float: left; font-size: 12px; border-radius: 3px 0px 3px 3px;" id="merge-command">@Html(command)</pre>
                 }
@@ -174,24 +174,24 @@ $(function(){
   @if(settings.ssh && loginAccount.isDefined){
     $('#repository-url-http').click(function(){
       // Update URL box
-      $('#repository-url').val('@forkedRepository.urls(repoBase).httpUrl');
+      $('#repository-url').val('@context.urls(forkedRepository).httpUrl');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
       // Update command guidance
       $('#merge-command').text($('#merge-command').text().replace(
-        '@forkedRepository.urls(repoBase).sshUrl(loginAccount.get.userName)',
-        '@forkedRepository.urls(repoBase).httpUrl'
+        '@context.urls(forkedRepository).sshUrl(loginAccount.get.userName)',
+        '@context.urls(forkedRepository).httpUrl'
       ));
       $('#merge-command-copy-1').attr('data-clipboard-text', $('#merge-command').text());
     });
 
     $('#repository-url-ssh').click(function(){
       // Update URL box
-      $('#repository-url').val('@forkedRepository.urls(repoBase).sshUrl(loginAccount.get.userName)');
+      $('#repository-url').val('@context.urls(forkedRepository).sshUrl(loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
       // Update command guidance
       $('#merge-command').text($('#merge-command').text().replace(
-        '@forkedRepository.urls(repoBase).httpUrl',
-        '@forkedRepository.urls(repoBase).sshUrl(loginAccount.get.userName)'
+        '@context.urls(forkedRepository).httpUrl',
+        '@context.urls(forkedRepository).sshUrl(loginAccount.get.userName)'
       ));
       $('#merge-command-copy-1').attr('data-clipboard-text', $('#merge-command').text());
     });

--- a/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
@@ -178,7 +178,7 @@ $(function(){
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
       // Update command guidance
       $('#merge-command').text($('#merge-command').text().replace(
-        '@forkedRepository.sshUrl(settings.sshPort.getOrElse(SystemSettingsService.DefaultSshPort), loginAccount.get.userName)',
+        '@forkedRepository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)',
         '@forkedRepository.httpUrl'
       ));
       $('#merge-command-copy-1').attr('data-clipboard-text', $('#merge-command').text());
@@ -186,12 +186,12 @@ $(function(){
 
     $('#repository-url-ssh').click(function(){
       // Update URL box
-      $('#repository-url').val('@forkedRepository.sshUrl(settings.sshPort.getOrElse(SystemSettingsService.DefaultSshPort), loginAccount.get.userName)');
+      $('#repository-url').val('@forkedRepository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
       // Update command guidance
       $('#merge-command').text($('#merge-command').text().replace(
         '@forkedRepository.httpUrl',
-        '@forkedRepository.sshUrl(settings.sshPort.getOrElse(SystemSettingsService.DefaultSshPort), loginAccount.get.userName)'
+        '@forkedRepository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)'
       ));
       $('#merge-command-copy-1').attr('data-clipboard-text', $('#merge-command').text());
     });

--- a/src/main/twirl/gitbucket/core/repo/guide.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/guide.scala.html
@@ -10,10 +10,10 @@
     } else {
       <h3><strong>Quick setup</strong> — if you've done this kind of thing before</h3>
       <div class="empty-repo-options">
-        via <a href="@repository.httpUrl" class="git-protocol-selector">HTTP</a>
+        via <a href="@repository.urls(repoBase).httpUrl" class="git-protocol-selector">HTTP</a>
       @if(settings.ssh && loginAccount.isDefined){
          or
-         <a href="@repository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)" class="git-protocol-selector">SSH</a>
+         <a href="@repository.urls(repoBase).sshUrl(loginAccount.get.userName)" class="git-protocol-selector">SSH</a>
       }
       </div>
       <h3 style="margin-top: 30px;">Create a new repository on the command line</h3>
@@ -22,12 +22,12 @@
         git init
         git add README.md
         git commit -m "first commit"
-        git remote add origin <span class="live-clone-url">@repository.httpUrl</span>
+        git remote add origin <span class="live-clone-url">@repository.urls(repoBase).httpUrl</span>
         git push -u origin master
       }
       <h3 style="margin-top: 30px;">Push an existing repository from the command line</h3>
       @pre {
-        git remote add origin <span class="live-clone-url">@repository.httpUrl</span>
+        git remote add origin <span class="live-clone-url">@repository.urls(repoBase).httpUrl</span>
         git push -u origin master
       }
       <script>

--- a/src/main/twirl/gitbucket/core/repo/guide.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/guide.scala.html
@@ -13,7 +13,7 @@
         via <a href="@repository.httpUrl" class="git-protocol-selector">HTTP</a>
       @if(settings.ssh && loginAccount.isDefined){
          or
-         <a href="@repository.sshUrl(settings.sshPort.getOrElse(SystemSettingsService.DefaultSshPort), loginAccount.get.userName)" class="git-protocol-selector">SSH</a>
+         <a href="@repository.sshUrl(settings.sshPortOrDefault, loginAccount.get.userName)" class="git-protocol-selector">SSH</a>
       }
       </div>
       <h3 style="margin-top: 30px;">Create a new repository on the command line</h3>

--- a/src/main/twirl/gitbucket/core/repo/guide.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/guide.scala.html
@@ -10,10 +10,10 @@
     } else {
       <h3><strong>Quick setup</strong> — if you've done this kind of thing before</h3>
       <div class="empty-repo-options">
-        via <a href="@repository.urls(repoBase).httpUrl" class="git-protocol-selector">HTTP</a>
+        via <a href="@context.urls(repository).httpUrl" class="git-protocol-selector">HTTP</a>
       @if(settings.ssh && loginAccount.isDefined){
          or
-         <a href="@repository.urls(repoBase).sshUrl(loginAccount.get.userName)" class="git-protocol-selector">SSH</a>
+         <a href="@context.urls(repository).sshUrl(loginAccount.get.userName)" class="git-protocol-selector">SSH</a>
       }
       </div>
       <h3 style="margin-top: 30px;">Create a new repository on the command line</h3>
@@ -22,12 +22,12 @@
         git init
         git add README.md
         git commit -m "first commit"
-        git remote add origin <span class="live-clone-url">@repository.urls(repoBase).httpUrl</span>
+        git remote add origin <span class="live-clone-url">@context.urls(repository).httpUrl</span>
         git push -u origin master
       }
       <h3 style="margin-top: 30px;">Push an existing repository from the command line</h3>
       @pre {
-        git remote add origin <span class="live-clone-url">@repository.urls(repoBase).httpUrl</span>
+        git remote add origin <span class="live-clone-url">@context.urls(repository).httpUrl</span>
         git push -u origin master
       }
       <script>

--- a/src/main/twirl/gitbucket/core/wiki/page.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/page.scala.html
@@ -67,8 +67,8 @@
       <div class="small">
         <strong>Clone this wiki locally</strong>
       </div>
-      @helper.html.copy("repository-url-copy", urls(repoBase, repository).httpUrl){
-        <input type="text" value="@urls(repoBase, repository).httpUrl" id="repository-url" class="form-control input-sm" readonly>
+      @helper.html.copy("repository-url-copy", context.wikiUrls(repository).httpUrl){
+        <input type="text" value="@context.wikiUrls(repository).httpUrl" id="repository-url" class="form-control input-sm" readonly>
       }
       @if(settings.ssh && loginAccount.isDefined){
         <div class="small">
@@ -133,11 +133,11 @@ $(function(){
 
   @if(settings.ssh && loginAccount.isDefined){
     $('#repository-url-http').click(function(){
-      $('#repository-url').val('@urls(repoBase, repository).httpUrl');
+      $('#repository-url').val('@context.wikiUrls(repository).httpUrl');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
     $('#repository-url-ssh').click(function(){
-      $('#repository-url').val('@urls(repoBase, repository).sshUrl(loginAccount.get.userName)');
+      $('#repository-url').val('@context.wikiUrls(repository).sshUrl(loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
   }

--- a/src/main/twirl/gitbucket/core/wiki/page.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/page.scala.html
@@ -67,8 +67,8 @@
       <div class="small">
         <strong>Clone this wiki locally</strong>
       </div>
-      @helper.html.copy("repository-url-copy", httpUrl(repository)){
-        <input type="text" value="@httpUrl(repository)" id="repository-url" class="form-control input-sm" readonly>
+      @helper.html.copy("repository-url-copy", httpUrl(repoBase, repository)){
+        <input type="text" value="@httpUrl(repoBase, repository)" id="repository-url" class="form-control input-sm" readonly>
       }
       @if(settings.ssh && loginAccount.isDefined){
         <div class="small">
@@ -133,11 +133,11 @@ $(function(){
 
   @if(settings.ssh && loginAccount.isDefined){
     $('#repository-url-http').click(function(){
-      $('#repository-url').val('@httpUrl(repository)');
+      $('#repository-url').val('@httpUrl(repoBase, repository)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
     $('#repository-url-ssh').click(function(){
-      $('#repository-url').val('@sshUrl(repository, settings, loginAccount.get.userName)');
+      $('#repository-url').val('@sshUrl(repoBase, repository, loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
   }

--- a/src/main/twirl/gitbucket/core/wiki/page.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/page.scala.html
@@ -67,8 +67,8 @@
       <div class="small">
         <strong>Clone this wiki locally</strong>
       </div>
-      @helper.html.copy("repository-url-copy", httpUrl(repoBase, repository)){
-        <input type="text" value="@httpUrl(repoBase, repository)" id="repository-url" class="form-control input-sm" readonly>
+      @helper.html.copy("repository-url-copy", urls(repoBase, repository).httpUrl){
+        <input type="text" value="@urls(repoBase, repository).httpUrl" id="repository-url" class="form-control input-sm" readonly>
       }
       @if(settings.ssh && loginAccount.isDefined){
         <div class="small">
@@ -133,11 +133,11 @@ $(function(){
 
   @if(settings.ssh && loginAccount.isDefined){
     $('#repository-url-http').click(function(){
-      $('#repository-url').val('@httpUrl(repoBase, repository)');
+      $('#repository-url').val('@urls(repoBase, repository).httpUrl');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
     $('#repository-url-ssh').click(function(){
-      $('#repository-url').val('@sshUrl(repoBase, repository, loginAccount.get.userName)');
+      $('#repository-url').val('@urls(repoBase, repository).sshUrl(loginAccount.get.userName)');
       $('#repository-url-copy').attr('data-clipboard-text', $('#repository-url').val());
     });
   }

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -102,6 +102,7 @@ class AvatarImageProviderSpec extends Specification with Mockito {
       notification             = false,
       activityLogLimit         = None,
       ssh                      = false,
+      sshHost                  = None,
       sshPort                  = None,
       useSMTP                  = false,
       smtp                     = None,


### PR DESCRIPTION
this should solve #734

the first few commits are mostly (hopefully) easily reviewable cleanups:
a lot of code could be made independent of the baseUrl by moving the generation of http/ssh-urls out of RepositoryInfo

after that, it was easy to make the hostname used for ssh urls configurable, additionally the views no longer need to know about the ssh port themselves.

note you still need to have a baseUrl configured in the settings for ssh because commit hooks need it to generate http urls.

i'd be glad if this got merged asap as it form the base for an implementation of #971 i have almost ready.
