### PR TITLE
Add Cache-Control header for _avatar and /plugin-assets (refs #777)

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -149,6 +149,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
 
   get("/:userName/_avatar"){
     val userName = params("userName")
+    response.setHeader("Cache-Control", "max-age=3600")
     getAccountByUserName(userName).flatMap(_.image).map { image =>
       RawData(FileUtil.getMimeType(image), new java.io.File(getUserUploadDir(userName), image))
     } getOrElse {

--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -15,6 +15,7 @@ import io.github.gitbucket.scalatra.forms._
 import org.apache.commons.io.FileUtils
 import org.scalatra.i18n.Messages
 import org.scalatra.BadRequest
+import java.util.Date
 
 
 class AccountController extends AccountControllerBase
@@ -149,12 +150,17 @@ trait AccountControllerBase extends AccountManagementControllerBase {
 
   get("/:userName/_avatar"){
     val userName = params("userName")
-    response.setHeader("Cache-Control", "max-age=3600")
-    getAccountByUserName(userName).flatMap(_.image).map { image =>
-      RawData(FileUtil.getMimeType(image), new java.io.File(getUserUploadDir(userName), image))
-    } getOrElse {
-      contentType = "image/png"
-      Thread.currentThread.getContextClassLoader.getResourceAsStream("noimage.png")
+    (for {
+      account <- getAccountByUserName(userName)
+      image <- account.image
+    } yield (account, image)) match{
+      case Some((account, image)) =>
+        response.setDateHeader("Last-Modified", account.updatedDate.getTime)
+        RawData(FileUtil.getMimeType(image), new java.io.File(getUserUploadDir(userName), image))
+      case None =>
+        contentType = "image/png"
+        response.setDateHeader("Last-Modified", (new Date(0)).getTime)
+        Thread.currentThread.getContextClassLoader.getResourceAsStream("noimage.png")
     }
   }
 

--- a/src/main/scala/gitbucket/core/servlet/PluginAssetsServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/PluginAssetsServlet.scala
@@ -26,6 +26,7 @@ class PluginAssetsServlet extends HttpServlet {
           val bytes = IOUtils.toByteArray(in)
           resp.setContentLength(bytes.length)
           resp.setContentType(FileUtil.getContentType(path, bytes))
+          resp.setHeader("Cache-Control", "max-age=3600")
           resp.getOutputStream.write(bytes)
         } finally {
           in.close()

--- a/src/main/scala/gitbucket/core/view/AvatarImageProvider.scala
+++ b/src/main/scala/gitbucket/core/view/AvatarImageProvider.scala
@@ -20,7 +20,7 @@ trait AvatarImageProvider { self: RequestCache =>
         if(account.image.isEmpty && context.settings.gravatar){
           s"""https://www.gravatar.com/avatar/${StringUtil.md5(account.mailAddress.toLowerCase)}?s=${size}&d=retro&r=g"""
         } else {
-          s"""${context.path}/${account.userName}/_avatar"""
+          s"""${context.path}/${account.userName}/_avatar?${helpers.hashDate(account.updatedDate)}"""
         }
       } getOrElse {
         s"""${context.path}/_unknown/_avatar"""
@@ -31,7 +31,7 @@ trait AvatarImageProvider { self: RequestCache =>
         if(account.image.isEmpty && context.settings.gravatar){
           s"""https://www.gravatar.com/avatar/${StringUtil.md5(account.mailAddress.toLowerCase)}?s=${size}&d=retro&r=g"""
         } else {
-          s"""${context.path}/${account.userName}/_avatar"""
+          s"""${context.path}/${account.userName}/_avatar?${helpers.hashDate(account.updatedDate)}"""
         }
       } getOrElse {
         if(context.settings.gravatar){

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -80,6 +80,16 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
   def hashDate(date: Date): String = new SimpleDateFormat("yyyyMMddHHmmss").format(date)
 
   /**
+    * java.util.Date of boot timestamp.
+    */
+  val bootDate: Date = new Date()
+
+  /**
+    * hashDate of bootDate for /assets, /plugin-assets
+    */
+  def hashQuery: String = hashDate(bootDate)
+
+  /**
    * Returns singular if count is 1, otherwise plural.
    * If plural is not specified, returns singular + "s" as plural.
    */
@@ -215,6 +225,11 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
    * Returns the url to the root of assets.
    */
   def assets(implicit context: Context): String = s"${context.path}/assets"
+
+  /**
+    * Returns the url to the path of assets.
+    */
+  def assets(path: String)(implicit context: Context): String = s"${context.path}/assets${path}?${hashQuery}"
 
   /**
    * Generates the text link to the account page.

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -75,6 +75,11 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
   def date(date: Date): String = new SimpleDateFormat("yyyy-MM-dd").format(date)
 
   /**
+    * Format java.util.Date to "yyyyMMDDHHmmss" (for url hash ex. /some/path.css?19800101010203
+    */
+  def hashDate(date: Date): String = new SimpleDateFormat("yyyyMMddHHmmss").format(date)
+
+  /**
    * Returns singular if count is 1, otherwise plural.
    * If plural is not specified, returns singular + "s" as plural.
    */

--- a/src/main/twirl/gitbucket/core/helper/diff.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/diff.scala.html
@@ -130,8 +130,8 @@
     </tr>
   </table>
 }
-<script type="text/javascript" src="@helpers.assets/vendors/jsdifflib/difflib.js"></script>
-<link href="@helpers.assets/vendors/jsdifflib/diffview.css" type="text/css" rel="stylesheet" />
+<script type="text/javascript" src="@helpers.assets("/vendors/jsdifflib/difflib.js")"></script>
+<link href="@helpers.assets("/vendors/jsdifflib/diffview.css")" type="text/css" rel="stylesheet" />
 <script>
 $(function(){
   @if(showIndex){

--- a/src/main/twirl/gitbucket/core/helper/preview.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/preview.scala.html
@@ -38,8 +38,8 @@
     </div>
   </div>
 </div>
-<link  href="@helpers.assets/vendors/google-code-prettify/prettify.css" type="text/css" rel="stylesheet"/>
-<script src="@helpers.assets/vendors/google-code-prettify/prettify.js"></script>
+<link  href="@helpers.assets("/vendors/google-code-prettify/prettify.css")" type="text/css" rel="stylesheet"/>
+<script src="@helpers.assets("/vendors/google-code-prettify/prettify.js")"></script>
 <script>
 $(function(){
   @if(elastic){
@@ -47,7 +47,7 @@ $(function(){
   }
 
   $('#preview@uid').click(function(){
-    $('#preview-area@uid').html('<img src="@helpers.assets/common/images/indicator.gif"> Previewing...');
+    $('#preview-area@uid').html('<img src="@helpers.assets("/common/images/indicator.gif")"> Previewing...');
     $.post('@helpers.url(repository)/_preview', {
       content          : $('#content@uid').val(),
       enableWikiLink   : @enableWikiLink,

--- a/src/main/twirl/gitbucket/core/index.scala.html
+++ b/src/main/twirl/gitbucket/core/index.scala.html
@@ -13,7 +13,7 @@
     @gitbucket.core.dashboard.html.tab()
     <div class="container">
       <div class="pull-right">
-        <a href="@context.path/activities.atom"><img src="@helpers.assets/common/images/feed.png" alt="activities"></a>
+        <a href="@context.path/activities.atom"><img src="@helpers.assets("/common/images/feed.png")" alt="activities"></a>
       </div>
       @gitbucket.core.helper.html.activities(activities)
     </div>

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -7,42 +7,42 @@
     <meta charset="utf-8">
     <title>@title</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <link rel="icon" href="@helpers.assets/common/images/gitbucket.png" type="image/vnd.microsoft.icon" />
+    <link rel="icon" href="@helpers.assets("/common/images/gitbucket.png")" type="image/vnd.microsoft.icon" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="@helpers.assets/vendors/bootstrap-3.3.6/css/bootstrap.min.css" rel="stylesheet">
-    <link href="@helpers.assets/vendors/octicons-4.2.0/octicons.css" rel="stylesheet">
-    <link href="@helpers.assets/vendors/bootstrap-datetimepicker-4.17.44/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
-    <link href="@helpers.assets/vendors/colorpicker/css/bootstrap-colorpicker.css" rel="stylesheet">
-    <link href="@helpers.assets/vendors/google-code-prettify/prettify.css" type="text/css" rel="stylesheet"/>
-    <link href="@helpers.assets/vendors/facebox/facebox.css" rel="stylesheet"/>
-    <link href="@helpers.assets/vendors/AdminLTE-2.3.8/css/AdminLTE.min.css" rel="stylesheet">
-    <link href="@helpers.assets/vendors/AdminLTE-2.3.8/css/skins/skin-blue.min.css" rel="stylesheet">
-    <link href="@helpers.assets/vendors/font-awesome-4.6.3/css/font-awesome.min.css" rel="stylesheet">
-    <link href="@helpers.assets/common/css/gitbucket.css" rel="stylesheet">
-    <script src="@helpers.assets/vendors/jquery/jquery-1.12.2.min.js"></script>
-    <script src="@helpers.assets/vendors/dropzone/dropzone.js"></script>
-    <script src="@helpers.assets/common/js/validation.js"></script>
-    <script src="@helpers.assets/common/js/gitbucket.js"></script>
-    <script src="@helpers.assets/vendors/bootstrap-3.3.6/js/bootstrap.js"></script>
-    <script src="@helpers.assets/vendors/bootstrap3-typeahead/bootstrap3-typeahead.js"></script>
-    <script src="@helpers.assets/vendors/bootstrap-datetimepicker-4.17.44/js/moment.min.js"></script>
-    <script src="@helpers.assets/vendors/bootstrap-datetimepicker-4.17.44/js/bootstrap-datetimepicker.min.js"></script>
-    <script src="@helpers.assets/vendors/colorpicker/js/bootstrap-colorpicker.js"></script>
-    <script src="@helpers.assets/vendors/google-code-prettify/prettify.js"></script>
-    <script src="@helpers.assets/vendors/elastic/jquery.elastic.source.js"></script>
-    <script src="@helpers.assets/vendors/facebox/facebox.js"></script>
-    <script src="@helpers.assets/vendors/jquery-hotkeys/jquery.hotkeys.js"></script>
-    <script src="@helpers.assets/vendors/jquery-textcomplete-1.6.2/jquery.textcomplete.js"></script>
+    <link href="@helpers.assets("/vendors/bootstrap-3.3.6/css/bootstrap.min.css")" rel="stylesheet">
+    <link href="@helpers.assets("/vendors/octicons-4.2.0/octicons.css")" rel="stylesheet">
+    <link href="@helpers.assets("/vendors/bootstrap-datetimepicker-4.17.44/css/bootstrap-datetimepicker.min.css")" rel="stylesheet">
+    <link href="@helpers.assets("/vendors/colorpicker/css/bootstrap-colorpicker.css")" rel="stylesheet">
+    <link href="@helpers.assets("/vendors/google-code-prettify/prettify.css")" type="text/css" rel="stylesheet"/>
+    <link href="@helpers.assets("/vendors/facebox/facebox.css")" rel="stylesheet"/>
+    <link href="@helpers.assets("/vendors/AdminLTE-2.3.8/css/AdminLTE.min.css")" rel="stylesheet">
+    <link href="@helpers.assets("/vendors/AdminLTE-2.3.8/css/skins/skin-blue.min.css")" rel="stylesheet">
+    <link href="@helpers.assets("/vendors/font-awesome-4.6.3/css/font-awesome.min.css")" rel="stylesheet">
+    <link href="@helpers.assets("/common/css/gitbucket.css")" rel="stylesheet">
+    <script src="@helpers.assets("/vendors/jquery/jquery-1.12.2.min.js")"></script>
+    <script src="@helpers.assets("/vendors/dropzone/dropzone.js")"></script>
+    <script src="@helpers.assets("/common/js/validation.js")"></script>
+    <script src="@helpers.assets("/common/js/gitbucket.js")"></script>
+    <script src="@helpers.assets("/vendors/bootstrap-3.3.6/js/bootstrap.js")"></script>
+    <script src="@helpers.assets("/vendors/bootstrap3-typeahead/bootstrap3-typeahead.js")"></script>
+    <script src="@helpers.assets("/vendors/bootstrap-datetimepicker-4.17.44/js/moment.min.js")"></script>
+    <script src="@helpers.assets("/vendors/bootstrap-datetimepicker-4.17.44/js/bootstrap-datetimepicker.min.js")"></script>
+    <script src="@helpers.assets("/vendors/colorpicker/js/bootstrap-colorpicker.js")"></script>
+    <script src="@helpers.assets("/vendors/google-code-prettify/prettify.js")"></script>
+    <script src="@helpers.assets("/vendors/elastic/jquery.elastic.source.js")"></script>
+    <script src="@helpers.assets("/vendors/facebox/facebox.js")"></script>
+    <script src="@helpers.assets("/vendors/jquery-hotkeys/jquery.hotkeys.js")"></script>
+    <script src="@helpers.assets("/vendors/jquery-textcomplete-1.6.2/jquery.textcomplete.js")"></script>
     @repository.map { repository =>
       <meta name="go-import" content="@context.baseUrl.replaceFirst("^https?://", "")/@repository.owner/@repository.name git @repository.httpUrl" />
     }
-    <script src="@helpers.assets/vendors/AdminLTE-2.3.8/js/app.js" type="text/javascript"></script>
+    <script src="@helpers.assets("/vendors/AdminLTE-2.3.8/js/app.js")" type="text/javascript"></script>
   </head>
   <body class="skin-blue page-load @if(context.sidebarCollapse){sidebar-collapse}">
     <div class="wrapper">
       <header class="main-header">
         <a href="@context.path/" class="logo">
-          <img src="@helpers.assets/common/images/gitbucket.png" style="width: 24px; height: 24px; display: inline;"/>
+          <img src="@helpers.assets("/common/images/gitbucket.png")" style="width: 24px; height: 24px; display: inline;"/>
           GitBucket
           <span class="header-version">@gitbucket.core.GitBucketCoreModule.getVersions.last.getVersion</span>
         </a>

--- a/src/main/twirl/gitbucket/core/pulls/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/compare.scala.html
@@ -43,7 +43,7 @@
         }
       </div>
       <div class="check-conflict" style="display: none;">
-        <img src="@helpers.assets/common/images/indicator.gif"/> Checking...
+        <img src="@helpers.assets("/common/images/indicator.gif")"/> Checking...
       </div>
     </div>
     @if(commits.nonEmpty && context.loginAccount.isDefined){

--- a/src/main/twirl/gitbucket/core/pulls/conversation.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/conversation.scala.html
@@ -21,7 +21,7 @@
       <div class="check-conflict" style="display: none;">
         <div class="issue-comment-box" style="background-color: #fbeed5">
           <div class="box-content"class="issue-content" style="border: 1px solid #c09853; padding: 10px;">
-            <img src="@helpers.assets/common/images/indicator.gif"/> Checking...
+            <img src="@helpers.assets("/common/images/indicator.gif")"/> Checking...
           </div>
         </div>
       </div>

--- a/src/main/twirl/gitbucket/core/repo/delete.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/delete.scala.html
@@ -50,8 +50,8 @@
     </form>
   }
 }
-<script type="text/javascript" src="@helpers.assets/vendors/jsdifflib/difflib.js"></script>
-<link href="@helpers.assets/vendors/jsdifflib/diffview.css" type="text/css" rel="stylesheet" />
+<script type="text/javascript" src="@helpers.assets("/vendors/jsdifflib/difflib.js")"></script>
+<link href="@helpers.assets("/vendors/jsdifflib/diffview.css")" type="text/css" rel="stylesheet" />
 <script>
 $(function(){
   diffUsingJS('oldText', 'newText', 'diffText', 1);

--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -72,9 +72,9 @@
     </form>
   }
 }
-<script src="@helpers.assets/vendors/ace/ace.js" type="text/javascript" charset="utf-8"></script>
-<script type="text/javascript" src="@helpers.assets/vendors/jsdifflib/difflib.js"></script>
-<link href="@helpers.assets/vendors/jsdifflib/diffview.css" type="text/css" rel="stylesheet" />
+<script src="@helpers.assets("/vendors/ace/ace.js")" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript" src="@helpers.assets("/vendors/jsdifflib/difflib.js")"></script>
+<link href="@helpers.assets("/vendors/jsdifflib/diffview.css")" type="text/css" rel="stylesheet" />
 <script>
 $(function(){
   $('#editor').text($('#initial').val());
@@ -132,7 +132,7 @@ $(function(){
 
     @if(fileName.map(helpers.isRenderable _).getOrElse(false)) {
       // update preview
-      $('#preview').html('<img src="@helpers.assets/common/images/indicator.gif"> Previewing...');
+      $('#preview').html('<img src="@helpers.assets("/common/images/indicator.gif")"> Previewing...');
       $.post('@helpers.url(repository)/_preview', {
         content          : editor.getValue(),
         enableWikiLink   : false,

--- a/src/main/twirl/gitbucket/core/repo/forked.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/forked.scala.html
@@ -49,8 +49,8 @@
 <script>
 $(function(){
   $('a[rel*=facebox]').facebox({
-    'loadingImage': '@helpers.assets/vendors/facebox/loading.gif',
-    'closeImage': '@helpers.assets/vendors/facebox/closelabel.png'
+    'loadingImage': '@helpers.assets("/vendors/facebox/loading.gif")',
+    'closeImage': '@helpers.assets("/vendors/facebox/closelabel.png")'
   });
 
   $(document).on("click", ".js-fork-owner-select-target", function() {

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -1,5 +1,6 @@
 package gitbucket.core.view
 
+import java.text.SimpleDateFormat
 import java.util.Date
 
 import gitbucket.core.model.Account
@@ -34,18 +35,22 @@ class AvatarImageProviderSpec extends FunSpec with MockitoSugar {
 
     it("should show uploaded image even if gravatar integration is enabled") {
       implicit val context = Context(createSystemSettings(true), None, request)
-      val provider = new AvatarImageProviderImpl(Some(createAccount(Some("icon.png"))))
+      val account = createAccount((Some("icon.png")))
+      val date = new SimpleDateFormat("yyyyMMddHHmmss").format(account.updatedDate)
+      val provider = new AvatarImageProviderImpl(Some(account))
 
       assert(provider.toHtml("user", 32).toString ==
-        "<img src=\"/user/_avatar\" class=\"avatar\" style=\"width: 32px; height: 32px;\" />")
+        s"""<img src="/user/_avatar?${date}" class="avatar" style="width: 32px; height: 32px;" />""")
     }
 
     it("should show local image for no image account if gravatar integration is disabled") {
       implicit val context = Context(createSystemSettings(false), None, request)
-      val provider = new AvatarImageProviderImpl(Some(createAccount(None)))
+      val account = createAccount(None)
+      val date = new SimpleDateFormat("yyyyMMddHHmmss").format(account.updatedDate)
+      val provider = new AvatarImageProviderImpl(Some(account))
 
       assert(provider.toHtml("user", 32).toString ==
-        "<img src=\"/user/_avatar\" class=\"avatar\" style=\"width: 32px; height: 32px;\" />")
+        s"""<img src="/user/_avatar?${date}" class="avatar" style="width: 32px; height: 32px;" />""")
     }
 
     it("should show Gravatar image for specified mail address if gravatar integration is enabled") {


### PR DESCRIPTION
For reduce network connection and CPU usage, add Cache-Control header.

On my PC, _avatar image transfer requires ~30ms per user.
/plugin-assets requires 200~300ms per file.
on #1489, some CSS/JS moved to /plugin-assets, it requires maybe 1s.
Because browser caches these files, it makes good effect to CPU usage too.

max-age=3600 means 60*60sec. There is no reason to chose this time.

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
