### PR TITLE
Add caution message when using H2 database

### DIFF
--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -1,4 +1,5 @@
 @(info: Option[Any])(implicit context: gitbucket.core.controller.Context)
+@import gitbucket.core.util.DatabaseConfig
 @gitbucket.core.html.main("System settings"){
   @gitbucket.core.admin.html.menu("system"){
     @gitbucket.core.helper.html.information(info)
@@ -20,7 +21,17 @@
             </tr>
             <tr>
               <td>DATABASE_URL</td>
-              <td>@gitbucket.core.util.DatabaseConfig.url</td>
+              @if(DatabaseConfig.url.startsWith("jdbc:h2:")) {
+              <td class="danger">
+                <p>@gitbucket.core.util.DatabaseConfig.url</p>
+                <p>H2 database should be used for evaluation purpose only.</p>
+                <p>
+                  Please configure using external database explained <a href="https://github.com/gitbucket/gitbucket/wiki/External-database-configuration">here</a>.
+                </p>
+              </td>
+              }else{
+                <td>@gitbucket.core.util.DatabaseConfig.url</td>
+              }
             </tr>
           </table>
           <!--====================================================================-->

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -24,7 +24,7 @@
               @if(DatabaseConfig.url.startsWith("jdbc:h2:")) {
               <td class="danger">
                 <p>@gitbucket.core.util.DatabaseConfig.url</p>
-                <p>H2 database should be used for evaluation purpose only.</p>
+                <p>Embedded H2 database should be used for evaluation purpose only.</p>
                 <p>
                   Please configure using external database explained <a href="https://github.com/gitbucket/gitbucket/wiki/External-database-configuration">here</a>.
                 </p>

--- a/src/main/twirl/gitbucket/core/signin.scala.html
+++ b/src/main/twirl/gitbucket/core/signin.scala.html
@@ -1,6 +1,7 @@
 @(userName: Option[Any] = None,
   password: Option[Any] = None,
   error: Option[Any] = None)(implicit context: gitbucket.core.controller.Context)
+@import gitbucket.core.util.DatabaseConfig
 @gitbucket.core.html.main("Sign in"){
   <div class="content-wrapper main-center">
     <div class="content body">
@@ -9,6 +10,12 @@
           <div class="alert alert-info" style="background-color: white; color: #555; border-color: #4183c4; font-size: small; line-height: 120%;">
             <button type="button" class="close" data-dismiss="alert">&times;</button>
             @Html(information)
+          </div>
+        }
+        @if(DatabaseConfig.url.startsWith("jdbc:h2:")) {
+          <div class="alert alert-warning">
+            <button type="button" class="close" data-dismiss="alert">&times;</button>
+            H2 database should be used for evaluation purpose only.
           </div>
         }
         @gitbucket.core.helper.html.error(error)

--- a/src/main/twirl/gitbucket/core/signin.scala.html
+++ b/src/main/twirl/gitbucket/core/signin.scala.html
@@ -1,7 +1,6 @@
 @(userName: Option[Any] = None,
   password: Option[Any] = None,
   error: Option[Any] = None)(implicit context: gitbucket.core.controller.Context)
-@import gitbucket.core.util.DatabaseConfig
 @gitbucket.core.html.main("Sign in"){
   <div class="content-wrapper main-center">
     <div class="content body">
@@ -10,12 +9,6 @@
           <div class="alert alert-info" style="background-color: white; color: #555; border-color: #4183c4; font-size: small; line-height: 120%;">
             <button type="button" class="close" data-dismiss="alert">&times;</button>
             @Html(information)
-          </div>
-        }
-        @if(DatabaseConfig.url.startsWith("jdbc:h2:")) {
-          <div class="alert alert-warning">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            H2 database should be used for evaluation purpose only.
           </div>
         }
         @gitbucket.core.helper.html.error(error)


### PR DESCRIPTION
This PR adds messages when using H2 database. Because H2 is not stable for production environment.

In sign in dialog:
![192658-sign in - google chrome](https://cloud.githubusercontent.com/assets/6997928/24578850/bfe57a70-1724-11e7-907c-515f63476025.png)

In System settings:
![214653-system settings - google chrome](https://cloud.githubusercontent.com/assets/6997928/24578852/c8b8a974-1724-11e7-9db4-881952112157.png)


### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
