### PR TITLE
Failure to clone LFS file when repository rename or transfer

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
@@ -129,6 +129,7 @@ trait RepositorySettingsControllerBase extends ControllerBase {
       defining(getLfsDir(repository.owner, repository.name)){ dir =>
         if(dir.isDirectory()) {
           FileUtils.moveDirectory(dir, getLfsDir(repository.owner, form.repositoryName))
+          FileUtil.deleteDirectoryIfEmpty(dir.getParentFile())
         }
       }
     }
@@ -333,7 +334,7 @@ trait RepositorySettingsControllerBase extends ControllerBase {
         defining(getLfsDir(repository.owner, repository.name)){ dir =>
           if(dir.isDirectory()) {
             FileUtils.moveDirectory(dir, getLfsDir(form.newOwner, repository.name))
-
+            FileUtil.deleteDirectoryIfEmpty(dir.getParentFile())
           }
         }
       }
@@ -351,7 +352,9 @@ trait RepositorySettingsControllerBase extends ControllerBase {
       FileUtils.deleteDirectory(getRepositoryDir(repository.owner, repository.name))
       FileUtils.deleteDirectory(getWikiRepositoryDir(repository.owner, repository.name))
       FileUtils.deleteDirectory(getTemporaryDir(repository.owner, repository.name))
-      FileUtils.deleteDirectory(getLfsDir(repository.owner, repository.name))
+      val lfsDir = getLfsDir(repository.owner, repository.name)
+      FileUtils.deleteDirectory(lfsDir)
+      FileUtil.deleteDirectoryIfEmpty(lfsDir.getParentFile())
     }
     redirect(s"/${repository.owner}")
   })

--- a/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
@@ -125,6 +125,12 @@ trait RepositorySettingsControllerBase extends ControllerBase {
       defining(getWikiRepositoryDir(repository.owner, repository.name)){ dir =>
         FileUtils.moveDirectory(dir, getWikiRepositoryDir(repository.owner, form.repositoryName))
       }
+      // Move lfs directory
+      defining(getLfsDir(repository.owner, repository.name)){ dir =>
+        if(dir.isDirectory()) {
+          FileUtils.moveDirectory(dir, getLfsDir(repository.owner, form.repositoryName))
+        }
+      }
     }
     flash += "info" -> "Repository settings has been updated."
     redirect(s"/${repository.owner}/${form.repositoryName}/settings/options")
@@ -322,6 +328,13 @@ trait RepositorySettingsControllerBase extends ControllerBase {
         // Move wiki repository
         defining(getWikiRepositoryDir(repository.owner, repository.name)){ dir =>
           FileUtils.moveDirectory(dir, getWikiRepositoryDir(form.newOwner, repository.name))
+        }
+        // Move lfs directory
+        defining(getLfsDir(repository.owner, repository.name)){ dir =>
+          if(dir.isDirectory()) {
+            FileUtils.moveDirectory(dir, getLfsDir(form.newOwner, repository.name))
+
+          }
         }
       }
     }

--- a/src/main/scala/gitbucket/core/util/FileUtil.scala
+++ b/src/main/scala/gitbucket/core/util/FileUtil.scala
@@ -67,4 +67,10 @@ object FileUtil {
     Directory.getLfsDir(owner, repository) + "/" + oid
 
   def readableSize(size: Long): String = FileUtils.byteCountToDisplaySize(size)
+
+  def deleteDirectoryIfEmpty(dir: File): Unit = {
+    if(dir.isDirectory() && dir.list().isEmpty) {
+      FileUtils.deleteDirectory(dir)
+    }
+  }
 }


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

I have tested this patterns.

1. push repository with LFS file
1. rename repository
    * check LFS file display in file brower
    * check the contents of the LFS file in the cloned repository
    * check that the LFS directory before the rename is deleted on the server side
1. transfer repositry
    * check LFS file display in file brower
    * check the contents of the LFS file in the cloned repository
    * check that the LFS directory before transfer is deleted on the server side
1. delete repository
    * check that the LFS directory has been deleted on the server side
