### PR TITLE
remove scala-java8-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ resolvers ++= Seq(
   "amateras-snapshot" at "http://amateras.sourceforge.jp/mvn-snapshot/"
 )
 libraryDependencies ++= Seq(
-  "org.scala-lang.modules"          %% "scala-java8-compat"           % "0.8.0",
   "org.eclipse.jgit"                %  "org.eclipse.jgit.http.server" % "4.6.0.201612231935-r",
   "org.eclipse.jgit"                %  "org.eclipse.jgit.archive"     % "4.6.0.201612231935-r",
   "org.scalatra"                    %% "scalatra"                     % ScalatraVersion,


### PR DESCRIPTION
I have added this for new Java8 backend.
https://github.com/gitbucket/gitbucket/commit/2bcab3052964343a54d79357c04
I think no longer needed because githbucket updated Scala 2.12.