### PR TITLE
Fix style for dropdown-menu that does not display the lower part.

### DIFF
--- a/src/main/twirl/gitbucket/core/settings/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/menu.scala.html
@@ -1,30 +1,32 @@
 @(active: String, repository: gitbucket.core.service.RepositoryService.RepositoryInfo)(body: Html)(implicit context: gitbucket.core.controller.Context)
 @import context._
 @import gitbucket.core.view.helpers._
-<ul class="nav nav-tabs" style="margin-bottom: 20px;">
-  <li@if(active=="options"){ class="active"}>
-    <a href="@url(repository)/settings/options">Options</a>
-  </li>
-  <li@if(active=="collaborators"){ class="active"}>
-    <a href="@url(repository)/settings/collaborators">Collaborators</a>
-  </li>
-  @if(!repository.branchList.isEmpty){
-  <li@if(active=="branches"){ class="active"}>
-    <a href="@url(repository)/settings/branches">Branches</a>
-  </li>
-  }
-  <li@if(active=="hooks"){ class="active"}>
-    <a href="@url(repository)/settings/hooks">Service Hooks</a>
-  </li>
-  <li@if(active=="danger"){ class="active"}>
-    <a href="@url(repository)/settings/danger">Danger Zone</a>
-  </li>
-  @gitbucket.core.plugin.PluginRegistry().getRepositorySettingTabs.map { tab =>
-    @tab(repository, context).map { link =>
-      <li@if(active==link.id){ class="active"}>
-        <a href="@url(repository)/@link.path">@link.label</a>
-      </li>
+<div class="tabbable">
+  <ul class="nav nav-tabs" style="margin-bottom: 20px;">
+    <li@if(active=="options"){ class="active"}>
+      <a href="@url(repository)/settings/options">Options</a>
+    </li>
+    <li@if(active=="collaborators"){ class="active"}>
+      <a href="@url(repository)/settings/collaborators">Collaborators</a>
+    </li>
+    @if(!repository.branchList.isEmpty){
+    <li@if(active=="branches"){ class="active"}>
+      <a href="@url(repository)/settings/branches">Branches</a>
+    </li>
     }
-  }
-</ul>
+    <li@if(active=="hooks"){ class="active"}>
+      <a href="@url(repository)/settings/hooks">Service Hooks</a>
+    </li>
+    <li@if(active=="danger"){ class="active"}>
+      <a href="@url(repository)/settings/danger">Danger Zone</a>
+    </li>
+    @gitbucket.core.plugin.PluginRegistry().getRepositorySettingTabs.map { tab =>
+      @tab(repository, context).map { link =>
+        <li@if(active==link.id){ class="active"}>
+          <a href="@url(repository)/@link.path">@link.label</a>
+        </li>
+      }
+    }
+  </ul>
+</div>
 @body

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -223,6 +223,10 @@ div.body {
   margin-bottom: 40px;
 }
 
+div.tabbable {
+  overflow: hidden;
+}
+
 span.error {
   color: red;
 }

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -201,7 +201,6 @@ div.main-sidebar {
 
 div.main-content {
   margin-left: 260px;
-  overflow: hidden;
 }
 
 div.main-center {


### PR DESCRIPTION
### Before

![screenshot-192 168 75 199 2016-05-09 17-40-08](https://cloud.githubusercontent.com/assets/4698834/15143911/17c5957a-16e7-11e6-8b26-5a811f784800.png)

### After

![screenshot-192 168 75 199 2016-05-10 18-39-36](https://cloud.githubusercontent.com/assets/4698834/15143920/1e1b42a8-16e7-11e6-94a6-bca577d74563.png)

### Before submitting a pull-request to Gitbucket I have first:

- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [] rebased my branch over master
- [] verified that project is compiling
- [] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

