### PR TITLE
To have compatibility with GitHub/GitHubEnterprise

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -672,10 +672,9 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     val revision = name.stripSuffix(suffix)
     
     using(Git.open(getRepositoryDir(repository.owner, repository.name))){ git =>
-      val revCommit = JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(revision))
-      
-      val sha1 = git.getRepository.resolve(revision).getName()
-      
+      val oid = git.getRepository.resolve(revision)
+      val revCommit = JGitUtil.getRevCommitFromId(git, oid)
+      val sha1 = oid.getName()     
       val filename = repository.name + "-" +
         (if(sha1.startsWith(revision)) sha1 else revision).replace('/','-') + suffix
 

--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -670,12 +670,14 @@ trait RepositoryViewerControllerBase extends ControllerBase {
 
   private def archiveRepository(name: String, suffix: String, repository: RepositoryService.RepositoryInfo): Unit = {
     val revision = name.stripSuffix(suffix)
-
-    val filename = repository.name + "-" +
-      (if(revision.length == 40) revision.substring(0, 10) else revision).replace('/', '-') + suffix
-
+    
     using(Git.open(getRepositoryDir(repository.owner, repository.name))){ git =>
       val revCommit = JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(revision))
+      
+      val sha1 = git.getRepository.resolve(revision).getName()
+      
+      val filename = repository.name + "-" +
+        (if(sha1.startsWith(revision)) sha1 else revision).replace('/','-') + suffix
 
       contentType = "application/octet-stream"
       response.setHeader("Content-Disposition", s"attachment; filename=${filename}")


### PR DESCRIPTION
when archive downloading with sha1, even if supplied part of sha1,
GH/GHE gives a filename with full(long) sha1.

This patch make GitBucket to be compatible with GH/GHE behaviour.

You can check that difference by following url.
I upload same repo as in GitHuB to GitBucket demo site.
 
GitHub:  
https://github.com/MunGell/awesome-for-beginners/archive/fc7d067.tar.gz
GitBucket:
http://gitbucket.herokuapp.com/root/awesome-for-beginners/archive/fc7d067.tar.gz

GH returns,
awesome-for-beginners-fc7d067cb13559f248bb362253ff2fa3b2617aba.tar.gz
Otherwise GitBucket returns,
awesome-for-beginners-fc7d067.tar.gz

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
