### PR TITLE
Improve GitHub API compatibility for Jenkins Integration.

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiBranch.scala
+++ b/src/main/scala/gitbucket/core/api/ApiBranch.scala
@@ -8,7 +8,7 @@ import gitbucket.core.util.RepositoryName
  */
 case class ApiBranch(
   name: String,
-  // commit: ApiBranchCommit,
+  commit: ApiBranchCommit,
   protection: ApiBranchProtection)(repositoryName:RepositoryName) extends FieldSerializable {
   def _links = Map(
    "self" -> ApiPath(s"/api/v3/repos/${repositoryName.fullName}/branches/${name}"),

--- a/src/main/scala/gitbucket/core/api/ApiContents.scala
+++ b/src/main/scala/gitbucket/core/api/ApiContents.scala
@@ -1,18 +1,27 @@
 package gitbucket.core.api
 
 import gitbucket.core.util.JGitUtil.FileInfo
+import gitbucket.core.util.RepositoryName
 import org.apache.commons.codec.binary.Base64
 
-case class ApiContents(`type`: String, name: String, content: Option[String], encoding: Option[String])
+case class ApiContents(
+  `type`: String,
+  name: String,
+  path: String,
+  sha: String,
+  content: Option[String],
+  encoding: Option[String])(repositoryName: RepositoryName){
+  val download_url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/raw/${sha}/${path}")
+}
 
 object ApiContents{
-  def apply(fileInfo: FileInfo, content: Option[Array[Byte]]): ApiContents = {
+  def apply(fileInfo: FileInfo, repositoryName: RepositoryName, content: Option[Array[Byte]]): ApiContents = {
     if(fileInfo.isDirectory) {
-      ApiContents("dir", fileInfo.name, None, None)
+      ApiContents("dir", fileInfo.name, fileInfo.path, fileInfo.commitId, None, None)(repositoryName)
     } else {
       content.map(arr =>
-        ApiContents("file", fileInfo.name, Some(Base64.encodeBase64String(arr)), Some("base64"))
-      ).getOrElse(ApiContents("file", fileInfo.name, None, None))
+        ApiContents("file", fileInfo.name, fileInfo.path, fileInfo.commitId, Some(Base64.encodeBase64String(arr)), Some("base64"))(repositoryName)
+      ).getOrElse(ApiContents("file", fileInfo.name, fileInfo.path, fileInfo.commitId, None, None)(repositoryName))
     }
   }
 }

--- a/src/main/scala/gitbucket/core/api/JsonFormat.scala
+++ b/src/main/scala/gitbucket/core/api/JsonFormat.scala
@@ -31,6 +31,7 @@ object JsonFormat {
     FieldSerializer[ApiPullRequest.Commit]() +
     FieldSerializer[ApiIssue]() +
     FieldSerializer[ApiComment]() +
+    FieldSerializer[ApiContents]() +
     FieldSerializer[ApiLabel]() +
     ApiBranchProtection.enforcementLevelSerializer
 


### PR DESCRIPTION
This PR improves API compatibility w.r.t. Jenkins GitHub Organization Folder Plugin based integration.

### Changes

- Add /api/v3/repos/:owner/:repo/branches/:branch API
- Add non-GitHub compatible API for raw contents transfer with BASIC auth
    - this action needs getPathObjectId() and responseRawFile(), then move these methods to ControllerBase.
- /api/v3/users/:userName also accepts groupname
- Add some fields for improve compatibility
    - ApiContents
    - ApiBranch

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
