### PR TITLE
Fix invisible closed label

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1099,6 +1099,10 @@ a.issue-title {
   background-color: #6cc644;
 }
 
+.label-important {
+  background-color: #bd2c00;
+}
+
 ul.label-list {
   list-style-type: none;
   padding-left: 0px;


### PR DESCRIPTION
Closed label has label-important attribute which
was not defined in gitbucket.css, so that define
the attribute.