### PR TITLE
Fix host command line argument

### DIFF
--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -3,12 +3,14 @@ import org.eclipse.jetty.webapp.WebAppContext;
 
 import java.io.File;
 import java.net.URL;
+import java.net.InetSocketAddress;
 import java.security.ProtectionDomain;
 
 public class JettyLauncher {
     public static void main(String[] args) throws Exception {
         String host = null;
         int port = 8080;
+        InetSocketAddress address = null;
         String contextPath = "/";
         boolean forceHttps = false;
 
@@ -29,7 +31,13 @@ public class JettyLauncher {
             }
         }
 
-        Server server = new Server(port);
+        if(host != null) {
+            address = new InetSocketAddress(host, port);
+        } else {
+            address = new InetSocketAddress(port);
+        }
+
+        Server server = new Server(address);
 
 //        SelectChannelConnector connector = new SelectChannelConnector();
 //        if(host != null) {


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

I couldn't find any open issues on this.

Tested in 3 modes:
1. No port or host specified
java -jar target/executable/gitbucket.war
Started ServerConnector@2a331b46{HTTP/1.1,[http/1.1]}{**0.0.0.0:8080**}

2. Port specified
java -jar target/executable/gitbucket.war --port=8888
Started ServerConnector@2a331b46{HTTP/1.1,[http/1.1]}{**0.0.0.0:8888**}

3. Host and port specified
java -jar target/executable/gitbucket.war --host=localhost --port=8888
Started ServerConnector@2a331b46{HTTP/1.1,[http/1.1]}{**localhost:8888**}
