### PR TITLE
Fix special character encoding for blob links

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -160,7 +160,7 @@
               </a>
             }
           } else {
-            <a href="@url(repository)/blob@{(encodeRefName(branch) :: pathList).mkString("/", "/", "/")}@file.name">@file.name</a>
+            <a href="@url(repository)/blob@{(branch :: pathList).map(encodeRefName).mkString("/", "/", "/")}@{encodeRefName(file.name)}">@file.name</a>
           }
         </td>
         <td class="mute">


### PR DESCRIPTION
This adds URL encoding to the 'blob' links in the repository viewer. This was done for the 'tree' links in 15e8527e01d2cea92c5f1121c1c23143a267a16c.

Solves a similar problem to #984 and #1043 but when viewing the file itself rather than the directory.