### PR TITLE
Fix some hidden pull requests

### DIFF
--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -399,7 +399,7 @@ trait IssuesService {
 object IssuesService {
   import javax.servlet.http.HttpServletRequest
 
-  val IssueLimit = 30
+  val IssueLimit = 25
 
   case class IssueSearchCondition(
       labels: Set[String] = Set.empty,


### PR DESCRIPTION
IssuesService.IssueLimit value is equalized with
PullRequestService.PullRequestLimit value by this commit.

If without this, some pull requests are hidden.
For example, inspite of 30 pull requests are exists, pull request page shows 25.