### PR TITLE
Fix layouts for Issue pages.

### DIFF
--- a/src/main/twirl/gitbucket/core/issues/create.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/create.scala.html
@@ -8,7 +8,7 @@
 @html.main(s"New Issue - ${repository.owner}/${repository.name}", Some(repository)){
   @html.menu("issues", repository){
     <form action="@url(repository)/issues/new" method="POST" validate="true" class="form-group">
-      <div class="row">
+      <div class="row-fluid">
         <div class="col-md-9">
           <span id="error-title" class="error"></span>
           <input type="text" id="issue-title" name="title" class="form-control" value="" placeholder="Title" style="margin-bottom: 6px;" autofocus/>

--- a/src/main/twirl/gitbucket/core/issues/issue.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/issue.scala.html
@@ -46,7 +46,7 @@
       </span>
     </div>
     <hr>
-    <div class="row" style="margin-top: 15px;">
+    <div class="row-fluid" style="margin-top: 15px;">
       <div class="col-md-9">
         @commentlist(Some(issue), comments, hasWritePermission, repository)
         @commentform(issue, true, hasWritePermission, repository)


### PR DESCRIPTION
In this PR, I'm fixing a layout problem in issues pages.

It looks that we have to use "row-fluid" class instead of "row" class, because we do not use fixed-size layout from 3.13.
FYI:
(English) http://stackoverflow.com/questions/25682804/row-fluid-vs-row-in-twitter-bootstrap
(Japanese) http://greenapple-room.com/conc/user/TwitterBootstrap/bootstrap_02.html

Could you take a look?

## Before
![before](https://cloud.githubusercontent.com/assets/391964/14198602/112fc0f8-f817-11e5-833c-3a23592c7e6a.png)
Labels/Milestone, ... are in bottom of comments.

## After
![after](https://cloud.githubusercontent.com/assets/391964/14198607/1f5a4efa-f817-11e5-8b00-d1b2dc8c9ddd.png)
Labels/Milestone, ... are in right of comments.

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*

