### PR TITLE
Show login failed message

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -49,13 +49,18 @@ trait IndexControllerBase extends ControllerBase {
     if(redirect.isDefined && redirect.get.startsWith("/")){
       flash += Keys.Flash.Redirect -> redirect.get
     }
-    gitbucket.core.html.signin()
+    gitbucket.core.html.signin(flash.get("userName"), flash.get("password"), flash.get("error"))
   }
 
   post("/signin", signinForm){ form =>
     authenticate(context.settings, form.userName, form.password) match {
       case Some(account) => signin(account)
-      case None          => redirect("/signin")
+      case None          => {
+        flash += "userName" -> form.userName
+        flash += "password" -> form.password
+        flash += "error" -> "Sorry, your Username and/or Password is incorrect. Please try again."
+        redirect("/signin")
+      }
     }
   }
 

--- a/src/main/twirl/gitbucket/core/signin.scala.html
+++ b/src/main/twirl/gitbucket/core/signin.scala.html
@@ -1,4 +1,6 @@
-@()(implicit context: gitbucket.core.controller.Context)
+@(userName: Option[Any] = None,
+  password: Option[Any] = None,
+  error: Option[Any] = None)(implicit context: gitbucket.core.controller.Context)
 @gitbucket.core.html.main("Sign in"){
   <div class="content-wrapper main-center">
     <div class="content body">
@@ -9,7 +11,8 @@
             @Html(information)
           </div>
         }
-        @gitbucket.core.html.signinform(context.settings)
+        @gitbucket.core.helper.html.error(error)
+        @gitbucket.core.html.signinform(context.settings, userName, password)
       </div>
     </div>
   </div>

--- a/src/main/twirl/gitbucket/core/signinform.scala.html
+++ b/src/main/twirl/gitbucket/core/signinform.scala.html
@@ -1,4 +1,6 @@
-@(systemSettings: gitbucket.core.service.SystemSettingsService.SystemSettings)(implicit context: gitbucket.core.controller.Context)
+@(systemSettings: gitbucket.core.service.SystemSettingsService.SystemSettings,
+  userName: Option[Any] = None,
+  password: Option[Any] = None)(implicit context: gitbucket.core.controller.Context)
 <div class="panel panel-default">
   <div class="panel-heading strong">Sign in</div>
   <ul class="list-group list-group-flush">
@@ -7,12 +9,12 @@
         <div class="form-group">
           <label for="userName">Username:</label>
           <span id="error-userName" class="error"></span>
-          <input type="text" name="userName" id="userName" class="form-control" autofocus/>
+          <input type="text" name="userName" id="userName" class="form-control" autofocus value="@userName"/>
         </div>
         <div class="form-group">
           <label for="password">Password:</label>
           <span id="error-password" class="error"></span>
-          <input type="password" name="password" id="password" class="form-control"/>
+          <input type="password" name="password" id="password" class="form-control" value="@password"/>
         </div>
         <input type="submit" class="btn btn-success" value="Sign in"/>
         @if(systemSettings.allowAccountRegistration){


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Related to #503. (but, I think it will not be solved completely, it won't be closed by this PR)

Show login failed message without detail reason.
When above, remain username and password user entered.
![sign in](https://cloud.githubusercontent.com/assets/3643499/22272701/1b21104a-e2df-11e6-8948-01d4d850fd61.png)
