### PR TITLE
(refs #1318) make record***Activity via ssh works again

### DIFF
--- a/src/main/scala/gitbucket/core/ssh/GitCommand.scala
+++ b/src/main/scala/gitbucket/core/ssh/GitCommand.scala
@@ -36,7 +36,7 @@ abstract class GitCommand extends Command with SessionAware {
     override def run(): Unit = {
       authUser match {
         case Some(authUser) =>
-          Database() withSession { implicit session =>
+          Database() withTransaction { implicit session =>
             try {
               runTask(authUser)
               callback.onExit(0)


### PR DESCRIPTION
### Impacted version

4.5.0 and 4.6.0
### Problem

In commit 2ca20af, "auto commit" feature is disabled in TransactionFilter.scala. Because it prevents gitbucket from recognizing ssh push from the client, it affects several issues as below.
- Issue #1318 : Commits does not appear in front-page.
- Pull-request is not updated (It is reported [here](https://gitter.im/gitbucket/gitbucket_ja?at=58003f8c457ae29b71d9cdc2)).

I think it can affect any other phenomenons which gitbucket needs record***Activity.
Especially, pull-request is key feature of the gitbucket.
So, I think this is critical issue to be resolved as soon as possible. I hope 4.6.1 is released...
### Solution

My solution is very simple.
Because I'm not sure why it is set as false, I made "auto commit" feature configurable.
But I think it shall be set as true. So, I changed its default value true.

I confirmed all tests passed and the phenomenon diapered.
I hope it works well. Thank you! 
