### PR TITLE
Fix a missing ctype from test hook

### DIFF
--- a/src/main/twirl/gitbucket/core/settings/edithooks.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/edithooks.scala.html
@@ -146,7 +146,7 @@ $(function(){
     $("#test-modal-url").text(url)
     $("#test-report-modal").modal('show')
     $("#test-report").hide();
-    var targetUrl = '@url(repository)/settings/hooks/test?url=' + encodeURIComponent(url) + '&token=';
+    var targetUrl = '@url(repository)/settings/hooks/test?url=' + encodeURIComponent(url) + '&ctype=' + ctype + '&token=';
     if (token) {
       targetUrl = targetUrl + encodeURIComponent(token);
     }


### PR DESCRIPTION
Fix a missing ctype from Test Hook

Test Hook returns an error.
Because ctype is missing from the request.

```
java.util.NoSuchElementException: key not found: ctype
	at scala.collection.MapLike$class.default(MapLike.scala:228)
	at org.scalatra.ScalatraParams.default(ScalatraParams.scala:5)
	at scala.collection.MapLike$class.apply(MapLike.scala:141)
	at org.scalatra.ScalatraParams.apply(ScalatraParams.scala:5)
	at org.scalatra.ScalatraBase$class.params(ScalatraBase.scala:818)
	at gitbucket.core.controller.ControllerBase.params(ControllerBase.scala:27)
	at gitbucket.core.controller.RepositorySettingsControllerBase$class.gitbucket$core$controller$RepositorySettingsControllerBase$class$$$anonfun$39(RepositorySettingsController.scala:228)
	at gitbucket.core.util.ControlUtil$.using(ControlUtil.scala:24)
	at gitbucket.core.controller.RepositorySettingsControllerBase$class.gitbucket$core$controller$RepositorySettingsControllerBase$class$$$anonfun$37(RepositorySettingsController.scala:218)
	at gitbucket.core.util.OwnerAuthenticator$class.gitbucket$core$util$OwnerAuthenticator$class$$$anonfun$7(Authenticator.scala:41)
	at scala.Option.map(Option.scala:146)
	at gitbucket.core.util.OwnerAuthenticator$class.gitbucket$core$util$OwnerAuthenticator$class$$$anonfun$6(Authenticator.scala:39)
	at gitbucket.core.util.ControlUtil$.defining(ControlUtil.scala:12)
	at gitbucket.core.util.OwnerAuthenticator$class.authenticate(Authenticator.scala:38)
	at gitbucket.core.util.OwnerAuthenticator$class.ownerOnly(Authenticator.scala:33)
	at gitbucket.core.controller.RepositorySettingsController.ownerOnly(RepositorySettingsController.scala:21)
	at gitbucket.core.controller.RepositorySettingsControllerBase$class.gitbucket$core$controller$RepositorySettingsControllerBase$class$$$anonfun$36(RepositorySettingsController.scala:215)
	at gitbucket.core.controller.ControllerBase.gitbucket$core$controller$ControllerBase$$$anonfun$5(ControllerBase.scala:107)
<snip>
```
