### PR TITLE
switch to commonmark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,12 @@ libraryDependencies ++= Seq(
   "commons-io"                % "commons-io"                   % "2.4",
   "io.github.gitbucket"       % "solidbase"                    % "1.0.0",
   "io.github.gitbucket"       % "markedj"                      % "1.0.9",
+
+  "com.atlassian.commonmark"  % "commonmark"                   % "0.7.1",
+  "com.atlassian.commonmark"  % "commonmark-ext-gfm-tables"    % "0.7.1",
+  "com.atlassian.commonmark"  % "commonmark-ext-autolink"      % "0.7.1",
+  "com.atlassian.commonmark"  % "commonmark-ext-heading-anchor" % "0.7.1",
+
   "org.apache.commons"        % "commons-compress"             % "1.11",
   "org.apache.commons"        % "commons-email"                % "1.4",
   "org.apache.httpcomponents" % "httpclient"                   % "4.5.1",


### PR DESCRIPTION
This PR is work in progress and is only submitted to show the attempt & progress on this subject & to allow discussions.

- [ ] introduce commonmark dependencies
- [ ] use commonmark for markdown rendering
- [ ] move RefLinks into a commonsmark-extension
- [ ] provide better handling/rendering for tasks, options:
  - use an AttributeProvider
  - extend an existing NodeRenderer
  - create an extensions
- [ ] ensure all mardown usage uses Markdown class
- [ ] remove markedj
- [ ] update existing tests, add additionals
- [ ] extend gitbucket to allow additional commonmark extensions
  - via Plugins mechanism
  - via configuration only and class availability in the classpath 

Do not hesitate to help on this topic if you are interested in the subject.