### PR TITLE
Fix loading avatar from resources

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -163,7 +163,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
       }
     }.getOrElse{
       response.setHeader("Cache-Control", "max-age=3600")
-      Thread.currentThread.getContextClassLoader.getResourceAsStream("noimage.png")
+      Thread.currentThread.getContextClassLoader.getResourceAsStream("/noimage.png")
     }
   }
 


### PR DESCRIPTION
Unknown users avatars (the ones who don't have account created in Gitbucket) wasn't displaying (404 error).

After investigating, I found that resource path was invalid.

Before:
![before](https://cloud.githubusercontent.com/assets/25744491/25006539/97c202b0-205d-11e7-8d4a-ddb9e4dec7ab.png)

After:
![after](https://cloud.githubusercontent.com/assets/25744491/25006548/a2702390-205d-11e7-86ef-28e196a71d90.png)
