### PR TITLE
add a chance to override default log level from command line

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,23 +6,7 @@
     </encoder>
   </appender>
 
-  <!--
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>gitbucket.log</file>
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
-  </appender>
-  -->
-
-  <root level="INFO">
+  <root level="${logLevel:-INFO}">
     <appender-ref ref="STDOUT" />
   </root>
-
-  <!--
-  <logger name="service.WebHookService" level="DEBUG" />
-  <logger name="servlet" level="DEBUG" />
-  <logger name="scala.slick.jdbc.JdbcBackend.statement" level="DEBUG" />
-  -->
-
 </configuration>


### PR DESCRIPTION
First step to better document how to log with gitbucket.

This PR allows for controlling externally the default log level of gitbucket for example by using `java -DlogLevel=DEBUG -jar gitbucket.war`

Also it relates to #1109 it does not fully answer it.
We'll need to document in a better way (with it's own wiki entry probably) how log can be configured for gitbucket.