### PR TITLE
avoid deprecated method since sbt 0.13.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,9 +165,9 @@ executableKey := {
   log info s"built executable webapp ${outputFile}"
   outputFile
 }
-publishTo <<= version { (v: String) =>
+publishTo := {
   val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
+  if (version.value.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
   else                             Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
 publishMavenStyle := true


### PR DESCRIPTION
```
build.sbt:168: warning: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
publishTo <<= version { (v: String) =>
          ^
```