### PR TITLE
Suppress noisy transition animation on load in IE11

### DIFF
--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -39,7 +39,7 @@
     }
     <script src="@helpers.assets/vendors/AdminLTE-2.3.6/js/app.js" type="text/javascript"></script>
   </head>
-  <body class="skin-blue">
+  <body class="skin-blue page-load">
     <div class="wrapper">
       <header class="main-header">
         <a href="@context.path/" class="logo">

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1762,3 +1762,14 @@ div.container.blame-container{
   width: 20px;
   height: 20px;
 }
+
+/****************************************************************************/
+/* Suppress transition animation on load */
+/****************************************************************************/
+body.page-load * {
+    -webkit-transition: none !important;
+    -moz-transition: none !important;
+    -ms-transition: none !important;
+    -o-transition: none !important;
+    transition: none !important;
+}

--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -28,6 +28,9 @@ $(function(){
 
   // syntax highlighting by google-code-prettify
   prettyPrint();
+
+  // Suppress transition animation on load
+  $("body").removeClass("page-load");
 });
 
 function displayErrors(data, elem){


### PR DESCRIPTION
### Problem

In IE11, on loading pages. Sidebar and navigation bar are show animation very noisy.
![noizy-animation-ie](https://cloud.githubusercontent.com/assets/6997928/19415071/b12fbac2-939e-11e6-807a-20398a2850ba.gif)

### Solution

http://stackoverflow.com/a/25674229
