### PR TITLE
Graceful shutdown on Jetty requires StatisticsHandler

### DIFF
--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -1,4 +1,6 @@
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 import java.io.File;
@@ -93,7 +95,9 @@ public class JettyLauncher {
             context.setInitParameter("org.scalatra.ForceHttps", "true");
         }
 
-        server.setHandler(context);
+        Handler handler = addStatisticsHandler(context);
+
+        server.setHandler(handler);
         server.setStopAtShutdown(true);
         server.setStopTimeout(7_000);
         server.start();
@@ -121,5 +125,13 @@ public class JettyLauncher {
             }
         }
         dir.delete();
+    }
+
+    private static Handler addStatisticsHandler(Handler handler) {
+        // The graceful shutdown is implemented via the statistics handler.
+        // See the following: https://bugs.eclipse.org/bugs/show_bug.cgi?id=420142
+        final StatisticsHandler statisticsHandler = new StatisticsHandler();
+        statisticsHandler.setHandler(handler);
+        return statisticsHandler;
     }
 }


### PR DESCRIPTION
The Jetty's graceful shutdown is provided via the [Statistics Handler](https://www.eclipse.org/jetty/documentation/9.3.x/statistics-handler.html). Therefore, the graceful shutdown implemented by #1267 does not work.

See the following: 
* [Bug 420142 - Jetty9's graceful shutdown is not graceful](https://bugs.eclipse.org/bugs/show_bug.cgi?id=420142)
* [Commit: 420142 reimplemented graceful shutdown](https://github.com/eclipse/jetty.project/commit/28566c72c8bb091b272fd7b25fb7b4389363b024)
