### PR TITLE
Fix bug that label duplicate check is wrong

### DIFF
--- a/src/main/scala/gitbucket/core/model/BasicTemplate.scala
+++ b/src/main/scala/gitbucket/core/model/BasicTemplate.scala
@@ -35,7 +35,7 @@ protected[model] trait TemplateComponent { self: Profile =>
       byRepository(userName, repositoryName) && (this.labelId === labelId)
 
     def byLabel(owner: String, repository: String, labelName: String) =
-      byRepository(userName, repositoryName) && (this.labelName === labelName.bind)
+      byRepository(owner, repository) && (this.labelName === labelName.bind)
   }
 
   trait MilestoneTemplate extends BasicTemplate { self: Table[_] =>


### PR DESCRIPTION
Updating label name could cause `Name has already been taken.` error even if the name is unique because the check query tests wrong repository.

For example, when both A and B project have label named `bug`, change B project's label `bug` -> `bug2` -> `bug` could cause duplicate error.