### PR TITLE
Added per-repository issue template feature.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val Organization = "io.github.gitbucket"
 val Name = "gitbucket"
-val GitBucketVersion = "4.6.0"
+val GitBucketVersion = "4.7.0"
 val ScalatraVersion = "2.4.1"
 val JettyVersion = "9.3.9.v20160517"
 

--- a/src/main/resources/update/gitbucket-core_4.7.xml
+++ b/src/main/resources/update/gitbucket-core_4.7.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeSet>
+    <addColumn tableName="REPOSITORY">
+        <column name="ISSUE_TEMPLATE" type="text" nullable="false" defaultValueText=""/>
+    </addColumn>
+</changeSet>

--- a/src/main/resources/update/gitbucket-core_4.7.xml
+++ b/src/main/resources/update/gitbucket-core_4.7.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <changeSet>
     <addColumn tableName="REPOSITORY">
-        <column name="ISSUE_TEMPLATE" type="text" nullable="false" defaultValueText=""/>
+        <column name="ISSUE_TEMPLATE" type="text" nullable="false" defaultValue=""/>
     </addColumn>
 </changeSet>

--- a/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
+++ b/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
@@ -18,5 +18,8 @@ object GitBucketCoreModule extends Module("gitbucket-core",
   new Version("4.5.0"),
   new Version("4.6.0",
     new LiquibaseMigration("update/gitbucket-core_4.6.xml")
+  ),
+  new Version("4.7.0",
+    new LiquibaseMigration("update/gitbucket-core_4.7.xml")
   )
 )

