### PR TITLE
Fix incorrect initial height of textarea

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/preview.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/preview.scala.html
@@ -44,6 +44,7 @@
 $(function(){
   @if(elastic){
     $('#content@uid').elastic();
+    $('#content@uid').trigger('blur');
   }
 
   $('#preview@uid').click(function(){


### PR DESCRIPTION
In the Elastic jQuery plugin, recalculation of the height after the blur event is incorrect. Therefore, as shown in the figure below, the height changes only by switching the focus of the textarea.

![gitbucket-incorrect-initial-height](https://cloud.githubusercontent.com/assets/7430980/25616020/6b1f9afc-2f75-11e7-999f-53b9857934db.png)
[EDITED] `before`: initial state, `after`: after switching focus. (focus and unfocus)

This PR fixes the height by explicitly calling the blur event after the `elastic` is initialized.

