### PR TITLE
add permalink to issue comments

### DIFF
--- a/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
@@ -46,7 +46,9 @@
             } else {
               referenced the @issueOrPullRequest()
             }
-            @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
+            <a href="@helpers.url(repository)/issues/@issue.get.issueId#comment-@comment.commentId">
+              @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
+            </a>
           </span>
           @if(comment.action != "commit" && comment.action != "merge" && comment.action != "refer"
                 && (isManageable || context.loginAccount.map(_.userName == comment.commentedUserName).getOrElse(false))){


### PR DESCRIPTION
This PR adds permalink to issue comments.

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
