### PR TITLE
update MySQL v5_7_latest in test

### DIFF
--- a/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
+++ b/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
@@ -29,7 +29,7 @@ class GitBucketCoreModuleSpec extends FunSuite {
   }
 
   test("Migration MySQL", ExternalDBTest){
-    val config = aMysqldConfig(v5_7_10)
+    val config = aMysqldConfig(v5_7_latest)
       .withPort(3306)
       .withUser("sa", "sa")
       .withCharset(Charset.UTF8)


### PR DESCRIPTION
v5_7_10 does not work with Sierra

https://github.com/wix/wix-embedded-mysql/blob/wix-embedded-mysql-2.1.4/src/main/java/com/wix/mysql/distribution/Version.java#L86
