### PR TITLE
Fix broken diffstat layout at zoom in/out

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/diff.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/diff.scala.html
@@ -16,7 +16,7 @@
     </div>
   </div>
   Showing <a href="javascript:void(0);" id="toggle-file-list">@diffs.size changed @helpers.plural(diffs.size, "file")</a>
-  <ul id="commit-file-list" style="display: none;clear:right">
+  <ul id="commit-file-list" style="display: none;">
   @diffs.zipWithIndex.map { case (diff, i) =>
     <li class="border">
       <span class="pull-right diffstat" data-diff-id="@i"></span>

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -586,6 +586,7 @@ ul#commit-file-list {
 ul#commit-file-list li.border {
   padding-bottom: 2px;
   border-top: 1px solid #eee;
+  clear: right;
 }
 
 li.L0, li.L1, li.L2, li.L3, li.L4, li.L5, li.L6, li.L7, li.L8, li.L9 {


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

**currently zoom out**
![image](https://cloud.githubusercontent.com/assets/1295639/24248174/bb665fb0-1011-11e7-91c7-3565b9ec9375.png)

**currently zoom in**
![image](https://cloud.githubusercontent.com/assets/1295639/24248205/e0d886ec-1011-11e7-999f-592e936fcd45.png)
