### PR TITLE
Extending markdown code block renderer by plugin system

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/MarkdownCodeRenderer.scala
+++ b/src/main/scala/gitbucket/core/plugin/MarkdownCodeRenderer.scala
@@ -1,0 +1,14 @@
+package gitbucket.core.plugin
+
+import io.github.gitbucket.markedj.Options
+
+/**
+ * A render engine to render code in a makrdown to String.
+ */
+trait MarkdownCodeRenderer {
+
+  /**
+   * Render the given code to String.
+   */
+  def renderCode(code: String, lang: String, escaped: Boolean, options: Options): String
+}

--- a/src/main/scala/gitbucket/core/plugin/MarkdownCodeRenderer.scala
+++ b/src/main/scala/gitbucket/core/plugin/MarkdownCodeRenderer.scala
@@ -1,6 +1,7 @@
 package gitbucket.core.plugin
 
 import io.github.gitbucket.markedj.Options
+import io.github.gitbucket.markedj.Utils._
 
 /**
  * A render engine to render code in a makrdown to String.
@@ -11,4 +12,11 @@ trait MarkdownCodeRenderer {
    * Render the given code to String.
    */
   def renderCode(code: String, lang: String, escaped: Boolean, options: Options): String
+}
+
+object DefaultMarkdownCodeRenderer extends MarkdownCodeRenderer {
+  override def renderCode(code: String, lang: String, escaped: Boolean, options: Options): String = {
+    "<pre class=\"prettyprint" + (if(lang != null) s" ${options.getLangPrefix}${lang}" else "" )+ "\">" +
+    (if(escaped) code else escape(code, true)) + "</pre>"
+  }
 }

--- a/src/main/scala/gitbucket/core/plugin/Plugin.scala
+++ b/src/main/scala/gitbucket/core/plugin/Plugin.scala
@@ -60,6 +60,16 @@ abstract class Plugin {
   def renderers(registry: PluginRegistry, context: ServletContext, settings: SystemSettings): Seq[(String, Renderer)] = Nil
 
   /**
+   * Override to declare this plug-in provides markdown code renderers.
+   */
+  val markdownCodeRenderers: Seq[(String, MarkdownCodeRenderer)] = Nil
+
+  /**
+   * Override to declare this plug-in provides markdown code renderers.
+   */
+  def markdownCodeRenderers(registry: PluginRegistry, context: ServletContext, settings: SystemSettings): Seq[(String, MarkdownCodeRenderer)] = Nil
+
+  /**
    * Override to add git repository routings.
    */
   val repositoryRoutings: Seq[GitRepositoryRouting] = Nil
@@ -205,6 +215,9 @@ abstract class Plugin {
     }
     (renderers ++ renderers(registry, context, settings)).foreach { case (extension, renderer) =>
       registry.addRenderer(extension, renderer)
+    }
+    (markdownCodeRenderers ++ markdownCodeRenderers(registry, context, settings)).foreach { case (lang, codeRenderer) =>
+      registry.addMarkdownCodeRenderer(lang, codeRenderer)
     }
     (repositoryRoutings ++ repositoryRoutings(registry, context, settings)).foreach { routing =>
       registry.addRepositoryRouting(routing)

--- a/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
@@ -31,6 +31,7 @@ class PluginRegistry {
   renderers ++= Seq(
     "md" -> MarkdownRenderer, "markdown" -> MarkdownRenderer
   )
+  private val markdownCodeRenders = mutable.Map[String, MarkdownCodeRenderer]()
   private val repositoryRoutings = new ListBuffer[GitRepositoryRouting]
   private val receiveHooks = new ListBuffer[ReceiveHook]
   receiveHooks += new ProtectedBranchReceiveHook()
@@ -86,6 +87,10 @@ class PluginRegistry {
   def getRenderer(extension: String): Renderer = renderers.get(extension).getOrElse(DefaultRenderer)
 
   def renderableExtensions: Seq[String] = renderers.keys.toSeq
+
+  def addMarkdownCodeRenderer(lang: String, renderer: MarkdownCodeRenderer): Unit = markdownCodeRenders += ((lang, renderer))
+
+  def getMarkdownCodeRenderer(lang: String): MarkdownCodeRenderer = markdownCodeRenders.get(lang).getOrElse(DefaultMarkdownCodeRenderer)
 
   def addRepositoryRouting(routing: GitRepositoryRouting): Unit = repositoryRoutings += routing
 

--- a/src/main/scala/gitbucket/core/view/Markdown.scala
+++ b/src/main/scala/gitbucket/core/view/Markdown.scala
@@ -5,6 +5,7 @@ import java.util.regex.Pattern
 import java.util.Locale
 
 import gitbucket.core.controller.Context
+import gitbucket.core.plugin.PluginRegistry
 import gitbucket.core.service.{RepositoryService, RequestCache}
 import gitbucket.core.util.StringUtil
 import io.github.gitbucket.markedj._
@@ -80,8 +81,8 @@ object Markdown {
     }
 
     override def code(code: String, lang: String, escaped: Boolean): String = {
-      "<pre class=\"prettyprint" + (if(lang != null) s" ${options.getLangPrefix}${lang}" else "" )+ "\">" +
-        (if(escaped) code else escape(code, true)) + "</pre>"
+      val codeRenderer = PluginRegistry().getMarkdownCodeRenderer(lang)
+      codeRenderer.renderCode(code, lang, escaped, options)
     }
 
     override def list(body: String, ordered: Boolean): String = {


### PR DESCRIPTION
This changes provides code render in a markdown file. A plugin will be able to render a code block like the below code in markdown.

    ```plantuml
    @startuml
    Bob->Alice : hello
    @enduml
    ```

This code will be handle by a plugin.

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
