### PR TITLE
fix get-contents API's format

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -109,14 +109,13 @@ trait ApiControllerBase extends ControllerBase {
    * https://developer.github.com/v3/repos/contents/#get-contents
    */
   get("/api/v3/repos/:owner/:repo/contents/*")(referrersOnly { repository =>
-    val (id, path) = repository.splitPath(multiParams("splat").head)
+    val path = multiParams("splat").head match {
+      case s if s.isEmpty => "."
+      case s => s
+    }
     val refStr = params.getOrElse("ref", repository.repository.defaultBranch)
     using(Git.open(getRepositoryDir(params("owner"), params("repo")))){ git =>
-      if (path.isEmpty) {
-        JsonFormat(getFileList(git, refStr, ".").map{f => ApiContents(f)})
-      } else {
-        JsonFormat(getFileList(git, refStr, path).map{f => ApiContents(f)})
-      }
+      JsonFormat(getFileList(git, refStr, path).map{f => ApiContents(f)})
     }
   })
 


### PR DESCRIPTION
Fix get-contents API to make it compatible with GitHub API specification.

In current implementation, [`splitPath`](https://github.com/gitbucket/gitbucket/blob/48b6a590bf8378134c182e3815493db36a123e43/src/main/scala/gitbucket/core/controller/ApiController.scala#L112) method is used.
[This method](https://github.com/gitbucket/gitbucket/blob/48b6a590bf8378134c182e3815493db36a123e43/src/main/scala/gitbucket/core/service/RepositoryService.scala#L424) expects that URL contains branch name or tag name, but this isn't compatible with GitHub API.
So, I fixed.


**Example**
To get information of `src` directory,

* Current
`GET /repos/:user/:repo/contents/master/src/`

* After this PR (and GitHub API)
`GET /repos/:user/:repo/contents/src/`