### PR TITLE
s/newInstance()/getDeclaredConstructor().newInstance()

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
@@ -175,7 +175,7 @@ object PluginRegistry {
       }).foreach { pluginJar =>
         val classLoader = new URLClassLoader(Array(pluginJar.toURI.toURL), Thread.currentThread.getContextClassLoader)
         try {
-          val plugin = classLoader.loadClass("Plugin").newInstance().asInstanceOf[Plugin]
+          val plugin = classLoader.loadClass("Plugin").getDeclaredConstructor().newInstance().asInstanceOf[Plugin]
 
           // Migration
           val solidbase = new Solidbase()


### PR DESCRIPTION
`java.lang.Class#newInstance` deprecated since Java 9

http://download.java.net/java/jdk9/docs/api/java/lang/Class.html#newInstance--