### PR TITLE
Disabling directory listing feature on Jetty

### DIFF
--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -96,6 +96,9 @@ public class JettyLauncher {
         }
         context.setTempDirectory(tmpDir);
 
+        // Disabling the directory listing feature.
+        context.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+
         ProtectionDomain domain = JettyLauncher.class.getProtectionDomain();
         URL location = domain.getCodeSource().getLocation();
 


### PR DESCRIPTION
Currently, If using `JettyLauncher`, the directory listing feature is enabled. Also, `NullPointerException` occurs when accessing `/assets`.
```
java.lang.NullPointerException
        at slick.jdbc.StatementInvoker.results(StatementInvoker.scala:33)
        at slick.jdbc.StatementInvoker.iteratorTo(StatementInvoker.scala:22)
        at slick.jdbc.Invoker.foreach(Invoker.scala:48)
        at slick.jdbc.Invoker.foreach$(Invoker.scala:47)
        at slick.jdbc.StatementInvoker.foreach(StatementInvoker.scala:16)
        at slick.jdbc.Invoker.firstOption(Invoker.scala:24)
        at slick.jdbc.Invoker.firstOption$(Invoker.scala:22)
        at slick.jdbc.StatementInvoker.firstOption(StatementInvoker.scala:16)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingQueryInvoker.firstOption(BlockingProfile.scala:90)
        at gitbucket.core.service.RepositoryService.getRepository(RepositoryService.scala:213)
        at gitbucket.core.service.RepositoryService.getRepository$(RepositoryService.scala:212)
        at gitbucket.core.controller.RepositoryViewerController.getRepository(RepositoryViewerController.scala:32)
        at gitbucket.core.util.ReferrerAuthenticator.$anonfun$authenticate$6(Authenticator.scala:99)
        at gitbucket.core.util.SyntaxSugars$.defining(SyntaxSugars.scala:12)
        at gitbucket.core.util.ReferrerAuthenticator.authenticate(Authenticator.scala:98)
        at gitbucket.core.util.ReferrerAuthenticator.referrersOnly(Authenticator.scala:93)
        at gitbucket.core.util.ReferrerAuthenticator.referrersOnly$(Authenticator.scala:93)
        at gitbucket.core.controller.RepositoryViewerController.referrersOnly(RepositoryViewerController.scala:32)
        at gitbucket.core.controller.RepositoryViewerControllerBase.$anonfun$$init$$3(RepositoryViewerController.scala:137)
        ...
```
