### PR TITLE
Make read LDAP bind password from environment variables

### DIFF
--- a/src/main/scala/gitbucket/core/util/LDAPUtil.scala
+++ b/src/main/scala/gitbucket/core/util/LDAPUtil.scala
@@ -18,6 +18,7 @@ object LDAPUtil {
   private val logger = LoggerFactory.getLogger(getClass().getName())
 
   private val LDAP_DUMMY_MAL = "@ldap-devnull"
+  private val ENV_NAME_LDAP_BIND_PASSWORD = "GITBUCKET_LDAP_BIND_PASSWORD"
 
   /**
    * Returns true if mail address ends with "@ldap-devnull"
@@ -46,7 +47,7 @@ object LDAPUtil {
       host     = ldapSettings.host,
       port     = ldapSettings.port.getOrElse(SystemSettingsService.DefaultLdapPort),
       dn       = ldapSettings.bindDN.getOrElse(""),
-      password = ldapSettings.bindPassword.getOrElse(""),
+      password = ldapSettings.bindPassword.getOrElse(sys.env.getOrElse(ENV_NAME_LDAP_BIND_PASSWORD, "")),
       tls      = ldapSettings.tls.getOrElse(false),
       ssl      = ldapSettings.ssl.getOrElse(false),
       keystore = ldapSettings.keystore.getOrElse(""),

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -191,6 +191,7 @@
               <div class="col-md-9">
                 <input type="password" id="ldapBindPassword" name="ldap.bindPassword" class="form-control" value="@context.settings.ldap.map(_.bindPassword)"/>
                 <span id="error-ldap_bindPassword" class="error"></span>
+                <span class="muted collapse in">If you use the environment variable "GITBUCKET_LDAP_BIND_PASSWORD", leave this field blank.</span>
               </div>
             </div>
             <div class="form-group">


### PR DESCRIPTION
I think that a realistic way to protect the LDAP bind password that meets the following minimum requirements is to use environment variables.

1. GitBucket should be able to use with operating system's process manager such as Upstart, systemd, and Task Scheduler. In other words, do not use the interactive interface.
1. System users, processes, and applications that can read the LDAP bind password should be minimal.

It is important to note that encryption does not provide any value unless you use an external security module (e.g. HSM) or agents together.

#### Example with systemd
```bash
cat << '_EOF_' > /etc/systemd/system/gitbucket.service
[Unit]
Description=GitBucket
After=network.target

[Service]
User=gitbucket
Environment="GITBUCKET_LDAP_BIND_PASSWORD=secret"
ExecStart=/usr/bin/java -Xms1024m -Xmx1024m -Djava.net.preferIPv4Stack=true -jar /usr/local/lib/gitbucket/gitbucket.war --gitbucket.home=/var/lib/gitbucket
Restart=always
PrivateTmp=true

[Install]
WantedBy=multi-user.target
_EOF_

chmod 400 /etc/systemd/system/gitbucket.service
systemctl daemon-reload
systemctl enable gitbucket.service
systemctl start gitbucket.service
```

Closes #634.