### PR TITLE
404 for non-implemented api

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -60,6 +60,13 @@ trait ApiControllerBase extends ControllerBase {
     with WritableUsersAuthenticator =>
 
   /**
+    * 404 for non-implemented api
+    */
+  get("/api/v3/*") {
+    NotFound()
+  }
+
+  /**
     * https://developer.github.com/v3/#root-endpoint
     */
   get("/api/v3/") {


### PR DESCRIPTION
When I call non-implemented api, GitBucket spent some times and return 404 by container.

BEFORE
```
$ curl -u root:root http://pc.local:8080/api/v3/emojis
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
<title>Error 404 Not Found</title>
</head>
<body><h2>HTTP ERROR 404</h2>
<p>Problem accessing /api/v3/emoji. Reason:
<pre>    Not Found</pre></p><hr><i><small>Powered by Jetty://</small></i><hr/>

</body>
</html>
```
This PR add support 404 for non-implemented API calls.

AFTER
```
$ curl -u root:root http://pc.local:8080/api/v3/emojis
{"message":"Not Found"}
```

### Before submitting a pull-request to Gitbucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
