### PR TITLE
Correct the relative links in the wiki pages (fixes #1021)

### DIFF
--- a/src/main/scala/gitbucket/core/view/Markdown.scala
+++ b/src/main/scala/gitbucket/core/view/Markdown.scala
@@ -164,7 +164,7 @@ object Markdown {
           repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/blob/" + branch + "/" + url + (if(isImage) "?raw=true" else "")
         }
       } else {
-        repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/_blob/" + url
+        repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/" + url
       }
     }
 
@@ -187,4 +187,3 @@ object Markdown {
   }
 
 }
-


### PR DESCRIPTION
Hi,

This request also fixes #1021 
Currently, if we want to use a relative link in the wiki, we must start with the `..` because, automatically insert `_blob` to the relative links in the wiki pages.
This is a non-intuitive way.

`_blob` seems to me that is not used anywhere.
If there are any features that I overlooked, please point them out.



### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
