### PR TITLE
Add API to get a single issue

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -278,6 +278,19 @@ trait ApiControllerBase extends ControllerBase {
   }
 
   /**
+   * https://developer.github.com/v3/issues/#get-a-single-issue
+   */
+  get("/api/v3/repos/:owner/:repository/issues/:id")(referrersOnly { repository =>
+    (for{
+      issueId  <- params("id").toIntOpt
+      issue <- getIssue(repository.owner, repository.name, issueId.toString)
+      openedUser <- getAccountByUserName(issue.openedUserName)
+    } yield {
+      JsonFormat(ApiIssue(issue, RepositoryName(repository), ApiUser(openedUser)))
+    }) getOrElse NotFound()
+  })
+
+  /**
    * https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
    */
   get("/api/v3/repos/:owner/:repository/issues/:id/comments")(referrersOnly { repository =>

--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -133,9 +133,12 @@ trait ApiControllerBase extends ControllerBase {
           val largeFile = params.get("large_file").exists(s => s.equals("true"))
           val content = getContentFromId(git, f.id, largeFile)
           request.getHeader("Accept") match {
-            case "application/vnd.github.v3.raw" =>
+            case "application/vnd.github.v3.raw" => {
+              contentType = "application/vnd.github.v3.raw"
               content
-            case "application/vnd.github.v3.html" if isRenderable(f.name) =>
+            }
+            case "application/vnd.github.v3.html" if isRenderable(f.name) => {
+              contentType = "application/vnd.github.v3.html"
               content.map(c =>
                 List(
                   "<div data-path=\"", path, "\" id=\"file\">", "<article>",
@@ -143,7 +146,9 @@ trait ApiControllerBase extends ControllerBase {
                   "</article>", "</div>"
                 ).mkString
               )
-            case "application/vnd.github.v3.html" =>
+            }
+            case "application/vnd.github.v3.html" => {
+              contentType = "application/vnd.github.v3.html"
               content.map(c =>
                 List(
                   "<div data-path=\"", path, "\" id=\"file\">", "<div class=\"plain\">", "<pre>",
@@ -151,6 +156,7 @@ trait ApiControllerBase extends ControllerBase {
                   "</pre>", "</div>", "</div>"
                 ).mkString
               )
+            }
             case _ =>
               Some(JsonFormat(ApiContents(f, content)))
           }


### PR DESCRIPTION
This PR adds the [API to get a sigle issue](https://developer.github.com/v3/issues/#get-a-single-issue).

**Usage**
```sh
$ curl http://localhost:8080/api/v3/repos/:owner/:repo/issues/:issue_number
```
---
The [second commit](https://github.com/gitbucket/gitbucket/commit/668f9ef91974424d31a76d0c1c96a41fc307c106) is a small fix of https://github.com/gitbucket/gitbucket/pull/1328.
This is independent from the first commit, but it's so small that I didn't divide into another PR.

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