--- a/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
@@ -36,7 +36,8 @@ trait RepositorySettingsControllerBase extends ControllerBase {
     enableWiki: Boolean,
     allowWikiEditing: Boolean,
     externalWikiUrl: Option[String],
-    allowFork: Boolean
+    allowFork: Boolean,
+    issueTemplate: String
   )
   
   val optionsForm = mapping(
@@ -48,7 +49,8 @@ trait RepositorySettingsControllerBase extends ControllerBase {
     "enableWiki"        -> trim(label("Enable Wiki"        , boolean())),
     "allowWikiEditing"  -> trim(label("Allow Wiki Editing" , boolean())),
     "externalWikiUrl"   -> trim(label("External Wiki URL"  , optional(text(maxlength(200))))),
-    "allowFork"         -> trim(label("Allow Forking"      , boolean()))
+    "allowFork"         -> trim(label("Allow Forking"      , boolean())),
+    "issueTemplate"     -> trim(label("Issue Template"     , text()))
   )(OptionsForm.apply)
 
   // for default branch
@@ -114,7 +116,8 @@ trait RepositorySettingsControllerBase extends ControllerBase {
       form.enableWiki,
       form.allowWikiEditing,
       form.externalWikiUrl,
-      form.allowFork
+      form.allowFork,
+      form.issueTemplate
     )
     // Change repository name
     if(repository.name != form.repositoryName){

--- a/src/main/scala/gitbucket/core/model/Repository.scala
+++ b/src/main/scala/gitbucket/core/model/Repository.scala
@@ -23,11 +23,12 @@ trait RepositoryComponent extends TemplateComponent { self: Profile =>
     val allowWikiEditing     = column[Boolean]("ALLOW_WIKI_EDITING")
     val externalWikiUrl      = column[String]("EXTERNAL_WIKI_URL")
     val allowFork            = column[Boolean]("ALLOW_FORK")
+    val issueTemplate        = column[String]("ISSUE_TEMPLATE")
 
     def * = (
       (userName, repositoryName, isPrivate, description.?, defaultBranch,
       registeredDate, updatedDate, lastActivityDate, originUserName.?, originRepositoryName.?, parentUserName.?, parentRepositoryName.?),
-      (enableIssues, externalIssuesUrl.?, enableWiki, allowWikiEditing, externalWikiUrl.?, allowFork)
+      (enableIssues, externalIssuesUrl.?, enableWiki, allowWikiEditing, externalWikiUrl.?, allowFork, issueTemplate)
     ).shaped <> (
       { case (repository, options) =>
         Repository(
@@ -90,5 +91,6 @@ case class RepositoryOptions(
   enableWiki: Boolean,
   allowWikiEditing: Boolean,
   externalWikiUrl: Option[String],
-  allowFork: Boolean
+  allowFork: Boolean,
+  issueTemplate: String
 )

--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -43,7 +43,8 @@ trait RepositoryService { self: AccountService =>
           enableWiki           = true,
           allowWikiEditing     = true,
           externalWikiUrl      = None,
-          allowFork            = true
+          allowFork            = true,
+          issueTemplate        = ""
         )
       )
 
@@ -325,10 +326,10 @@ trait RepositoryService { self: AccountService =>
       description: Option[String], isPrivate: Boolean,
       enableIssues: Boolean, externalIssuesUrl: Option[String],
       enableWiki: Boolean, allowWikiEditing: Boolean, externalWikiUrl: Option[String],
-      allowFork: Boolean)(implicit s: Session): Unit =
+      allowFork: Boolean, issueTemplate: String)(implicit s: Session): Unit =
     Repositories.filter(_.byRepository(userName, repositoryName))
-      .map { r => (r.description.?, r.isPrivate, r.enableIssues, r.externalIssuesUrl.?, r.enableWiki, r.allowWikiEditing, r.externalWikiUrl.?, r.allowFork, r.updatedDate) }
-      .update (description, isPrivate, enableIssues, externalIssuesUrl, enableWiki, allowWikiEditing, externalWikiUrl, allowFork, currentDate)
+      .map { r => (r.description.?, r.isPrivate, r.enableIssues, r.externalIssuesUrl.?, r.enableWiki, r.allowWikiEditing, r.externalWikiUrl.?, r.allowFork, r.issueTemplate, r.updatedDate) }
+      .update (description, isPrivate, enableIssues, externalIssuesUrl, enableWiki, allowWikiEditing, externalWikiUrl, allowFork, issueTemplate, currentDate)
 
   def saveRepositoryDefaultBranch(userName: String, repositoryName: String,
       defaultBranch: String)(implicit s: Session): Unit =

--- a/src/main/twirl/gitbucket/core/issues/create.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/create.scala.html
@@ -13,7 +13,7 @@
           <input type="text" id="issue-title" name="title" class="form-control" value="" placeholder="Title" style="margin-bottom: 6px;" autofocus/>
           @gitbucket.core.helper.html.preview(
             repository         = repository,
-            content            = "",
+            content            = repository.repository.options.issueTemplate,
             enableWikiLink     = false,
             enableRefsLink     = true,
             enableLineBreaks   = true,

--- a/src/main/twirl/gitbucket/core/settings/options.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/options.scala.html
@@ -52,6 +52,10 @@
                   Provides Lightweight issue tracking integrated with this repository. Add issues to milestones, label issues, and close & reference issues from commit messages.
                 </div>
               </label>
+              <label for="issueTemplate" class="strong">
+                Issue Template:
+              </label>
+              <textarea class="form-control" rows="10" id="issueTemplate" name="issueTemplate">@repository.repository.options.issueTemplate</textarea>
               <label for="externalIssuesUrl" class="strong">External URL:
                 <span class="normal muted">(Put if you have the external issue tracking system for this project)</span>
               </label>
@@ -103,6 +107,7 @@ $(function(){
 
 function updateFeatures() {
   $('#externalIssuesUrl').prop('disabled', $('#enableIssues').prop('checked'));
+  $('#issueTemplate').prop('disabled', !$('#enableIssues').prop('checked'));
   $('#allowWikiEditing').prop('disabled', !$('#enableWiki').prop('checked'));
   $('#externalWikiUrl').prop('disabled', $('#enableWiki').prop('checked'));
 }


### PR DESCRIPTION
This feature allows repository administrators to enter a default issue text on the repository options form. On new issue creation this default text is presented in the issue description textarea.