### PR TITLE
root dir in archive file

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -675,8 +675,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       val oid = git.getRepository.resolve(revision)
       val revCommit = JGitUtil.getRevCommitFromId(git, oid)
       val sha1 = oid.getName()     
-      val filename = repository.name + "-" +
-        (if(sha1.startsWith(revision)) sha1 else revision).replace('/','-') + suffix
+      val repositorySuffix = (if(sha1.startsWith(revision)) sha1 else revision).replace('/','-')
+      val filename = repository.name + "-" + repositorySuffix + suffix
 
       contentType = "application/octet-stream"
       response.setHeader("Content-Disposition", s"attachment; filename=${filename}")
@@ -684,6 +684,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
 
       git.archive
          .setFormat(suffix.tail)
+         .setPrefix(repository.name + "-" + repositorySuffix + "/")
          .setTree(revCommit)
          .setOutputStream(response.getOutputStream)
          .call()


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
----
With GitHub/GitHub Enterprise, they serve archive file that has root dir.
root dir naming rule is same as the name of archive file.
e.g. 
- hogehoge-master.tar.gz
- hogehoge-fc7d067cb13559f248bb362253ff2fa3b2617aba.tar.gz

The archive file that GitBucket makes, does not have root dir.
So this patch make GitBucket to output same directory structure as GH/GHE.