### PR TITLE
fix to align diffstat positions (refs #1503)

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/diff.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/diff.scala.html
@@ -16,9 +16,9 @@
     </div>
   </div>
   Showing <a href="javascript:void(0);" id="toggle-file-list">@diffs.size changed @helpers.plural(diffs.size, "file")</a>
-  <ul id="commit-file-list" style="display: none;">
+  <ul id="commit-file-list" style="display: none;clear:right">
   @diffs.zipWithIndex.map { case (diff, i) =>
-    <li@if(i > 0){ class="border"}>
+    <li class="border">
       <span class="pull-right diffstat" data-diff-id="@i"></span>
       <a href="#diff-@i">
         @if(diff.changeType == ChangeType.COPY || diff.changeType == ChangeType.RENAME){


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

![image](https://cloud.githubusercontent.com/assets/1295639/24070982/e930e5ce-0c0a-11e7-9f8a-6f8c87cd2b24.png)

It is strange that `class="border"` was not attached when i = 0 in the source before correction.
If there is no `class="border"` in the 1st diffstat, the 2nd diffstat will not be aligned.

![image](https://cloud.githubusercontent.com/assets/1295639/24071064/4f329af0-0c0d-11e7-9940-d7a01dd87798.png)
