### PR TITLE
Add pull_request key in list issues api if an issue is a pull request

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiIssue.scala
+++ b/src/main/scala/gitbucket/core/api/ApiIssue.scala
@@ -20,6 +20,16 @@ case class ApiIssue(
   body: String)(repositoryName: RepositoryName, isPullRequest: Boolean){
   val comments_url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/issues/${number}/comments")
   val html_url = ApiPath(s"/${repositoryName.fullName}/${if(isPullRequest){ "pull" }else{ "issues" }}/${number}")
+  val pull_request = if (isPullRequest) {
+    Some(Map(
+      "url" -> ApiPath(s"/api/v3/repos/${repositoryName.fullName}/pulls/${number}"),
+      "html_url" -> ApiPath(s"/${repositoryName.fullName}/pull/${number}")
+      // "diff_url" -> ApiPath(s"/${repositoryName.fullName}/pull/${number}.diff"),
+      // "patch_url" -> ApiPath(s"/${repositoryName.fullName}/pull/${number}.patch")
+    ))
+  } else {
+    None
+  }
 }
 
 object ApiIssue{

--- a/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
+++ b/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
@@ -252,6 +252,12 @@ class JsonFormatSpec extends FunSuite {
     "user": $apiUserJson,
     "comments_url": "${context.baseUrl}/api/v3/repos/octocat/Hello-World/issues/1347/comments",
     "html_url": "${context.baseUrl}/octocat/Hello-World/pull/1347",
+    "pull_request": {
+      "url": "${context.baseUrl}/api/v3/repos/octocat/Hello-World/pulls/1347",
+      "html_url": "${context.baseUrl}/octocat/Hello-World/pull/1347"
+      // "diff_url": "${context.baseUrl}/octocat/Hello-World/pull/1347.diff",
+      // "patch_url": "${context.baseUrl}/octocat/Hello-World/pull/1347.patch"
+    },
     "created_at": "2011-04-14T16:00:49Z",
     "updated_at": "2011-04-14T16:00:49Z"
   }"""


### PR DESCRIPTION
Now, GitHub pull request builder plugin for Jenkins ignores trigger phrase like `test this please` written in GitBucket pull request comment. This is because issues webhook payload for GitBucket doesn't contain `pull_request` key when a pull request comment is written.

See also: https://github.com/jenkinsci/ghprb-plugin/pull/258

This PR sets `pull_request` key in issues webhook payload to trigger build by pull request comment only if an issue is pull request like [GitHub](https://developer.github.com/v3/issues/#list-issues).

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
