### PR TITLE
fix CSS for PR comments layout (refs. #1366)

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -1127,7 +1127,7 @@ table.diff tbody tr.not-diff:hover td{
 }
 
 .not-diff > .comment-box-container {
-    white-space: initial;
+    white-space: normal;
     line-height: initial;
     padding: 10px;
 }


### PR DESCRIPTION
from https://developer.mozilla.org/en-US/docs/Web/CSS/white-space white-space: normal is initial value.
This PR changes `white-space: initial;` to `white-space: normal`.

broken image in #1366.

This PR fixes layout.

Internet Explorer 11:
![004051-update readme md - pull request 4 - gr1 test1 - internet explorer](https://cloud.githubusercontent.com/assets/6997928/24051227/d9ae5910-0b74-11e7-8eb4-404df0a70464.png)

Chrome:
![004015-update readme md - pull request 4 - gr1 test1 - google chrome](https://cloud.githubusercontent.com/assets/6997928/24051235/e178be06-0b74-11e7-9c0d-2d45ebfe3af9.png)


Firefox:
![004204-update readme md - pull request 4 - gr1 test1 - mozilla firefox](https://cloud.githubusercontent.com/assets/6997928/24051257/eb0240be-0b74-11e7-94d4-4e03685d20a4.png)


### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
