### PR TITLE
Add Theme Plugin support

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AnonymousAccessController.scala
+++ b/src/main/scala/gitbucket/core/controller/AnonymousAccessController.scala
@@ -5,7 +5,7 @@ class AnonymousAccessController extends AnonymousAccessControllerBase
 trait AnonymousAccessControllerBase extends ControllerBase {
   get(!context.settings.allowAnonymousAccess, context.loginAccount.isEmpty) {
     if(!context.currentPath.startsWith("/assets") && !context.currentPath.startsWith("/signin") &&
-      !context.currentPath.startsWith("/register")) {
+      !context.currentPath.startsWith("/register") && !context.currentPath.startsWith("/plugin-assets")) {
       Unauthorized()
     } else {
       pass()

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -25,6 +25,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
   private val form = mapping(
     "baseUrl"                  -> trim(label("Base URL", optional(text()))),
     "information"              -> trim(label("Information", optional(text()))),
+    "themeAndSkinName"                  -> trim(label("Theme and skin name", optional(text()))),
     "allowAccountRegistration" -> trim(label("Account registration", boolean())),
     "allowAnonymousAccess"     -> trim(label("Anonymous access", boolean())),
     "isCreateRepoOptionPublic" -> trim(label("Default option to create a new repository", boolean())),

--- a/src/main/scala/gitbucket/core/plugin/Plugin.scala
+++ b/src/main/scala/gitbucket/core/plugin/Plugin.scala
@@ -268,11 +268,13 @@ abstract class Plugin {
     themeJavaScriptFiles.foreach { file =>
       registry.addThemeJavaScriptFile(pluginId, file)
     }
-    themeCssFiles.foreach { file =>
-      registry.addThemeCssFile(pluginId, file)
-    }
-    themeSkinNames.foreach {skinName =>
-      registry.addThemeSkinName(pluginId, skinName)
+    if (isThemePlugin){
+      themeCssFiles.foreach { file =>
+        registry.addThemeCssFile(pluginId, file)
+      }
+      themeSkinNames.foreach {skinName =>
+        registry.addThemeSkinName(pluginId, skinName)
+      }
     }
   }
 

--- a/src/main/scala/gitbucket/core/plugin/Plugin.scala
+++ b/src/main/scala/gitbucket/core/plugin/Plugin.scala
@@ -190,11 +190,6 @@ abstract class Plugin {
   def suggestionProviders(registry: PluginRegistry, context: ServletContext, settings: SystemSettings): Seq[SuggestionProvider] = Nil
 
   /**
-    * Override and set true if this plugin is theme plugin.
-    */
-  val isThemePlugin: Boolean = false
-
-  /**
     * Override to add JavaScript files for theme plugin.
     */
   def themeJavaScriptFiles: Seq[String] = Nil
@@ -268,13 +263,11 @@ abstract class Plugin {
     themeJavaScriptFiles.foreach { file =>
       registry.addThemeJavaScriptFile(pluginId, file)
     }
-    if (isThemePlugin){
-      themeCssFiles.foreach { file =>
-        registry.addThemeCssFile(pluginId, file)
-      }
-      themeSkinNames.foreach {skinName =>
-        registry.addThemeSkinName(pluginId, skinName)
-      }
+    themeCssFiles.foreach { file =>
+      registry.addThemeCssFile(pluginId, file)
+    }
+    themeSkinNames.foreach {skinName =>
+      registry.addThemeSkinName(pluginId, skinName)
     }
   }
 

--- a/src/main/scala/gitbucket/core/plugin/Plugin.scala
+++ b/src/main/scala/gitbucket/core/plugin/Plugin.scala
@@ -190,6 +190,26 @@ abstract class Plugin {
   def suggestionProviders(registry: PluginRegistry, context: ServletContext, settings: SystemSettings): Seq[SuggestionProvider] = Nil
 
   /**
+    * Override and set true if this plugin is theme plugin.
+    */
+  val isThemePlugin: Boolean = false
+
+  /**
+    * Override to add JavaScript files for theme plugin.
+    */
+  def themeJavaScriptFiles: Seq[String] = Nil
+
+  /**
+    * Override to add css files for theme plugin.
+    */
+  def themeCssFiles: Seq[String] = Nil
+
+  /**
+    * override to define Css(maybe adminLTE) skinNames
+    */
+  def themeSkinNames: Seq[String] = Nil
+
+  /**
    * This method is invoked in initialization of plugin system.
    * Register plugin functionality to PluginRegistry.
    */
@@ -244,6 +264,15 @@ abstract class Plugin {
     }
     (suggestionProviders ++ suggestionProviders(registry, context, settings)).foreach { suggestionProvider =>
       registry.addSuggestionProvider(suggestionProvider)
+    }
+    themeJavaScriptFiles.foreach { file =>
+      registry.addThemeJavaScriptFile(pluginId, file)
+    }
+    themeCssFiles.foreach { file =>
+      registry.addThemeCssFile(pluginId, file)
+    }
+    themeSkinNames.foreach {skinName =>
+      registry.addThemeSkinName(pluginId, skinName)
     }
   }
 

--- a/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
@@ -153,7 +153,6 @@ class PluginRegistry {
 
   def addThemeJavaScriptFile(pluginId: String, file: String): Unit = themeJavaScriptFiles += ((pluginId, file))
 
-  // def getThemeJavaScriptFiles(pluginId): List[String] = themeJavaScriptFiles.filter(x => pluginId.matches(x._1)).toList.map(_._2)
   def getThemeJavaScriptFiles(pluginId: String): List[String] = themeJavaScriptFiles.filter(x => x._1 == pluginId).toList.map(_._2)
 
   def addThemeCssFile(pluginId: String, file: String): Unit = themeCssFiles += ((pluginId, file))

--- a/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
@@ -49,6 +49,10 @@ class PluginRegistry {
   private val suggestionProviders = new ListBuffer[SuggestionProvider]
   suggestionProviders += new UserNameSuggestionProvider()
 
+  private val themeJavaScriptFiles = new ListBuffer[(String, String)]
+  private val themeCssFiles = new ListBuffer[(String, String)]
+  private val themeSkinNames = new ListBuffer[(String, String)]
+
   def addPlugin(pluginInfo: PluginInfo): Unit = plugins += pluginInfo
 
   def getPlugins(): List[PluginInfo] = plugins.toList
@@ -146,6 +150,19 @@ class PluginRegistry {
   def addSuggestionProvider(suggestionProvider: SuggestionProvider): Unit = suggestionProviders += suggestionProvider
 
   def getSuggestionProviders: Seq[SuggestionProvider] = suggestionProviders.toSeq
+
+  def addThemeJavaScriptFile(pluginId: String, file: String): Unit = themeJavaScriptFiles += ((pluginId, file))
+
+  // def getThemeJavaScriptFiles(pluginId): List[String] = themeJavaScriptFiles.filter(x => pluginId.matches(x._1)).toList.map(_._2)
+  def getThemeJavaScriptFiles(pluginId: String): List[String] = themeJavaScriptFiles.filter(x => x._1 == pluginId).toList.map(_._2)
+
+  def addThemeCssFile(pluginId: String, file: String): Unit = themeCssFiles += ((pluginId, file))
+
+  def getThemeCssFiles(pluginId: String): List[String] = themeCssFiles.filter(x => x._1 == pluginId).toList.map(_._2)
+
+  def addThemeSkinName(pluginId: String, skinName: String): Unit = themeSkinNames += ((pluginId, skinName))
+
+  def getThemeSkinNames: Seq[(String, String)] = themeSkinNames.toSeq
 }
 
 /**

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -15,6 +15,7 @@ trait SystemSettingsService {
     defining(new java.util.Properties()){ props =>
       settings.baseUrl.foreach(x => props.setProperty(BaseURL, x.replaceFirst("/\\Z", "")))
       settings.information.foreach(x => props.setProperty(Information, x))
+      settings.themeAndSkinName.foreach(x => props.setProperty(ThemeAndSkinName, x))
       props.setProperty(AllowAccountRegistration, settings.allowAccountRegistration.toString)
       props.setProperty(AllowAnonymousAccess, settings.allowAnonymousAccess.toString)
       props.setProperty(IsCreateRepoOptionPublic, settings.isCreateRepoOptionPublic.toString)
@@ -71,6 +72,7 @@ trait SystemSettingsService {
       SystemSettings(
         getOptionValue[String](props, BaseURL, None).map(x => x.replaceFirst("/\\Z", "")),
         getOptionValue(props, Information, None),
+        getOptionValue(props, ThemeAndSkinName, None),
         getValue(props, AllowAccountRegistration, false),
         getValue(props, AllowAnonymousAccess, true),
         getValue(props, IsCreateRepoOptionPublic, true),
@@ -124,6 +126,7 @@ object SystemSettingsService {
   case class SystemSettings(
     baseUrl: Option[String],
     information: Option[String],
+    themeAndSkinName: Option[String],
     allowAccountRegistration: Boolean,
     allowAnonymousAccess: Boolean,
     isCreateRepoOptionPublic: Boolean,
@@ -182,12 +185,14 @@ object SystemSettingsService {
   case class Lfs(
     serverUrl: Option[String])
 
+  val DefaultSkinName = "skin-blue"
   val DefaultSshPort = 29418
   val DefaultSmtpPort = 25
   val DefaultLdapPort = 389
 
   private val BaseURL = "base_url"
   private val Information = "information"
+  private val ThemeAndSkinName = "theme_skin_name"
   private val AllowAccountRegistration = "allow_account_registration"
   private val AllowAnonymousAccess = "allow_anonymous_access"
   private val IsCreateRepoOptionPublic = "is_create_repository_option_public"

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -212,6 +212,11 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
   def assets(implicit context: Context): String = s"${context.path}/assets"
 
   /**
+    * Returns the url to the root of plugin assets.
+    */
+  def pluginAssets(implicit context: Context): String = s"${context.path}/plugin-assets"
+
+  /**
    * Generates the text link to the account page.
    * If user does not exist or disabled, this method returns user name as text without link.
    */

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -7,7 +7,7 @@ import gitbucket.core.controller.Context
 import gitbucket.core.model.CommitState
 import gitbucket.core.plugin.{PluginRegistry, RenderRequest}
 import gitbucket.core.service.RepositoryService.RepositoryInfo
-import gitbucket.core.service.{RepositoryService, RequestCache}
+import gitbucket.core.service.{RepositoryService, RequestCache, SystemSettingsService}
 import gitbucket.core.util.{FileUtil, JGitUtil, StringUtil}
 import play.twirl.api.{Html, HtmlFormat}
 
@@ -215,6 +215,16 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
     * Returns the url to the root of plugin assets.
     */
   def pluginAssets(implicit context: Context): String = s"${context.path}/plugin-assets"
+
+  /**
+    * Returns theme plugin name from settings.
+    */
+  def themePluginName(implicit context: Context): Option[String] = context.settings.themeAndSkinName.map(_.split('/')(0))
+
+  /**
+    * Returns skin name from settings.
+    */
+  def skinName(implicit context: Context): String = context.settings.themeAndSkinName.map(_.split('/')(1)).getOrElse(SystemSettingsService.DefaultSkinName)
 
   /**
    * Generates the text link to the account page.

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -1,4 +1,5 @@
 @(info: Option[Any])(implicit context: gitbucket.core.controller.Context)
+@import gitbucket.core.plugin.PluginRegistry
 @gitbucket.core.html.main("System settings"){
   @gitbucket.core.admin.html.menu("system"){
     @gitbucket.core.helper.html.information(info)
@@ -46,6 +47,18 @@
           <label><span class="strong">Information</span> (HTML is available)</label>
           <fieldset>
             <textarea name="information" class="form-control" style="height: 100px;">@context.settings.information</textarea>
+          </fieldset>
+          <!--====================================================================-->
+          <!-- Skin Settings -->
+          <!--====================================================================-->
+          <hr>
+          <label><span class="strong">Skin name</span></label>
+          <fieldset>
+            <select name="themAndSkinName">
+              @PluginRegistry().getThemeSkinNames.map{ case (pluginId, skinName) =>
+                <option>@pluginId/@skinName</option>
+              }
+            </select>
           </fieldset>
           <!--====================================================================-->
           <!-- Account registration -->

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -57,7 +57,7 @@
           <fieldset>
             <select name="themeAndSkinName">
               @PluginRegistry().getThemeSkinNames.map{ case (pluginId, skinName) =>
-                <option @if((pluginId == helpers.themePluginName.get) && (skinName == helpers.skinName)){ selected}>@pluginId/@skinName</option>
+                <option @if((pluginId == helpers.themePluginName.getOrElse("")) && (skinName == helpers.skinName)){ selected}>@pluginId/@skinName</option>
               }
             </select>
           </fieldset>

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -54,7 +54,7 @@
           <hr>
           <label><span class="strong">Skin name</span></label>
           <fieldset>
-            <select name="themAndSkinName">
+            <select name="themeAndSkinName">
               @PluginRegistry().getThemeSkinNames.map{ case (pluginId, skinName) =>
                 <option>@pluginId/@skinName</option>
               }

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -1,5 +1,6 @@
 @(info: Option[Any])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.plugin.PluginRegistry
+@import gitbucket.core.view.helpers
 @gitbucket.core.html.main("System settings"){
   @gitbucket.core.admin.html.menu("system"){
     @gitbucket.core.helper.html.information(info)
@@ -56,7 +57,7 @@
           <fieldset>
             <select name="themeAndSkinName">
               @PluginRegistry().getThemeSkinNames.map{ case (pluginId, skinName) =>
-                <option>@pluginId/@skinName</option>
+                <option @if((pluginId == helpers.themePluginName.get) && (skinName == helpers.skinName)){ selected}>@pluginId/@skinName</option>
               }
             </select>
           </fieldset>

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -15,10 +15,15 @@
     <link href="@helpers.assets/vendors/colorpicker/css/bootstrap-colorpicker.css" rel="stylesheet">
     <link href="@helpers.assets/vendors/google-code-prettify/prettify.css" type="text/css" rel="stylesheet"/>
     <link href="@helpers.assets/vendors/facebox/facebox.css" rel="stylesheet"/>
-    <link href="@helpers.assets/vendors/AdminLTE-2.3.8/css/AdminLTE.min.css" rel="stylesheet">
-    <link href="@helpers.assets/vendors/AdminLTE-2.3.8/css/skins/skin-blue.min.css" rel="stylesheet">
     <link href="@helpers.assets/vendors/font-awesome-4.6.3/css/font-awesome.min.css" rel="stylesheet">
     <link href="@helpers.assets/common/css/gitbucket.css" rel="stylesheet">
+    @PluginRegistry().getThemeCssFiles("adminLTE-theme").map { file =>
+      <link href="@helpers.pluginAssets/@file" rel="stylesheet">
+    }
+    @if(PluginRegistry().getThemeCssFiles("adminLTE-theme").isEmpty) {
+      <link href="@helpers.assets/vendors/AdminLTE-2.3.8/css/AdminLTE.min.css" rel="stylesheet">
+      <link href="@helpers.assets/vendors/AdminLTE-2.3.8/css/skins/skin-blue.min.css" rel="stylesheet">
+    }
     <script src="@helpers.assets/vendors/jquery/jquery-1.12.2.min.js"></script>
     <script src="@helpers.assets/vendors/dropzone/dropzone.js"></script>
     <script src="@helpers.assets/common/js/validation.js"></script>
@@ -33,10 +38,16 @@
     <script src="@helpers.assets/vendors/facebox/facebox.js"></script>
     <script src="@helpers.assets/vendors/jquery-hotkeys/jquery.hotkeys.js"></script>
     <script src="@helpers.assets/vendors/jquery-textcomplete-1.6.2/jquery.textcomplete.js"></script>
+    @PluginRegistry().getThemeJavaScriptFiles("adminLTE-theme").map { file =>
+      <script src="@helpers.pluginAssets/@file"></script>
+    }
+    @if(PluginRegistry().getThemeJavaScriptFiles("adminLTE-theme").isEmpty) {
+      <script src="@helpers.assets/vendors/AdminLTE-2.3.8/js/app.js" type="text/javascript"></script>
+    }
     @repository.map { repository =>
       <meta name="go-import" content="@context.baseUrl.replaceFirst("^https?://", "")/@repository.owner/@repository.name git @repository.httpUrl" />
     }
-    <script src="@helpers.assets/vendors/AdminLTE-2.3.8/js/app.js" type="text/javascript"></script>
+    <!--<script src="@helpers.assets/vendors/AdminLTE-2.3.8/js/app.js" type="text/javascript"></script>-->
   </head>
   <body class="skin-blue page-load @if(context.sidebarCollapse){sidebar-collapse}">
     <div class="wrapper">

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -41,7 +41,7 @@
     <script src="@helpers.assets/vendors/jquery-textcomplete-1.6.2/jquery.textcomplete.js"></script>
     @helpers.themePluginName.map{ pluginName =>
       @PluginRegistry().getThemeJavaScriptFiles(pluginName).map { file =>
-        <script src="@helpers.pluginAssets/@file"></script>
+        <script src="@helpers.pluginAssets/@file" type="text/javascript"></script>
       }
     }.getOrElse {
       <script src="@helpers.assets/vendors/AdminLTE-2.3.8/js/app.js" type="text/javascript"></script>

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -17,10 +17,11 @@
     <link href="@helpers.assets/vendors/facebox/facebox.css" rel="stylesheet"/>
     <link href="@helpers.assets/vendors/font-awesome-4.6.3/css/font-awesome.min.css" rel="stylesheet">
     <link href="@helpers.assets/common/css/gitbucket.css" rel="stylesheet">
-    @PluginRegistry().getThemeCssFiles("adminLTE-theme").map { file =>
-      <link href="@helpers.pluginAssets/@file" rel="stylesheet">
-    }
-    @if(PluginRegistry().getThemeCssFiles("adminLTE-theme").isEmpty) {
+    @helpers.themePluginName.map { pluginName =>
+      @PluginRegistry().getThemeCssFiles(pluginName).map { file =>
+        <link href="@helpers.pluginAssets/@file" rel="stylesheet">
+      }
+    }.getOrElse{
       <link href="@helpers.assets/vendors/AdminLTE-2.3.8/css/AdminLTE.min.css" rel="stylesheet">
       <link href="@helpers.assets/vendors/AdminLTE-2.3.8/css/skins/skin-blue.min.css" rel="stylesheet">
     }
@@ -38,18 +39,18 @@
     <script src="@helpers.assets/vendors/facebox/facebox.js"></script>
     <script src="@helpers.assets/vendors/jquery-hotkeys/jquery.hotkeys.js"></script>
     <script src="@helpers.assets/vendors/jquery-textcomplete-1.6.2/jquery.textcomplete.js"></script>
-    @PluginRegistry().getThemeJavaScriptFiles("adminLTE-theme").map { file =>
-      <script src="@helpers.pluginAssets/@file"></script>
-    }
-    @if(PluginRegistry().getThemeJavaScriptFiles("adminLTE-theme").isEmpty) {
+    @helpers.themePluginName.map{ pluginName =>
+      @PluginRegistry().getThemeJavaScriptFiles(pluginName).map { file =>
+        <script src="@helpers.pluginAssets/@file"></script>
+      }
+    }.getOrElse {
       <script src="@helpers.assets/vendors/AdminLTE-2.3.8/js/app.js" type="text/javascript"></script>
     }
     @repository.map { repository =>
       <meta name="go-import" content="@context.baseUrl.replaceFirst("^https?://", "")/@repository.owner/@repository.name git @repository.httpUrl" />
     }
-    <!--<script src="@helpers.assets/vendors/AdminLTE-2.3.8/js/app.js" type="text/javascript"></script>-->
   </head>
-  <body class="skin-blue page-load @if(context.sidebarCollapse){sidebar-collapse}">
+  <body class="@helpers.skinName page-load @if(context.sidebarCollapse){sidebar-collapse}">
     <div class="wrapper">
       <header class="main-header">
         <a href="@context.path/" class="logo">

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -101,6 +101,7 @@ class AvatarImageProviderSpec extends FunSpec with MockitoSugar {
     SystemSettings(
       baseUrl                  = None,
       information              = None,
+      themeAndSkinName         = None,
       allowAccountRegistration = false,
       allowAnonymousAccess     = true,
       isCreateRepoOptionPublic = true,


### PR DESCRIPTION
This PR introduce "Theme Plugin" support. discoused in #1279.

Each GitBucket instance has some "theme"s. And each theme has some "skin"s.
ex.

- [AdminLTE theme](https://github.com/kounoike/gitbucket-theme-AdminLTE-plugin) is theme of AdminLTE theme.
    - skin-blue
    - skin-blue-light
    - skin-black
    - skin-black-light, etc.
- [AdminLTE pink theme](https://github.com/kounoike/gitbucket-theme-AdminLTE-pink-plugin) is demonstrate version theme.
    - skin-pink

In System settings, You can chose "skin name" with theme/skin pair.

![140328-system settings - google chrome](https://cloud.githubusercontent.com/assets/6997928/23829182/af3b1952-072d-11e7-94f3-8d950e0e3dda.png)

first option is adminLTE-pink theme's skin. others are AdminLTE theme's skin.

theme/skin setting is saved into GITBUCKET_HOME/gitbucket.conf.

Every page of GitBucket load only selected theme's CSS/JS.

If you didn't have no theme-plugins, fallback to previous AdminLTE/skin-blue settings.

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
