### PR TITLE
Bump patch version of Scalatra and some libs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 val Organization = "gitbucket"
 val Name = "gitbucket"
 val GitBucketVersion = "4.1.0"
-val ScalatraVersion = "2.4.0"
-val JettyVersion = "9.3.6.v20151106"
+val ScalatraVersion = "2.4.1"
+val JettyVersion = "9.3.9.v20160517"
 
 lazy val root = (project in file(".")).enablePlugins(SbtTwirl, JettyPlugin)
 
@@ -21,8 +21,8 @@ resolvers ++= Seq(
 )
 libraryDependencies ++= Seq(
   "org.scala-lang.modules"   %% "scala-java8-compat"           % "0.7.0",
-  "org.eclipse.jgit"          % "org.eclipse.jgit.http.server" % "4.1.1.201511131810-r",
-  "org.eclipse.jgit"          % "org.eclipse.jgit.archive"     % "4.1.1.201511131810-r",
+  "org.eclipse.jgit"          % "org.eclipse.jgit.http.server" % "4.1.2.201602141800-r",
+  "org.eclipse.jgit"          % "org.eclipse.jgit.archive"     % "4.1.2.201602141800-r",
   "org.scalatra"             %% "scalatra"                     % ScalatraVersion,
   "org.scalatra"             %% "scalatra-json"                % ScalatraVersion,
   "org.json4s"               %% "json4s-jackson"               % "3.3.0",
@@ -30,27 +30,27 @@ libraryDependencies ++= Seq(
   "commons-io"                % "commons-io"                   % "2.4",
   "io.github.gitbucket"       % "solidbase"                    % "1.0.0",
   "io.github.gitbucket"       % "markedj"                      % "1.0.9-SNAPSHOT",
-  "org.apache.commons"        % "commons-compress"             % "1.10",
+  "org.apache.commons"        % "commons-compress"             % "1.11",
   "org.apache.commons"        % "commons-email"                % "1.4",
   "org.apache.httpcomponents" % "httpclient"                   % "4.5.1",
   "org.apache.sshd"           % "apache-sshd"                  % "1.0.0",
-  "org.apache.tika"           % "tika-core"                    % "1.11",
+  "org.apache.tika"           % "tika-core"                    % "1.13",
   "com.typesafe.slick"       %% "slick"                        % "2.1.0",
   "com.novell.ldap"           % "jldap"                        % "2009-10-07",
-  "com.h2database"            % "h2"                           % "1.4.190",
-  "mysql"                     % "mysql-connector-java"         % "5.1.38",
+  "com.h2database"            % "h2"                           % "1.4.192",
+  "mysql"                     % "mysql-connector-java"         % "5.1.39",
   "org.postgresql"            % "postgresql"                   % "9.4.1208",
-  "ch.qos.logback"            % "logback-classic"              % "1.1.1",
-  "com.zaxxer"                % "HikariCP"                     % "2.4.5",
+  "ch.qos.logback"            % "logback-classic"              % "1.1.7",
+  "com.zaxxer"                % "HikariCP"                     % "2.4.6",
   "com.typesafe"              % "config"                       % "1.3.0",
-  "com.typesafe.akka"        %% "akka-actor"                   % "2.3.14",
+  "com.typesafe.akka"        %% "akka-actor"                   % "2.3.15",
   "fr.brouillard.oss.security.xhub" % "xhub4j-core"            % "1.0.0",
   "com.enragedginger"        %% "akka-quartz-scheduler"        % "1.4.0-akka-2.3.x" exclude("c3p0","c3p0"),
   "org.eclipse.jetty"         % "jetty-webapp"                 % JettyVersion     % "provided",
   "javax.servlet"             % "javax.servlet-api"            % "3.1.0"          % "provided",
   "junit"                     % "junit"                        % "4.12"           % "test",
   "org.scalatra"             %% "scalatra-scalatest"           % ScalatraVersion  % "test",
-  "org.scalaz"               %% "scalaz-core"                  % "7.2.0"          % "test",
+  "org.scalaz"               %% "scalaz-core"                  % "7.2.4"          % "test",
   "com.wix"                   % "wix-embedded-mysql"           % "1.0.3"          % "test",
   "ru.yandex.qatools.embed"   % "postgresql-embedded"          % "1.14"           % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11


### PR DESCRIPTION
This pull request bumps patch version of the following libraries.

- Scalatra
- jgit
- logback
- commons-compress
- h2
- mysql-connector-java
- HikariCP
- tika-core
- akka-actor

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
