### PR TITLE
Fix plugin versions in installed plugins page

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
@@ -203,7 +203,7 @@ object PluginRegistry {
           instance.addPlugin(PluginInfo(
             pluginId    = plugin.pluginId,
             pluginName  = plugin.pluginName,
-            version     = plugin.versions.head.getVersion,
+            version     = plugin.versions.last.getVersion,
             description = plugin.description,
             pluginClass = plugin
           ))


### PR DESCRIPTION
Solidbase migration requires ascending order of versions.
I fix this issue with a workaround because many existing plugins have descending order.
