### PR TITLE
Fix incorrect redirect URL and authorization in Update branch feature

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -153,7 +153,7 @@ trait PullRequestsControllerBase extends ControllerBase {
     } getOrElse NotFound()
   })
 
-  post("/:owner/:repository/pull/:id/update_branch")(writableUsersOnly { baseRepository =>
+  post("/:owner/:repository/pull/:id/update_branch")(readableUsersOnly { baseRepository =>
     (for {
       issueId <- params("id").toIntOpt
       loginAccount <- context.loginAccount
@@ -217,7 +217,7 @@ trait PullRequestsControllerBase extends ControllerBase {
           }
         }
       }
-      redirect(s"/${repository.owner}/${repository.name}/pull/${issueId}")
+      redirect(s"/${baseRepository.owner}/${baseRepository.name}/pull/${issueId}")
 
     }) getOrElse NotFound()
   })


### PR DESCRIPTION
If the branch is out-of-date in PR, the update branch feature can be used. However, in some cases, this feature does not work.

This PR fixes following:
* Redirect to incorrect URL after updating branch.
* The owner of the PR's source repository can not use the Update branch feature.
