### PR TITLE
add some API. required by Jenkins GitHub Branch Source plugin

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiBranch.scala
+++ b/src/main/scala/gitbucket/core/api/ApiBranch.scala
@@ -14,3 +14,10 @@ case class ApiBranch(
    "self" -> ApiPath(s"/api/v3/repos/${repositoryName.fullName}/branches/${name}"),
    "html" -> ApiPath(s"/${repositoryName.fullName}/tree/${name}"))
 }
+
+case class ApiBranchCommit(sha: String)
+
+case class ApiBranchForList(
+  name: String,
+  commit: ApiBranchCommit
+)

--- a/src/main/scala/gitbucket/core/api/ApiContents.scala
+++ b/src/main/scala/gitbucket/core/api/ApiContents.scala
@@ -1,0 +1,11 @@
+package gitbucket.core.api
+
+import gitbucket.core.util.JGitUtil.FileInfo
+
+case class ApiContents(`type`: String, name: String)
+
+object ApiContents{
+  def apply(fileInfo: FileInfo): ApiContents =
+    if(fileInfo.isDirectory) ApiContents("dir", fileInfo.name)
+    else ApiContents("file", fileInfo.name)
+}

--- a/src/main/scala/gitbucket/core/api/ApiEndPoint.scala
+++ b/src/main/scala/gitbucket/core/api/ApiEndPoint.scala
@@ -1,0 +1,3 @@
+package gitbucket.core.api
+
+case class ApiEndPoint(rate_limit_url: ApiPath = ApiPath("/api/v3/rate_limit"))

--- a/src/main/scala/gitbucket/core/api/ApiRef.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRef.scala
@@ -1,0 +1,5 @@
+package gitbucket.core.api
+
+case class ApiObject(sha: String)
+
+case class ApiRef(ref: String, `object`: ApiObject)

--- a/src/main/scala/gitbucket/core/api/ApiUser.scala
+++ b/src/main/scala/gitbucket/core/api/ApiUser.scala
@@ -13,6 +13,7 @@ case class ApiUser(
   created_at: Date) {
   val url                 = ApiPath(s"/api/v3/users/${login}")
   val html_url            = ApiPath(s"/${login}")
+  val avatar_url          = ApiPath(s"/${login}/_avatar")
   // val followers_url       = ApiPath(s"/api/v3/users/${login}/followers")
   // val following_url       = ApiPath(s"/api/v3/users/${login}/following{/other_user}")
   // val gists_url           = ApiPath(s"/api/v3/users/${login}/gists{/gist_id}")

--- a/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
+++ b/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
@@ -37,7 +37,8 @@ class JsonFormatSpec extends FunSuite {
     "site_admin":false,
     "created_at":"2011-04-14T16:00:49Z",
     "url":"http://gitbucket.exmple.com/api/v3/users/octocat",
-    "html_url":"http://gitbucket.exmple.com/octocat"
+    "html_url":"http://gitbucket.exmple.com/octocat",
+    "avatar_url":"http://gitbucket.exmple.com/octocat/_avatar"
   }"""
 
   val repository = ApiRepository(


### PR DESCRIPTION
By this PR, GitBucket can get more API compatibility with GitHub.
These are enough APIs for Jenkins GitHub Branch Source plugin.

If this PR and other my PRs are merged, we can use Jenkins CI by only write the "Jenkinsfile". There is no need to configure Jenkins job GUI. Job configuration is required only once per user/organization.

My changes for using Jenkins plugin are divided to three PR.

1. add some APIs (this PR)
2. allow Basic Auth in API (#1247)
3. Jenkins plugin's change (create PR soon in Jenkins plugin's repository)
