### PR TITLE
correct empty security token usage, fixes #1168

### DIFF
--- a/src/main/scala/gitbucket/core/service/WebHookService.scala
+++ b/src/main/scala/gitbucket/core/service/WebHookService.scala
@@ -109,10 +109,10 @@ trait WebHookService {
             def postContent = new UrlEncodedFormEntity(params, "UTF-8")
             httpPost.setEntity(postContent)
 
-            if (!webHook.token.isEmpty) {
+            if (webHook.token.exists(_.trim.nonEmpty)) {
               // TODO find a better way and see how to extract content from postContent
               val contentAsBytes = URLEncodedUtils.format(params, "UTF-8").getBytes("UTF-8")
-              httpPost.addHeader("X-Hub-Signature", XHub.generateHeaderXHubToken(XHubConverter.HEXA_LOWERCASE, XHubDigest.SHA1, webHook.token.orNull, contentAsBytes))
+              httpPost.addHeader("X-Hub-Signature", XHub.generateHeaderXHubToken(XHubConverter.HEXA_LOWERCASE, XHubDigest.SHA1, webHook.token.get, contentAsBytes))
             }
 
             val res = httpClient.execute(httpPost)

--- a/src/main/twirl/gitbucket/core/settings/edithooks.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/edithooks.scala.html
@@ -136,9 +136,13 @@ $(function(){
     $("#test-modal-url").text(url)
     $("#test-report-modal").modal('show')
     $("#test-report").hide();
+    var targetUrl = '@url(repository)/settings/hooks/test?url=' + encodeURIComponent(url) + '&token=';
+    if (token) {
+      targetUrl = targetUrl + encodeURIComponent(token);
+    }
     $.ajax({
       method:'POST',
-      url:'@url(repository)/settings/hooks/test?url=' + encodeURIComponent(url) + '&token=' + encodeURIComponent(token),
+      url:targetUrl,
       success: function(e){
         //console.log(e);
         $('#test-report-tab a:first').tab('show');


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Was missing a good handling for empty strings for the security token.
Successfully tested with an uptodate installation and http://requestb.in online service.
