### PR TITLE
Issue and PR template per repository

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IssuesController.scala
+++ b/src/main/scala/gitbucket/core/controller/IssuesController.scala
@@ -107,6 +107,7 @@ trait IssuesControllerBase extends ControllerBase {
           getMilestones(owner, name),
           getLabels(owner, name),
           isIssueManageable(repository),
+          getContentTemplate(repository, "ISSUE_TEMPLATE"),
           repository)
       }
     } else Unauthorized()

--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -368,6 +368,7 @@ trait PullRequestsControllerBase extends ControllerBase {
               forkedId,
               oldId.getName,
               newId.getName,
+              getContentTemplate(originRepository, "PULL_REQUEST_TEMPLATE"),
               forkedRepository,
               originRepository,
               forkedRepository,

--- a/src/main/twirl/gitbucket/core/issues/create.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/create.scala.html
@@ -2,6 +2,7 @@
   milestones: List[gitbucket.core.model.Milestone],
   labels: List[gitbucket.core.model.Label],
   isManageable: Boolean,
+  content: String,
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main(s"New Issue - ${repository.owner}/${repository.name}", Some(repository)){
@@ -13,7 +14,7 @@
           <input type="text" id="issue-title" name="title" class="form-control" value="" placeholder="Title" style="margin-bottom: 6px;" autofocus/>
           @gitbucket.core.helper.html.preview(
             repository         = repository,
-            content            = "",
+            content            = content,
             enableWikiLink     = false,
             enableRefsLink     = true,
             enableLineBreaks   = true,

--- a/src/main/twirl/gitbucket/core/pulls/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/compare.scala.html
@@ -7,6 +7,7 @@
   forkedId: String,
   sourceId: String,
   commitId: String,
+  content: String,
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
   originRepository: gitbucket.core.service.RepositoryService.RepositoryInfo,
   forkedRepository: gitbucket.core.service.RepositoryService.RepositoryInfo,
@@ -59,7 +60,7 @@
               <input type="text" name="title" value="@title" class="form-control" style="margin-bottom: 6px;" placeholder="Title"/>
               @gitbucket.core.helper.html.preview(
                 repository         = repository,
-                content            = "",
+                content            = content,
                 enableWikiLink     = false,
                 enableRefsLink     = true,
                 enableLineBreaks   = true,


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Related #1342.
When Issue/PR creating, set initial content via template file in project root or `.gitbucket` folder. (compliant with [GitHub behavior](https://github.com/blog/2111-issue-and-pull-request-templates))