### PR TITLE
fix: can't resolve the git repository path provided by the plugin

### DIFF
--- a/src/main/scala/gitbucket/core/util/Implicits.scala
+++ b/src/main/scala/gitbucket/core/util/Implicits.scala
@@ -73,7 +73,7 @@ object Implicits {
 
     def hasAttribute(name: String): Boolean = request.getAttribute(name) != null
 
-    def gitRepositoryPath: String = request.getRequestURI.replaceFirst("^/git/", "/")
+    def gitRepositoryPath: String = request.getRequestURI.replaceFirst("^" + request.getContextPath + "/git/", "/")
 
     def baseUrl:String = {
       val url = request.getRequestURL.toString

--- a/src/main/scala/gitbucket/core/util/Implicits.scala
+++ b/src/main/scala/gitbucket/core/util/Implicits.scala
@@ -4,6 +4,8 @@ import gitbucket.core.api.JsonFormat
 import gitbucket.core.controller.Context
 import gitbucket.core.servlet.Database
 
+import java.util.regex.Pattern.quote
+
 import javax.servlet.http.{HttpSession, HttpServletRequest}
 
 import scala.util.matching.Regex
@@ -73,7 +75,7 @@ object Implicits {
 
     def hasAttribute(name: String): Boolean = request.getAttribute(name) != null
 
-    def gitRepositoryPath: String = request.getRequestURI.replaceFirst("^" + request.getContextPath + "/git/", "/")
+    def gitRepositoryPath: String = request.getRequestURI.replaceFirst("^" + quote(request.getContextPath) + "/git/", "/")
 
     def baseUrl:String = {
       val url = request.getRequestURL.toString


### PR DESCRIPTION
If the contextPath is not equals to `/`, gitRepositoryPath contains
the contextPath + `/git`.  Therefore, gitbucket can not resolve
the git repository path provided by the plugin.

For example, you can not clone the snippets repository of gist-plugin.

To fix this, also deletes contextPath from requestURI.