### PR TITLE
Fix some layout CSS

### DIFF
--- a/src/main/twirl/gitbucket/core/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/menu.scala.html
@@ -58,7 +58,7 @@
     </div>
   </div>
   <div class="content-wrapper">
-    <div class="content body">
+    <div class="content body clearfix">
       <div class="headbar">
         <div class="container">
           @helper.html.information(info)

--- a/src/main/twirl/gitbucket/core/pulls/conversation.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/conversation.scala.html
@@ -20,7 +20,7 @@
   }.exists(_.action == "merge")){ merged =>
     @if(!issue.closed){
       <div class="check-conflict" style="display: none;">
-        <div class="box issue-comment-box" style="background-color: #fbeed5">
+        <div class="box issue-comment-box" style="background-color: #fbeed5; margin-left: 0;">
           <div class="box-content"class="issue-content" style="border: 1px solid #c09853; padding: 10px;">
             <img src="@assets/common/images/indicator.gif"/> Checking...
           </div>
@@ -29,7 +29,7 @@
     }
     @if(hasWritePermission && issue.closed && pullreq.userName == pullreq.requestUserName && merged &&
       pullreq.repositoryName == pullreq.requestRepositoryName && repository.branchList.contains(pullreq.requestBranch)){
-      <div class="box issue-comment-box" style="background-color: #d0eeff;">
+      <div class="box issue-comment-box" style="background-color: #d0eeff; margin-left: 0;">
         <div class="box-content"class="issue-content" style="border: 1px solid #87a8c9; padding: 10px;">
           <a href="@url(repository)/pull/@issue.issueId/delete/@encodeRefName(pullreq.requestBranch)" class="btn btn-info pull-right delete-branch" data-name="@pullreq.requestBranch">Delete branch</a>
           <div>

--- a/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
@@ -7,7 +7,7 @@
 @import context._
 @import gitbucket.core.view.helpers._
 @import model.CommitState
-<div class="box issue-comment-box" style="background-color: @if(status.hasProblem){ #fbeed5 }else{ #d8f5cd };">
+<div class="box issue-comment-box" style="background-color: @if(status.hasProblem){ #fbeed5 }else{ #d8f5cd }; margin-left: 0;">
   <div class="box-content issue-content" style="border: 1px solid @if(status.hasProblem){ #c09853 }else{ #95c97e };padding:0">
     <div id="merge-pull-request">
       @if(!status.statuses.isEmpty){


### PR DESCRIPTION
This PR fixes two issues in the Gitbucket's CSS.

* The first one fixes the CSS for some divs (comments) floating outside the content layout.

  Example:
![image](https://cloud.githubusercontent.com/assets/137572/16693773/3452f300-450d-11e6-9eb5-036b89acdd0d.png)

  After the fix:
![image](https://cloud.githubusercontent.com/assets/137572/16693831/7391ef12-450d-11e6-86c8-03bcabab8194.png)

* The second fixes the CSS of the check-conflict box.

  Example:
![image](https://cloud.githubusercontent.com/assets/137572/16693918/e435ca04-450d-11e6-9e37-762739af7790.png)

  After the fix:
![image](https://cloud.githubusercontent.com/assets/137572/16693935/f9817778-450d-11e6-8f56-a09756a6136b.png)
 