### PR TITLE
properly escape html metacharacters in repository description

### DIFF
--- a/src/test/scala/gitbucket/core/view/HelpersSpec.scala
+++ b/src/test/scala/gitbucket/core/view/HelpersSpec.scala
@@ -32,7 +32,28 @@ class HelpersSpec extends Specification {
       after mustEqual """Example Project. <a href="http://example.com">http://example.com</a>. (See also <a href="https://github.com/">https://github.com/</a>)"""
     }
 
+    "properly escape html metacharacters" in {
+      val before = "<>&"
+      val after = detectAndRenderLinks(before).toString()
+      after mustEqual """&lt;&gt;&amp;"""
+    }
+
+    "escape html metacharacters adjacent to a link" in {
+      val before = "<http://example.com>"
+      val after = detectAndRenderLinks(before).toString()
+      after mustEqual """&lt;<a href="http://example.com">http://example.com</a>&gt;"""
+    }
+
+    "stop link recognition at a metacharacter" in {
+      val before = "http://exa<mple.com"
+      val after = detectAndRenderLinks(before).toString()
+      after mustEqual """<a href="http://exa">http://exa</a>&lt;mple.com"""
+    }
+
+    "make sure there are no double quotes in the href attribute" in {
+      val before = "http://exa\"mple.com"
+      val after = detectAndRenderLinks(before).toString()
+      after mustEqual """<a href="http://exa&quot;mple.com">http://exa"mple.com</a>"""
+    }
   }
-
 }
-


### PR DESCRIPTION
try entering this description when you create a new project:
```javascript
<script>alert("hallo")</script>
```