### PR TITLE
dropdown input filter element id from placeholder fix

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/dropdown.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/dropdown.scala.html
@@ -3,7 +3,7 @@
   style : String  = "",
   right : Boolean = false,
   filter: String = "")(body: Html)
-@defining(if(filter.isEmpty) "" else filter + "-" + scala.util.Random.alphanumeric.take(4).mkString){ filterId =>
+@defining(if(filter.isEmpty) "" else filter.replaceAll("[^a-zA-Z0-9]","_") + "-" + scala.util.Random.alphanumeric.take(4).mkString){ filterId =>
   <div class="btn-group" @if(style.nonEmpty){style="@style"}>
     <button
         class="dropdown-toggle btn btn-default btn-sm" data-toggle="dropdown">


### PR DESCRIPTION
if html.dropdown specified with filter placeholder that includes inhibit character, dropdown filter does not work.
Current, dropdown filter element id is created by placeholder string + random 4 characters.
If placeholder includes inhibit character for html id, (e.g. '\s' , '/' and so on)
input filter element does not recognized by that id.
This patch replace characters(except [a-zA-Z0-9]) to "_"( allowed to use in id ).

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
