### PR TITLE
Default value of pull request title

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -354,7 +354,15 @@ trait PullRequestsControllerBase extends ControllerBase {
               originRepository.owner, originRepository.name, oldId.getName,
               forkedRepository.owner, forkedRepository.name, newId.getName)
 
+            val title = if(commits.flatten.length == 1){
+              commits.flatten.head.shortMessage
+            } else {
+              val text = forkedId.replaceAll("[\\-_]", " ")
+              text.substring(0, 1).toUpperCase + text.substring(1)
+            }
+
             html.compare(
+              title,
               commits,
               diffs,
               (forkedRepository.repository.originUserName, forkedRepository.repository.originRepositoryName) match {

--- a/src/main/twirl/gitbucket/core/pulls/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/compare.scala.html
@@ -1,4 +1,5 @@
-@(commits: Seq[Seq[gitbucket.core.util.JGitUtil.CommitInfo]],
+@(title: String,
+  commits: Seq[Seq[gitbucket.core.util.JGitUtil.CommitInfo]],
   diffs: Seq[gitbucket.core.util.JGitUtil.DiffInfo],
   members: List[(String, String)],
   comments: List[gitbucket.core.model.Comment],
@@ -56,7 +57,7 @@
           <div class="row">
             <div class="col-md-9">
               <span class="error" id="error-title"></span>
-              <input type="text" name="title" class="form-control" style="margin-bottom: 6px;" placeholder="Title"/>
+              <input type="text" name="title" value="@title" class="form-control" style="margin-bottom: 6px;" placeholder="Title"/>
               @helper.html.preview(
                 repository         = repository,
                 content            = "",


### PR DESCRIPTION
If the pull request has 1 commit then commit message is displayed as the default value of the pull request title. Otherwise, the default value of the pull request title is generated from the branch name.

![pull-request-title](https://cloud.githubusercontent.com/assets/1094760/15681782/aa41ad8a-2795-11e6-9a05-d98f48f18157.png)

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
