### PR TITLE
Add support for SMTP STARTTLS

### DIFF
--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -41,6 +41,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
         "user"                     -> trim(label("SMTP User", optional(text()))),
         "password"                 -> trim(label("SMTP Password", optional(text()))),
         "ssl"                      -> trim(label("Enable SSL", optional(boolean()))),
+        "starttls"                 -> trim(label("Enable STARTTLS", optional(boolean()))),
         "fromAddress"              -> trim(label("FROM Address", optional(text()))),
         "fromName"                 -> trim(label("FROM Name", optional(text())))
     )(Smtp.apply)),
@@ -77,6 +78,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
       "user"        -> trim(label("SMTP User", optional(text()))),
       "password"    -> trim(label("SMTP Password", optional(text()))),
       "ssl"         -> trim(label("Enable SSL", optional(boolean()))),
+      "starttls"    -> trim(label("Enable STARTTLS", optional(boolean()))),
       "fromAddress" -> trim(label("FROM Address", optional(text()))),
       "fromName"    -> trim(label("FROM Name", optional(text())))
     )(Smtp.apply),

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -32,6 +32,7 @@ trait SystemSettingsService {
           smtp.user.foreach(props.setProperty(SmtpUser, _))
           smtp.password.foreach(props.setProperty(SmtpPassword, _))
           smtp.ssl.foreach(x => props.setProperty(SmtpSsl, x.toString))
+          smtp.starttls.foreach(x => props.setProperty(SmtpStarttls, x.toString))
           smtp.fromAddress.foreach(props.setProperty(SmtpFromAddress, _))
           smtp.fromName.foreach(props.setProperty(SmtpFromName, _))
         }
@@ -87,6 +88,7 @@ trait SystemSettingsService {
             getOptionValue(props, SmtpUser, None),
             getOptionValue(props, SmtpPassword, None),
             getOptionValue[Boolean](props, SmtpSsl, None),
+            getOptionValue[Boolean](props, SmtpStarttls, None),
             getOptionValue(props, SmtpFromAddress, None),
             getOptionValue(props, SmtpFromName, None)))
         } else {
@@ -168,6 +170,7 @@ object SystemSettingsService {
     user: Option[String],
     password: Option[String],
     ssl: Option[Boolean],
+    starttls: Option[Boolean],
     fromAddress: Option[String],
     fromName: Option[String])
 
@@ -200,6 +203,7 @@ object SystemSettingsService {
   private val SmtpUser = "smtp.user"
   private val SmtpPassword = "smtp.password"
   private val SmtpSsl = "smtp.ssl"
+  private val SmtpStarttls = "smtp.starttls"
   private val SmtpFromAddress = "smtp.from_address"
   private val SmtpFromName = "smtp.from_name"
   private val LdapAuthentication = "ldap_authentication"

--- a/src/main/scala/gitbucket/core/util/Notifier.scala
+++ b/src/main/scala/gitbucket/core/util/Notifier.scala
@@ -118,6 +118,10 @@ class Mailer(private val smtp: Smtp) extends Notifier {
         email.setSslSmtpPort(smtp.port.get.toString)
       }
     }
+    smtp.starttls.foreach { starttls =>
+      email.setStartTLSEnabled(starttls)
+      email.setStartTLSRequired(starttls)
+    }
     smtp.fromAddress
       .map (_ -> smtp.fromName.getOrElse(loginAccount.userName))
       .orElse (Some("notifications@gitbucket.com" -> loginAccount.userName))

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -294,6 +294,12 @@
               </div>
             </div>
             <div class="form-group">
+              <label class="control-label col-md-3" for="smtpStarttls">Enable STARTTLS</label>
+              <div class="col-md-9">
+                <input type="checkbox" id="smtpStarttls" name="smtp.starttls"@if(context.settings.smtp.flatMap(_.starttls).getOrElse(false)){ checked}/>
+              </div>
+            </div>
+            <div class="form-group">
               <label class="control-label col-md-3" for="fromAddress">FROM address</label>
               <div class="col-md-9">
                 <input type="text" id="fromAddress" name="smtp.fromAddress" class="form-control" value="@context.settings.smtp.map(_.fromAddress)"/>
@@ -343,6 +349,7 @@ $(function(){
     var user        = $('#smtpUser'    ).val();
     var password    = $('#smtpPassword').val();
     var ssl         = $('#smtpSsl'     ).prop('checked');
+    var starttls    = $('#smtpStarttls').prop('checked');
     var fromAddress = $('#fromAddress' ).val();
     var fromName    = $('#fromName'    ).val();
     var testAddress = $('#testAddress' ).val();
@@ -360,6 +367,7 @@ $(function(){
         'smtp.user': user,
         'smtp.password': password,
         'smtp.ssl': ssl,
+        'smtp.starttls': starttls,
         'smtp.fromAddress': fromAddress,
         'smtp.fromName': fromName,
         'testAddress': testAddress


### PR DESCRIPTION
Fixes #1410

STARTTLS is mandatory for certain SMTP providers, such as Office 365. This PR adds that option, tested and veified to be working with our subscription.