### PR TITLE
Fix #1516 send noimage.png if user is removed.

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -150,20 +150,21 @@ trait AccountControllerBase extends AccountManagementControllerBase {
 
   get("/:userName/_avatar"){
     val userName = params("userName")
+    contentType = "image/png"
     getAccountByUserName(userName).map{ account =>
       response.setDateHeader("Last-Modified", account.updatedDate.getTime)
       account.image.map{ image =>
         RawData(FileUtil.getMimeType(image), new java.io.File(getUserUploadDir(userName), image))
       }.getOrElse{
-        contentType = "image/png"
         (if (account.isGroupAccount) {
           TextAvatarUtil.textGroupAvatar(account.fullName)
         } else {
           TextAvatarUtil.textAvatar(account.fullName)
-        }).getOrElse(Thread.currentThread.getContextClassLoader.getResourceAsStream("noimage.png"))
+        }).get
       }
     }.getOrElse{
-      NotFound()
+      response.setHeader("Cache-Control", "max-age=3600")
+      Thread.currentThread.getContextClassLoader.getResourceAsStream("noimage.png")
     }
   }
 

--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -151,16 +151,16 @@ trait AccountControllerBase extends AccountManagementControllerBase {
   get("/:userName/_avatar"){
     val userName = params("userName")
     contentType = "image/png"
-    getAccountByUserName(userName).map{ account =>
+    getAccountByUserName(userName).flatMap{ account =>
       response.setDateHeader("Last-Modified", account.updatedDate.getTime)
       account.image.map{ image =>
-        RawData(FileUtil.getMimeType(image), new java.io.File(getUserUploadDir(userName), image))
+        Some(RawData(FileUtil.getMimeType(image), new java.io.File(getUserUploadDir(userName), image)))
       }.getOrElse{
-        (if (account.isGroupAccount) {
+        if (account.isGroupAccount) {
           TextAvatarUtil.textGroupAvatar(account.fullName)
         } else {
           TextAvatarUtil.textAvatar(account.fullName)
-        }).get
+        }
       }
     }.getOrElse{
       response.setHeader("Cache-Control", "max-age=3600")


### PR DESCRIPTION
This PR fixes #1516.
Sorry, I didn't care to removed user in #1497.

Before:
![205518-manage users - google chrome](https://cloud.githubusercontent.com/assets/6997928/24578784/0802730a-1723-11e7-9c6d-335a4202bf40.png)


After:
![205802-manage users - google chrome](https://cloud.githubusercontent.com/assets/6997928/24578785/0a4ea156-1723-11e7-8efe-d1e1a4240caa.png)


### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing (mysql test is failed by timeout)
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
