### PR TITLE
Adjust img width in content box to max-width:100%

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -341,6 +341,10 @@ div.box-content-bottom {
   margin-bottom: 20px;
 }
 
+div.box-content-bottom img {
+  max-width: 100%;
+}
+
 table.table th.box-header {
   background-color: #f5f5f5;
 }


### PR DESCRIPTION
When viewing large images in commits, that protrudes from its container.
I adjusted it.

**Before**
![before](https://cloud.githubusercontent.com/assets/234142/13250168/b8759e24-da6b-11e5-94eb-02497d86dea8.png)

**After**
![after](https://cloud.githubusercontent.com/assets/234142/13250174/c0fff148-da6b-11e5-8653-ec6f84015791.png)

