### PR TITLE
typo: DAT(A)BASE_URL

### DIFF
--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -22,7 +22,7 @@
               <td>@GitBucketHome</td>
             </tr>
             <tr>
-              <td>DATBASE_URL</td>
+              <td>DATABASE_URL</td>
               <td>@gitbucket.core.util.DatabaseConfig.url</td>
             </tr>
           </table>


### PR DESCRIPTION
correct typo in system administration -> system settings -> property