### PR TITLE
Remove SLF4J JDK14 binding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons"              %  "commons-compress"             % "1.11",
   "org.apache.commons"              %  "commons-email"                % "1.4",
   "org.apache.httpcomponents"       %  "httpclient"                   % "4.5.1",
-  "org.apache.sshd"                 %  "apache-sshd"                  % "1.2.0",
+  "org.apache.sshd"                 %  "apache-sshd"                  % "1.2.0" exclude("org.slf4j","slf4j-jdk14"),
   "org.apache.tika"                 %  "tika-core"                    % "1.13",
   "com.github.takezoe"              %% "blocking-slick-32"            % "0.0.8",
   "joda-time"                       %  "joda-time"                    % "2.9.6",


### PR DESCRIPTION
GitBucket is using the assembly version of Apache Mina SSHD which contains all optional libraries. Therefore, GitBucket's WAR contains unnecessary dependencies such as SLF4J JDK14 binding.

This PR removes SLF4J JDK14 binding from dependencies to avoid collision of SLF4J binding. However, in principle, should use Apache Mina SSHD Core directly. See also https://github.com/gitbucket/gitbucket/issues/1109#issuecomment-258848322.
