### PR TITLE
bump embedded-mysql for windows support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ libraryDependencies ++= Seq(
   "javax.servlet"             % "javax.servlet-api"            % "3.1.0"          % "provided",
   "junit"                     % "junit"                        % "4.12"           % "test",
   "org.scalatra"             %% "scalatra-scalatest"           % ScalatraVersion  % "test",
-  "com.wix"                   % "wix-embedded-mysql"           % "1.0.3"          % "test",
+  "com.wix"                   % "wix-embedded-mysql"           % "2.1.4"          % "test",
   "ru.yandex.qatools.embed"   % "postgresql-embedded"          % "1.14"           % "test"
 )
 

--- a/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
+++ b/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
@@ -33,6 +33,7 @@ class GitBucketCoreModuleSpec extends FunSuite {
       .withPort(3306)
       .withUser("sa", "sa")
       .withCharset(Charset.UTF8)
+      .withServerVariable("log_syslog", 0)
       .build()
 
     val mysqld = anEmbeddedMysql(config)
@@ -41,7 +42,7 @@ class GitBucketCoreModuleSpec extends FunSuite {
 
     try {
       new Solidbase().migrate(
-        DriverManager.getConnection("jdbc:mysql://localhost:3306/gitbucket", "sa", "sa"),
+        DriverManager.getConnection("jdbc:mysql://localhost:3306/gitbucket?useSSL=false", "sa", "sa"),
         Thread.currentThread().getContextClassLoader(),
         new MySQLDatabase(),
         new Module(GitBucketCoreModule.getModuleId, GitBucketCoreModule.getVersions)


### PR DESCRIPTION
Older versions fail because they do not support testing on windows.