### PR TITLE
Sshd update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons"        % "commons-compress"             % "1.11",
   "org.apache.commons"        % "commons-email"                % "1.4",
   "org.apache.httpcomponents" % "httpclient"                   % "4.5.1",
-  "org.apache.sshd"           % "apache-sshd"                  % "1.0.0",
+  "org.apache.sshd"           % "apache-sshd"                  % "1.2.0",
   "org.apache.tika"           % "tika-core"                    % "1.13",
   "com.typesafe.slick"       %% "slick"                        % "2.1.0",
   "com.novell.ldap"           % "jldap"                        % "2009-10-07",

--- a/src/main/scala/gitbucket/core/ssh/GitCommand.scala
+++ b/src/main/scala/gitbucket/core/ssh/GitCommand.scala
@@ -13,7 +13,7 @@ import ControlUtil._
 import org.eclipse.jgit.api.Git
 import Directory._
 import org.eclipse.jgit.transport.{ReceivePack, UploadPack}
-import org.apache.sshd.server.command.UnknownCommand
+import org.apache.sshd.server.scp.UnknownCommand
 import org.eclipse.jgit.errors.RepositoryNotFoundException
 
 object GitCommand {

--- a/src/main/scala/gitbucket/core/ssh/PublicKeyAuthenticator.scala
+++ b/src/main/scala/gitbucket/core/ssh/PublicKeyAuthenticator.scala
@@ -7,12 +7,12 @@ import gitbucket.core.service.SshKeyService
 import gitbucket.core.servlet.Database
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator
 import org.apache.sshd.server.session.ServerSession
-import org.apache.sshd.common.session.Session
+import org.apache.sshd.common.AttributeStore
 import org.slf4j.LoggerFactory
 
 object PublicKeyAuthenticator {
   // put in the ServerSession here to be read by GitCommand later
-  private val userNameSessionKey = new Session.AttributeKey[String]
+  private val userNameSessionKey = new AttributeStore.AttributeKey[String]
 
   def putUserName(serverSession:ServerSession, userName:String):Unit =
     serverSession.setAttribute(userNameSessionKey, userName)

--- a/src/test/scala/gitbucket/core/ssh/GitCommandSpec.scala
+++ b/src/test/scala/gitbucket/core/ssh/GitCommandSpec.scala
@@ -1,6 +1,6 @@
 package gitbucket.core.ssh
 
-import org.apache.sshd.server.command.UnknownCommand
+import org.apache.sshd.server.scp.UnknownCommand
 import org.scalatest.FunSpec
 
 class GitCommandFactorySpec extends FunSpec {


### PR DESCRIPTION
I had been getting errors connecting to Gitbucket ssh, from my ubuntu 14.04 box. I was seeing this error message:
```
debug1: ssh_rsa_verify: signature correct
debug2: kex_derive_keys
debug2: set_newkeys: mode 1
debug1: SSH2_MSG_NEWKEYS sent
debug1: expecting SSH2_MSG_NEWKEYS
debug2: set_newkeys: mode 0
debug1: SSH2_MSG_NEWKEYS received
debug1: SSH2_MSG_SERVICE_REQUEST sent
Corrupted MAC on input.
Disconnecting: Packet corrupt
```
After updating to latest apache-sshd, it works like a charm.


### Before submitting a pull-request to Gitbucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

