### PR TITLE
Replace embedded variables in commit message Update Branch button generates

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -178,7 +178,7 @@ trait PullRequestsControllerBase extends ControllerBase {
           }
           val existIds = using(Git.open(Directory.getRepositoryDir(owner, name))) { git => JGitUtil.getAllCommitIds(git) }.toSet
           pullRemote(owner, name, pullreq.requestBranch, pullreq.userName, pullreq.repositoryName, pullreq.branch, loginAccount,
-                     "Merge branch '${alias}' into ${pullreq.requestBranch}") match {
+                     s"Merge branch '${alias}' into ${pullreq.requestBranch}") match {
             case None => // conflict
               flash += "error" -> s"Can't automatic merging branch '${alias}' into ${pullreq.requestBranch}."
             case Some(oldId) =>


### PR DESCRIPTION
When click `Update Branch` button in a pull request page, commit message where variables are embedded is generated like `Merge branch '${alias}' into ${pullreq.requestBranch} `.

This PR replaces the embedded variables with their values by string interpolation.