### PR TITLE
Disabling Server header on Jetty

### DIFF
--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -1,3 +1,5 @@
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -5,6 +7,8 @@ import java.io.File;
 import java.net.URL;
 import java.net.InetSocketAddress;
 import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.Collection;
 
 public class JettyLauncher {
     public static void main(String[] args) throws Exception {
@@ -61,6 +65,11 @@ public class JettyLauncher {
 //        connector.setSoLingerTime(-1);
 //        connector.setPort(port);
 //        server.addConnector(connector);
+
+        // Disabling Server header
+        Arrays.stream(server.getConnectors()).map(Connector::getConnectionFactories).flatMap(Collection::stream)
+                .filter(HttpConnectionFactory.class::isInstance).map(HttpConnectionFactory.class::cast)
+                .map(HttpConnectionFactory::getHttpConfiguration).forEach(config -> config.setSendServerVersion(false));
 
         WebAppContext context = new WebAppContext();
 

--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -1,3 +1,4 @@
+import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -9,8 +10,6 @@ import java.io.File;
 import java.net.URL;
 import java.net.InetSocketAddress;
 import java.security.ProtectionDomain;
-import java.util.Arrays;
-import java.util.Collection;
 
 public class JettyLauncher {
     public static void main(String[] args) throws Exception {
@@ -69,9 +68,13 @@ public class JettyLauncher {
 //        server.addConnector(connector);
 
         // Disabling Server header
-        Arrays.stream(server.getConnectors()).map(Connector::getConnectionFactories).flatMap(Collection::stream)
-                .filter(HttpConnectionFactory.class::isInstance).map(HttpConnectionFactory.class::cast)
-                .map(HttpConnectionFactory::getHttpConfiguration).forEach(config -> config.setSendServerVersion(false));
+        for (Connector connector : server.getConnectors()) {
+            for (ConnectionFactory factory : connector.getConnectionFactories()) {
+                if (factory instanceof HttpConnectionFactory) {
+                    ((HttpConnectionFactory) factory).getHttpConfiguration().setSendServerVersion(false);
+                }
+            }
+        }
 
         WebAppContext context = new WebAppContext();
 


### PR DESCRIPTION
There is no point in returning the `Server` header.

For reference, Tomcat 9.0.x and 8.5.x no longer set the Server header by default.
