### PR TITLE
Add support for proxy setting

### DIFF
--- a/src/main/scala/gitbucket/core/service/WebHookService.scala
+++ b/src/main/scala/gitbucket/core/service/WebHookService.scala
@@ -97,7 +97,7 @@ trait WebHookService {
             }
           }
           try{
-            val httpClient = HttpClientBuilder.create.addInterceptorLast(itcp).build
+            val httpClient = HttpClientBuilder.create.useSystemProperties.addInterceptorLast(itcp).build
             logger.debug(s"start web hook invocation for ${webHook.url}")
             val httpPost = new HttpPost(webHook.url)
             logger.info(s"Content-Type: ${webHook.ctype.ctype}")


### PR DESCRIPTION
I would like to use GitBucket properly behind a proxy server.

```
export "JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=XXX.XXX.XXX -Dhttp.proxyPort=nnnn -Dhttps.proxyHost=XXX.XXX.XXX.XXX -Dhttps.proxyPort=nnn -Dhttp.nonProxyHosts=XXX.XXX.*"
```

When using the HTTPClient builder use the useSystemProperties() method to enable the standard JVM -D proxy parameters.