### PR TITLE
Improve GitHub compatibility for Jenkins

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -1,12 +1,12 @@
 
-import gitbucket.core.controller._
-import gitbucket.core.plugin.PluginRegistry
-import gitbucket.core.servlet.{ApiAuthenticationFilter, Database, GitAuthenticationFilter, TransactionFilter}
-import gitbucket.core.util.Directory
 import java.util.EnumSet
 import javax.servlet._
 
+import gitbucket.core.controller._
+import gitbucket.core.plugin.PluginRegistry
 import gitbucket.core.service.SystemSettingsService
+import gitbucket.core.servlet._
+import gitbucket.core.util.Directory
 import org.scalatra._
 
 
@@ -25,6 +25,9 @@ class ScalatraBootstrap extends LifeCycle with SystemSettingsService {
     context.getFilterRegistration("gitAuthenticationFilter").addMappingForUrlPatterns(EnumSet.allOf(classOf[DispatcherType]), true, "/git/*")
     context.addFilter("apiAuthenticationFilter", new ApiAuthenticationFilter)
     context.getFilterRegistration("apiAuthenticationFilter").addMappingForUrlPatterns(EnumSet.allOf(classOf[DispatcherType]), true, "/api/v3/*")
+    context.addFilter("ghCompatRepositoryAccessFilter", new GHCompatRepositoryAccessFilter)
+    context.getFilterRegistration("ghCompatRepositoryAccessFilter").addMappingForUrlPatterns(EnumSet.allOf(classOf[DispatcherType]), true, "/*")
+
     // Register controllers
     context.mount(new AnonymousAccessController, "/*")
 

--- a/src/main/scala/gitbucket/core/servlet/GHCompatRepositoryAccessFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/GHCompatRepositoryAccessFilter.scala
@@ -1,0 +1,36 @@
+package gitbucket.core.servlet
+
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import gitbucket.core.service.SystemSettingsService
+
+/**
+  * A controller to provide GitHub compatible URL for Git clients.
+  */
+class GHCompatRepositoryAccessFilter extends Filter with SystemSettingsService {
+
+  /**
+    * Pattern of GitHub compatible repository URL.
+    * <code>/:user/:repo.git/</code>
+    */
+  private val githubRepositoryPattern = """^/[^/]+/[^/]+\.git/.*""".r
+
+  override def init(filterConfig: FilterConfig) = {}
+
+  override def doFilter(req: ServletRequest, res: ServletResponse, chain: FilterChain) = {
+    implicit val request  = req.asInstanceOf[HttpServletRequest]
+    val response = res.asInstanceOf[HttpServletResponse]
+    val requestPath = request.getRequestURI.substring(request.getContextPath.length)
+    requestPath match {
+      case githubRepositoryPattern() =>
+        response.sendRedirect(baseUrl + "/git" + requestPath)
+
+      case _ =>
+        chain.doFilter(req, res)
+    }
+  }
+
+  override def destroy() = {}
+
+}


### PR DESCRIPTION
I am using [Jenkins Multibranch Pipeline](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Multibranch+Plugin) and found it does not work with GitBucket. It assumes Git client can access to a repository via GitHub compatible URL. Also it assumes Users API serves not only a user but also an organization (this is current behavior of GitHub API but not documented on [specification](https://developer.github.com/v3/users/)).

This pull request contains ~~2 commits~~ a commit to improve GitHub compatibility as follows.

1. Add redirection to allow Git client to access a repository by GitHub compatible URL, e.g. redirection from `/int128/gitbucket.git/` to `/git/int128/gitbucket.git/`.
2. ~~Change Users API serves also organization as GitHub API, e.g. `/api/v3/users/gitbucket` serves the organization `gitbucket`.~~ This is not needed on the latest Multibranch Pipeline.

I have tested these features on both my Mac and EC2 server terminated with ELB SSL.

Additionally, I am happy to contribute a Wiki page how to use Jenkins Multibranch Pipeline and GitBucket. For more details, please see [my blog post](http://int128.hatenablog.com/entry/2016/10/06/224444) (Japanese).

Thanks for the great work.