### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.java]
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) supports many editors(Vim/Emacs/VS Code/Atom, etc.)/IDEs(IDEAJ/Eclipse, etc.)'s configuration with `.editorconfig` file.
If this PR is merged, editors are automatically configured by GitBucket's 2-space indent style.

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
