### PR TITLE
Add Scala-IDE specific files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ project/plugins/project/
 .classpath
 .project
 .cache
+.cache-main
+.cache-tests
 .settings
 
 # IntelliJ specific


### PR DESCRIPTION
The files `.cache-main` and `.cache-tests` appear to be generated by the Scala IDE.