### PR TITLE
Add API to get a file content

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiContents.scala
+++ b/src/main/scala/gitbucket/core/api/ApiContents.scala
@@ -1,11 +1,18 @@
 package gitbucket.core.api
 
 import gitbucket.core.util.JGitUtil.FileInfo
+import org.apache.commons.codec.binary.Base64
 
-case class ApiContents(`type`: String, name: String)
+case class ApiContents(`type`: String, name: String, content: Option[String], encoding: Option[String])
 
 object ApiContents{
-  def apply(fileInfo: FileInfo): ApiContents =
-    if(fileInfo.isDirectory) ApiContents("dir", fileInfo.name)
-    else ApiContents("file", fileInfo.name)
+  def apply(fileInfo: FileInfo, content: Option[Array[Byte]]): ApiContents = {
+    if(fileInfo.isDirectory) {
+      ApiContents("dir", fileInfo.name, None, None)
+    } else {
+      content.map(arr =>
+        ApiContents("file", fileInfo.name, Some(Base64.encodeBase64String(arr)), Some("base64"))
+      ).getOrElse(ApiContents("file", fileInfo.name, None, None))
+    }
+  }
 }


### PR DESCRIPTION
Support [Get-Contents API](https://developer.github.com/v3/repos/contents/#get-contents) for a **file**.
**cf.** Get-Contents API for a **directory** is already supported by #1248

When a given path is a file, base64-encoded content will be returned.

### Example

**API call:**
```shell
$ curl http://localhost:8080/api/v3/repos/user1/gitbucket/contents/project/build.properties
```
**Reponse:**
```js
{
  "type":"file",
  "name":"build.properties",
  "content":"c2J0LnZlcnNpb249MC4xMy4xMgo=",
  "encoding":"base64"
}
```
