### PR TITLE
Word wrap commit descriptions

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -556,6 +556,7 @@ pre.commit-description {
   background-color: transparent;
   padding: 2px;
   margin: 0px;
+  white-space: pre-wrap;
 }
 
 #repository-url {


### PR DESCRIPTION
As @joshuacurtiss noticed in #1539, commit descriptions do not word wrap. Also because of this "Browse code" link was missing/hidden (see screenshots).

I fixed it as @joshuacurtiss suggested. Thanks!

Before fix:
![before](https://cloud.githubusercontent.com/assets/25744491/25066873/00f9d95c-2233-11e7-957d-5408380c51ef.png)

After fix:
![after](https://cloud.githubusercontent.com/assets/25744491/25066875/0898e27a-2233-11e7-8e78-667d11857b14.png)

