### PR TITLE
correct path to CONTRIBUTING file, fixes #1128

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Before submitting an issue to Gitbucket I have first:
 
-- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/CONTRIBUTING.md)
+- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
 - [] searched for similar already existing issue
 - [] read the documentation and [wiki](https://github.com/gitbucket/gitbucket/wiki) 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Before submitting a pull-request to Gitbucket I have first:
 
-- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/CONTRIBUTING.md)
+- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
 - [] rebased my branch over master
 - [] verified that project is compiling
 - [] verified that tests are passing


### PR DESCRIPTION
while moving to `.github` directory to centralize files, path was not changed.

I didn't found any standard URL that could redirect to CONTRIBUTING file wherever it is placed, so I changed manually the URL