### PR TITLE
Link avatar image to the user's profile page

### DIFF
--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -225,6 +225,13 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
   def avatarLink(userName: String, size: Int, mailAddress: String = "", tooltip: Boolean = false)(implicit context: Context): Html =
     userWithContent(userName, mailAddress)(avatar(userName, size, tooltip, mailAddress))
 
+  /**
+    * Generates the avatar link to the account page.
+    * If user does not exist or disabled, this method returns avatar image without link.
+    */
+  def avatarLink(commit: JGitUtil.CommitInfo, size: Int)(implicit context: Context): Html =
+    userWithContent(commit.authorName, commit.authorEmailAddress)(avatar(commit, size))
+
   private def userWithContent(userName: String, mailAddress: String = "", styleClass: String = "")(content: Html)(implicit context: Context): Html =
     (if(mailAddress.isEmpty){
       getAccountByUserName(userName)

--- a/src/main/twirl/gitbucket/core/account/main.scala.html
+++ b/src/main/twirl/gitbucket/core/account/main.scala.html
@@ -22,7 +22,7 @@
             <div>
               <div>Groups</div>
               @groupNames.map { groupName =>
-                <a href="@url(groupName)">@avatar(groupName, 36, tooltip = true)</a>
+                @avatarLink(groupName, 36, tooltip = true)
               }
             </div>
           }

--- a/src/main/twirl/gitbucket/core/helper/commitcomment.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/commitcomment.scala.html
@@ -10,7 +10,7 @@
     @if(comment.fileName.isDefined){filename="@comment.fileName.get"}
     @if(comment.newLine.isDefined){newline="@comment.newLine.get"}
     @if(comment.oldLine.isDefined){oldline="@comment.oldLine.get"}>
-  <div class="issue-avatar-image">@avatar(comment.commentedUserName, 48)</div>
+  <div class="issue-avatar-image">@avatarLink(comment.commentedUserName, 48)</div>
   <div class="panel- panel-default commit-comment-box commit-comment-@comment.commentId">
     <div class="panel-heading">
       @user(comment.commentedUserName, styleClass="username strong")

--- a/src/main/twirl/gitbucket/core/issues/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentform.scala.html
@@ -7,7 +7,7 @@
 @if(loginAccount.isDefined){
   <hr/><br/>
   <form method="POST" validate="true">
-    <div class="issue-avatar-image">@avatar(loginAccount.get.userName, 48)</div>
+    <div class="issue-avatar-image">@avatarLink(loginAccount.get.userName, 48)</div>
     <div class="panel panel-default issue-comment-box">
       <div class="panel-body">
         @helper.html.preview(

--- a/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
@@ -7,7 +7,7 @@
 @import gitbucket.core.view.helpers._
 @import gitbucket.core.model.CommitComment
 @if(issue.isDefined){
-  <div class="issue-avatar-image">@avatar(issue.get.openedUserName, 48)</div>
+  <div class="issue-avatar-image">@avatarLink(issue.get.openedUserName, 48)</div>
   <div class="panel panel-default issue-comment-box">
     <div class="panel-heading">
       @user(issue.get.openedUserName, styleClass="username strong") <span class="muted">commented @helper.html.datetimeago(issue.get.registeredDate)</span>
@@ -36,7 +36,7 @@
   case comment: gitbucket.core.model.IssueComment => {
     @if(comment.action != "close" && comment.action != "reopen" && comment.action != "delete_branch"
       && comment.action != "commit" && comment.action != "refer"){
-      <div class="issue-avatar-image">@avatar(comment.commentedUserName, 48)</div>
+      <div class="issue-avatar-image">@avatarLink(comment.commentedUserName, 48)</div>
       <div class="panel panel-default issue-comment-box" id="comment-@comment.commentId">
         <div class="panel-heading">
           @user(comment.commentedUserName, styleClass="username strong")

--- a/src/main/twirl/gitbucket/core/issues/create.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/create.scala.html
@@ -10,7 +10,7 @@
     <form action="@url(repository)/issues/new" method="POST" validate="true" class="form-group">
       <div class="row">
         <div class="col-md-10">
-          <div class="issue-avatar-image">@avatar(loginAccount.get.userName, 48)</div>
+          <div class="issue-avatar-image">@avatarLink(loginAccount.get.userName, 48)</div>
           <div class="panel panel-default issue-box">
             <div class="panel-body">
               <span id="error-title" class="error"></span>

--- a/src/main/twirl/gitbucket/core/pulls/commits.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/commits.scala.html
@@ -17,7 +17,7 @@
             <li><a href="@url(repository)/tree/@commit.id" style="line-height: 16px;"><i class="octicon octicon-code link"></i></a></li>
           </ul>
           <div>
-            <div class="commit-avatar-image">@avatar(commit, 40)</div>
+            <div class="commit-avatar-image">@avatarLink(commit, 40)</div>
             <div>
               <a href="@url(repository)/commit/@commit.id" class="commit-message" style="font-weight: bold;">@link(commit.summary, repository)</a>
               @if(commit.description.isDefined){

--- a/src/main/twirl/gitbucket/core/pulls/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/compare.scala.html
@@ -55,7 +55,7 @@
         <form method="POST" action="@path/@originRepository.owner/@originRepository.name/pulls/new" validate="true">
           <div class="row">
             <div class="col-md-10">
-              <div class="issue-avatar-image">@avatar(loginAccount.get.userName, 48)</div>
+              <div class="issue-avatar-image">@avatarLink(loginAccount.get.userName, 48)</div>
               <div class="panel panel-default issue-box">
                 <div class="panel-body">
                   <span class="error" id="error-title"></span>

--- a/src/main/twirl/gitbucket/core/repo/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commentform.scala.html
@@ -11,7 +11,7 @@
   @if(!fileName.isDefined){<hr/><br/>}
   <form method="POST" validate="true" style="max-width: 874px;">
     @if(!fileName.isDefined){
-      <div class="issue-avatar-image">@avatar(loginAccount.get.userName, 48)</div>
+      <div class="issue-avatar-image">@avatarLink(loginAccount.get.userName, 48)</div>
     }
     <div class="panel panel-default issue-comment-box">
       <div class="panel-body">

--- a/src/main/twirl/gitbucket/core/repo/commits.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commits.scala.html
@@ -46,7 +46,7 @@
                 <li><a href="@url(repository)/tree/@commit.id" style="line-height: 16px;"><i class="octicon octicon-code link"></i></a></li>
               </ul>
               <div>
-                <div class="commit-avatar-image">@avatar(commit, 40)</div>
+                <div class="commit-avatar-image">@avatarLink(commit, 40)</div>
                 <div>
                   <a href="@url(repository)/commit/@commit.id" class="commit-message" style="font-weight: bold;">@link(commit.summary, repository)</a>
                   @if(commit.description.isDefined){

--- a/src/main/twirl/gitbucket/core/repo/delete.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/delete.scala.html
@@ -33,7 +33,7 @@
           </td>
         </tr>
       </table>
-      <div class="issue-avatar-image">@avatar(loginAccount.get.userName, 48)</div>
+      <div class="issue-avatar-image">@avatarLink(loginAccount.get.userName, 48)</div>
         <div class="box issue-comment-box">
         <div class="box-content">
           <div>

--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -47,7 +47,7 @@
           </td>
         </tr>
       </table>
-      <div class="issue-avatar-image">@avatar(loginAccount.get.userName, 48)</div>
+      <div class="issue-avatar-image">@avatarLink(loginAccount.get.userName, 48)</div>
       <div class="panel panel-default issue-comment-box">
         <div class="panel-body">
           <div>


### PR DESCRIPTION
I added link tag to avatar images so that users can jump to the profile page easily.

In this PR, avatar images which size is 48x48 or 40x40 are modified. Small avatar images (16x16) are not always clickable even on GitHub, so I thought them out of scope for now.