### PR TITLE
Load plugins alphabetically

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistory.scala
@@ -172,7 +172,7 @@ object PluginRegistry {
     if(pluginDir.exists && pluginDir.isDirectory){
       pluginDir.listFiles(new FilenameFilter {
         override def accept(dir: File, name: String): Boolean = name.endsWith(".jar")
-      }).foreach { pluginJar =>
+      }).sortBy(_.getName).foreach { pluginJar =>
         val classLoader = new URLClassLoader(Array(pluginJar.toURI.toURL), Thread.currentThread.getContextClassLoader)
         try {
           val plugin = classLoader.loadClass("Plugin").getDeclaredConstructor().newInstance().asInstanceOf[Plugin]


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Currently, the loading order of the plugins not fixed.
The order of the menus added by the plugin may be different.
Therefore, the plugin is loaded in alphabetical order.

[File#listFiles](https://docs.oracle.com/javase/8/docs/api/java/io/File.html#listFiles--)

> There is no guarantee that the name strings in the resulting array will appear in any specific order; they are not, in particular, guaranteed to appear in alphabetical order.

![menu_order1](https://cloud.githubusercontent.com/assets/1295639/26441616/31239106-416c-11e7-8d95-5972545fdbe7.png)

![menu_order2](https://cloud.githubusercontent.com/assets/1295639/26441619/35aafb60-416c-11e7-9f79-a46d1da192b6.png)

