### PR TITLE
Diffstat displays only top-level files in the first commit.

### DIFF
--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -538,6 +538,7 @@ object JGitUtil {
       } else {
         // initial commit
         using(new TreeWalk(git.getRepository)){ treeWalk =>
+          treeWalk.setRecursive(true)
           treeWalk.addTree(revCommit.getTree)
           val buffer = new scala.collection.mutable.ListBuffer[DiffInfo]()
           while(treeWalk.next){


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Currently, diffstat displays only top-level files at the first commit.
This patch displays diffstat for all files.

---
**fixed diffstat**

![image](https://cloud.githubusercontent.com/assets/1295639/24077631/72375862-0c97-11e7-9a45-09b41bf1004f.png)

---
**git log**

![image](https://cloud.githubusercontent.com/assets/1295639/24077632/83d8cfba-0c97-11e7-8b62-ceb788ff4988.png)

---
**currently diffstat**

![image](https://cloud.githubusercontent.com/assets/1295639/24077636/989c5a48-0c97-11e7-96b4-6fc662b8ba0e.png)
