### PR TITLE
Fixed dropdown menu text color

### DIFF
--- a/src/main/webapp/assets/vendors/AdminLTE-2.3.8/css/skins/skin-blue.css
+++ b/src/main/webapp/assets/vendors/AdminLTE-2.3.8/css/skins/skin-blue.css
@@ -36,7 +36,7 @@
     background-color: rgba(255, 255, 255, 0.1);
   }
   .skin-blue .main-header .navbar .dropdown-menu li a {
-    color: #fff;
+    color: inherit;
   }
   .skin-blue .main-header .navbar .dropdown-menu li a:hover {
     background: #367fa9;


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Hi,
In small screens text color becomes #fff and cannot see profile, account settings or sign out fields. I just changed that property to inherit its value from its parent element.