### PR TITLE
Fix source display on mobile devices

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1950,6 +1950,11 @@ div.container.blame-container{
   div.input-group>span.fork {
     display: none;
   }
+  /* allow wrapping on raw/mobile/history buttons */ 
+  div.main-content>div.box-header>div.btn-group.pull-right 
+  { 
+    float: none !important; 
+  } 
 }
 
 /****************************************************************************/


### PR DESCRIPTION
The raw/mobile/history buttons used to incorrectly overflow on mobile devices, obscuring the entire (!) source view.