### PR TITLE
Modify branch filter method

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -675,8 +675,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       val oid = git.getRepository.resolve(revision)
       val revCommit = JGitUtil.getRevCommitFromId(git, oid)
       val sha1 = oid.getName()     
-      val filename = repository.name + "-" +
-        (if(sha1.startsWith(revision)) sha1 else revision).replace('/','-') + suffix
+      val repositorySuffix = (if(sha1.startsWith(revision)) sha1 else revision).replace('/','-')
+      val filename = repository.name + "-" + repositorySuffix + suffix
 
       contentType = "application/octet-stream"
       response.setHeader("Content-Disposition", s"attachment; filename=${filename}")
@@ -684,6 +684,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
 
       git.archive
          .setFormat(suffix.tail)
+         .setPrefix(repository.name + "-" + repositorySuffix + "/")
          .setTree(revCommit)
          .setOutputStream(response.getOutputStream)
          .call()

--- a/src/main/twirl/gitbucket/core/helper/branchcontrol.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/branchcontrol.scala.html
@@ -31,7 +31,7 @@
     $('#branch-control-input').keyup(function() {
       var inputVal = $('#branch-control-input').val();
       $.each($('#branch-control-input').parent().parent().find('a'), function(index, elem) {
-        if (!inputVal || !elem.text.trim() || elem.text.trim().lastIndexOf(inputVal, 0) >= 0) {
+        if (!inputVal || !elem.text.trim() || elem.text.trim().match(new RegExp(inputVal,'i'))) {
           $(elem).parent().show();
         } else {
           $(elem).parent().hide();


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
====

Currently, case sensitive and forward match.
This patch makes to achieve case insensitive and intermediate match.
When having MANY branches, this feature must be useful.
(GitHub seems to have same feature)