### PR TITLE
Add support use mail address as user name when using LDAP

### DIFF
--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -53,6 +53,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
         "bindPassword"             -> trim(label("Bind Password", optional(text()))),
         "baseDN"                   -> trim(label("Base DN", text(required))),
         "userNameAttribute"        -> trim(label("User name attribute", text(required))),
+        "useMailAddressAsUserName" -> trim(label("Use mail address as user name", optional(boolean()))),
         "additionalFilterCondition"-> trim(label("Additional filter condition", optional(text()))),
         "fullNameAttribute"        -> trim(label("Full name attribute", optional(text()))),
         "mailAttribute"            -> trim(label("Mail address attribute", optional(text()))),
@@ -67,6 +68,9 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
       } else None,
       if(settings.ssh && settings.sshHost.isEmpty){
         Some("sshHost" -> "SSH host is required if SSH access is enabled.")
+      } else None,
+      if(settings.ldapAuthentication && settings.ldap.get.useMailAddressAsUserName.getOrElse(false) && settings.ldap.get.mailAttribute.getOrElse("").isEmpty){
+        Some("ldap.mailAttribute" -> "Mail address attribute is required if Use mail address as user name is checked.")
       } else None
     ).flatten
   }

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -46,6 +46,7 @@ trait SystemSettingsService {
           ldap.bindPassword.foreach(x => props.setProperty(LdapBindPassword, x))
           props.setProperty(LdapBaseDN, ldap.baseDN)
           props.setProperty(LdapUserNameAttribute, ldap.userNameAttribute)
+          ldap.useMailAddressAsUserName.foreach(x => props.setProperty(LdapUseMailAddressAsUserName, x.toString))
           ldap.additionalFilterCondition.foreach(x => props.setProperty(LdapAdditionalFilterCondition, x))
           ldap.fullNameAttribute.foreach(x => props.setProperty(LdapFullNameAttribute, x))
           ldap.mailAttribute.foreach(x => props.setProperty(LdapMailAddressAttribute, x))
@@ -103,6 +104,7 @@ trait SystemSettingsService {
             getOptionValue(props, LdapBindPassword, None),
             getValue(props, LdapBaseDN, ""),
             getValue(props, LdapUserNameAttribute, ""),
+            getOptionValue[Boolean](props, LdapUseMailAddressAsUserName, None),
             getOptionValue(props, LdapAdditionalFilterCondition, None),
             getOptionValue(props, LdapFullNameAttribute, None),
             getOptionValue(props, LdapMailAddressAttribute, None),
@@ -157,6 +159,7 @@ object SystemSettingsService {
     bindPassword: Option[String],
     baseDN: String,
     userNameAttribute: String,
+    useMailAddressAsUserName: Option[Boolean],
     additionalFilterCondition: Option[String],
     fullNameAttribute: Option[String],
     mailAttribute: Option[String],
@@ -213,6 +216,7 @@ object SystemSettingsService {
   private val LdapBindPassword = "ldap.bind_password"
   private val LdapBaseDN = "ldap.baseDN"
   private val LdapUserNameAttribute = "ldap.username_attribute"
+  private val LdapUseMailAddressAsUserName = "ldap.useMailAddressAsUserName"
   private val LdapAdditionalFilterCondition = "ldap.additional_filter_condition"
   private val LdapFullNameAttribute = "ldap.fullname_attribute"
   private val LdapMailAddressAttribute = "ldap.mail_attribute"

--- a/src/main/scala/gitbucket/core/util/LDAPUtil.scala
+++ b/src/main/scala/gitbucket/core/util/LDAPUtil.scala
@@ -80,7 +80,7 @@ object LDAPUtil {
       } else {
         findMailAddress(conn, userDN, ldapSettings.userNameAttribute, userName, ldapSettings.mailAttribute.get) match {
           case Some(mailAddress) => Right(LDAPUserInfo(
-            userName    = getUserNameFromMailAddress(userName),
+            userName    = getUserNameFromMailAddress(if (ldapSettings.useMailAddressAsUserName.getOrElse(false)) mailAddress else userName),
             fullName    = ldapSettings.fullNameAttribute.flatMap { fullNameAttribute =>
               findFullName(conn, userDN, ldapSettings.userNameAttribute, userName, fullNameAttribute)
             }.getOrElse(userName),

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -208,6 +208,13 @@
               </div>
             </div>
             <div class="form-group">
+              <label class="control-label col-md-3">Use mail address as user name</label>
+              <div class="col-md-9">
+                <input type="checkbox" name="ldap.useMailAddressAsUserName"@if(context.settings.ldap.flatMap(_.useMailAddressAsUserName).getOrElse(false)){ checked}/>
+                <span class="muted collapse in">If checked, use the part of the mail address that appears to the left of the @@ symbol (hereinafter called "PREFIX") as the user name. The user name attribute is used only to identify the user on login. Note: the PREFIX must be unique within the search base of the LDAP directory.</span>
+              </div>
+            </div>
+            <div class="form-group">
               <label class="control-label col-md-3" for="ldapAdditionalFilterCondition">Additional filter condition</label>
               <div class="col-md-9">
                 <input type="text" id="ldapAdditionalFilterCondition" name="ldap.additionalFilterCondition" class="form-control" value="@context.settings.ldap.map(_.additionalFilterCondition)"/>


### PR DESCRIPTION
This PR provides an option to use the part of the mail address that appears to the left of the @ symbol (hereinafter called "PREFIX") as the user name when using LDAP.
If using this option, the user name attribute is used only to identify the user on login.

IMHO, a large bandwidth is required to support user aliases related to #336, #652, and #1157, but in many use-cases, the PREFIX of the mail address registered in LDAP becomes unique and can be used instead of aliases. So this PR could be a good start.

#### 1. System settings
![001_system-settings](https://cloud.githubusercontent.com/assets/7430980/25649674/6da4897a-3012-11e7-8b16-36b77d6573a9.png)

#### 2. Login
uid=`12345678`, mail=`john-doe@users.noreply.github.com`, sn=`John Doe`
![002_login](https://cloud.githubusercontent.com/assets/7430980/25649675/6da755ba-3012-11e7-81cb-ac63e34cead5.png)

#### 3. Profile
![003_profile](https://cloud.githubusercontent.com/assets/7430980/25649676/6daf0b66-3012-11e7-963f-49e7ed469070.png)

#### 4. News feed
![004_news-feed](https://cloud.githubusercontent.com/assets/7430980/25649677/6db3446a-3012-11e7-9c70-ffd551f5524f.png)
