### PR TITLE
add temp_dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You can specify following options:
 - `--prefix=[CONTEXTPATH]`
 - `--host=[HOSTNAME]`
 - `--gitbucket.home=[DATA_DIR]`
+- `--temp_dir=[TEMP_DIR]`
 
 You can also deploy gitbucket.war to a servlet container which supports Servlet 3.0 (like Jetty, Tomcat, JBoss, etc)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ You can specify following options:
 - `--gitbucket.home=[DATA_DIR]`
 - `--temp_dir=[TEMP_DIR]`
 
+`TEMP_DIR` is used as the [temporary directory for the jetty application context](https://www.eclipse.org/jetty/documentation/9.3.x/ref-temporary-directories.html).
+This is the directory into which the gitbucket.war file is unpacked, the source
+files are compiled, etc.  
+If given this parameter **must** match the path of an existing directory
+or the application will quit reporting an error; if not given the path used
+will be a `tmp` directory inside the gitbucket home.
+
 You can also deploy gitbucket.war to a servlet container which supports Servlet 3.0 (like Jetty, Tomcat, JBoss, etc)
 
 For more information about installation on Mac or Windows Server (with IIS), or configuration of Apache or Nginx and also integration with other tools or services such as Jenkins or Slack, see [Wiki](https://github.com/gitbucket/gitbucket/wiki).

--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -12,6 +12,7 @@ public class JettyLauncher {
         int port = 8080;
         InetSocketAddress address = null;
         String contextPath = "/";
+        String tmpDirPath="";
         boolean forceHttps = false;
 
         for(String arg: args) {
@@ -29,6 +30,8 @@ public class JettyLauncher {
                         }
                     } else if(dim[0].equals("--gitbucket.home")){
                         System.setProperty("gitbucket.home", dim[1]);
+                    } else if(dim[0].equals("--temp_dir")){
+                        tmpDirPath = dim[1];
                     }
                 }
             }
@@ -53,9 +56,21 @@ public class JettyLauncher {
 
         WebAppContext context = new WebAppContext();
 
-        File tmpDir = new File(getGitBucketHome(), "tmp");
-        if(!tmpDir.exists()){
-            tmpDir.mkdirs();
+        File tmpDir;
+        if(tmpDirPath.equals("")){
+            tmpDir = new File(getGitBucketHome(), "tmp");
+            if(!tmpDir.exists()){
+                tmpDir.mkdirs();
+            }
+        } else {
+            tmpDir = new File(tmpDirPath);
+            if(!tmpDir.exists()){
+                throw new java.io.FileNotFoundException(
+                    String.format("temp_dir \"%s\" not found", tmpDirPath));
+            } else if(!tmpDir.isDirectory()) {
+                throw new IllegalArgumentException(
+                    String.format("temp_dir \"%s\" is not a directory", tmpDirPath));
+            }
         }
         context.setTempDirectory(tmpDir);
 


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:
- [✓] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [✓] rebased my branch over master
- [✓] verified that project is compiling
- [✓] verified that tests are passing
- [✓] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [✓] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

This PR adds a command line option `--temp_dir=[TEMP_DIR]` which can be used to set an arbitrary jetty context temporary directory.
If the path specified is not-existent or it is not a directory an exception is thrown.
If the option is not given or no path has been specified the old value (`getGitBucketHome() + "tmp"`) is used.