### PR TITLE
(refs #1282) Fix text-ellipsis which does't work

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -143,7 +143,7 @@
           <i class="octicon octicon-file-text"></i>
         }
         </td>
-        <td class="content-name">
+        <td class="ellipsis-cell" style="width: 20%; min-width: 160px;">
           @if(file.isDirectory){
             @if(file.linkUrl.isDefined){
               <a href="@file.linkUrl">
@@ -164,10 +164,10 @@
             <a href="@helpers.url(repository)/blob@{(branch :: pathList).map(helpers.encodeRefName).mkString("/", "/", "/")}@{helpers.encodeRefName(file.name)}">@file.name</a>
           }
         </td>
-        <td class="mute">
-          <a href="@helpers.url(repository)/commit/@file.commitId" class="commit-message shorten-text" title="@file.message">@helpers.link(file.message, repository)</a>
+        <td class="ellipsis-cell" style="width: 70%;">
+          <a href="@helpers.url(repository)/commit/@file.commitId" class="commit-message" title="@file.message">@helpers.link(file.message, repository)</a>
         </td>
-        <td style="text-align: right;">@gitbucket.core.helper.html.datetimeago(file.time, false)</td>
+        <td style="width: 10%; min-width: 125px; text-align: right;">@gitbucket.core.helper.html.datetimeago(file.time, false)</td>
       </tr>
       }
     </table>

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -174,12 +174,6 @@ span.error {
   font-weight: normal;
 }
 
-.shorten-text {
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-}
-
 a.commit-message, a.commit-id, a.username, a.issue-comment-count {
   color: #333333;
 }
@@ -297,6 +291,20 @@ table.table th.box-header {
 
 th.box-header .octicon {
   display: inline;
+}
+
+td.ellipsis-cell {
+  position: relative;
+}
+
+td.ellipsis-cell > * {
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding-right: 5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 img.avatar {


### PR DESCRIPTION
- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

This PR fixes layout-break caused by too long commit message, referred in #1282.

Google Chrome 54.0
![2016-12-12 20 56 29](https://cloud.githubusercontent.com/assets/2328540/21099497/eafaa376-c0b1-11e6-9548-c80febe83bd6.png)

FireFox 49.0
![2016-12-12 20 57 01](https://cloud.githubusercontent.com/assets/2328540/21099517/ffd8f13a-c0b1-11e6-91f4-c7274865a316.png)

Safari 10.0
![2016-12-12 20 57 57](https://cloud.githubusercontent.com/assets/2328540/21099527/14295aee-c0b2-11e6-8fb2-3242083b40e5.png)
