### PR TITLE
modify branch filter method

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/branchcontrol.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/branchcontrol.scala.html
@@ -31,7 +31,7 @@
     $('#branch-control-input').keyup(function() {
       var inputVal = $('#branch-control-input').val();
       $.each($('#branch-control-input').parent().parent().find('a'), function(index, elem) {
-        if (!inputVal || !elem.text.trim() || elem.text.trim().lastIndexOf(inputVal, 0) >= 0) {
+        if (!inputVal || !elem.text.trim() || elem.text.trim().match(new RegExp(inputVal,'i'))) {
           $(elem).parent().show();
         } else {
           $(elem).parent().hide();


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
----
I recreate this PR in response to a comment in #1549.

This patch enables GitBucket to filter branch names by intermediate & case insensitive match.

