### PR TITLE
fix: can't show the user profile when joining any groups

### DIFF
--- a/src/main/twirl/gitbucket/core/account/main.scala.html
+++ b/src/main/twirl/gitbucket/core/account/main.scala.html
@@ -28,6 +28,7 @@
           @groupNames.map { groupName =>
             <li>@avatarLink(groupName, 20, tooltip = true, label = true)</li>
           }
+        </ul>
       }
     </div>
   </div>

--- a/src/main/twirl/gitbucket/core/account/main.scala.html
+++ b/src/main/twirl/gitbucket/core/account/main.scala.html
@@ -28,7 +28,6 @@
           @groupNames.map { groupName =>
             <li>@avatarLink(groupName, 20, tooltip = true, label = true)</li>
           }
-        </div>
       }
     </div>
   </div>


### PR DESCRIPTION
### Before

![before](https://cloud.githubusercontent.com/assets/1295639/16559964/6e078730-422b-11e6-8c99-d21c4081dfdb.png)

### After

![after](https://cloud.githubusercontent.com/assets/1295639/16559970/76cf010e-422b-11e6-8c77-e16b90de910a.png)

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

