### PR TITLE
Prevents security warning dialog from being displayed during testing.

### DIFF
--- a/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
+++ b/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
@@ -34,6 +34,7 @@ class GitBucketCoreModuleSpec extends FunSuite {
       .withUser("sa", "sa")
       .withCharset(Charset.UTF8)
       .withServerVariable("log_syslog", 0)
+      .withServerVariable("bind-address", "127.0.0.1")
       .build()
 
     val mysqld = anEmbeddedMysql(config)


### PR DESCRIPTION
When Emmbed Mysql server starts, windows will display a security warning dialog.

![image](https://cloud.githubusercontent.com/assets/18655/21964525/d5b3fc5c-db90-11e6-9915-413748c68048.png)
