### PR TITLE
Fixed typo in 4.7: '... ans guests...' -> '... and guests...'

### DIFF
--- a/src/main/twirl/gitbucket/core/settings/options.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/options.scala.html
@@ -97,7 +97,7 @@
               </div>
               <div class="radio">
                 <label>
-                  <input type="radio" name="wikiOption" value="PUBLIC" @if(repository.repository.options.wikiOption == "PUBLIC"){ checked}> Developers ans guests can view, create and edit wiki pages
+                  <input type="radio" name="wikiOption" value="PUBLIC" @if(repository.repository.options.wikiOption == "PUBLIC"){ checked}> Developers and guests can view, create and edit wiki pages
                 </label>
               </div>
               <div class="radio for-public-repo">


### PR DESCRIPTION
Fixes a simple typo.