### PR TITLE
Fix AccountService#getGroupNames returns duplicated group name .

### DIFF
--- a/src/main/scala/gitbucket/core/service/AccountService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountService.scala
@@ -186,7 +186,7 @@ trait AccountService {
 
   def getGroupNames(userName: String)(implicit s: Session): List[String] = {
     List(userName) ++
-      Collaborators.filter(_.collaboratorName === userName.bind).sortBy(_.userName).map(_.userName).list
+      Collaborators.filter(_.collaboratorName === userName.bind).sortBy(_.userName).map(_.userName).list.distinct
   }
 
 }


### PR DESCRIPTION
Thank you for your great work. 

I found a little defect. When user group has several repositories, organization filter menu in issues list shows duplicated organization. I fixed it and hope you will merge it.

<img width="791" alt="2016-08-11 15 22 24" src="https://cloud.githubusercontent.com/assets/99401/17580312/b094c4b2-5fd8-11e6-9038-3aa0167c081a.png">
