### PR TITLE
Prevent LinkConverter matching escaped apostrophe (fixes #1148)

### DIFF
--- a/src/main/scala/gitbucket/core/view/LinkConverter.scala
+++ b/src/main/scala/gitbucket/core/view/LinkConverter.scala
@@ -73,7 +73,7 @@ trait LinkConverter { self: RequestCache =>
       }
 
       // convert issue id to link
-      .replaceBy(("(?<=(^|\\W))(GH-|" + issueIdPrefix + ")([0-9]+)(?=(\\W|$))").r){ m =>
+      .replaceBy(("(?<=(^|\\W))(GH-|(?<!&)" + issueIdPrefix + ")([0-9]+)(?=(\\W|$))").r){ m =>
         val prefix = if(m.group(2) == "issue:") "#" else m.group(2)
         getIssue(repository.owner, repository.name, m.group(3)) match {
           case Some(issue) if(issue.isPullRequest) =>


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

I was able to reproduce the bug and fix by changing regex in LinkConverter. Confirmed that apostrophe not parsed as link and issue 39 is linkable (when applicable):
![gitbucket-apostrophe](https://cloud.githubusercontent.com/assets/8049605/20638872/40f3a5cc-b381-11e6-8a42-b800e9f8acdc.png)
