### PR TITLE
Make all settings configurable by system property or environment variable

### DIFF
--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -134,16 +134,16 @@ public class JettyLauncher {
         return new File(System.getProperty("user.home"), ".gitbucket");
     }
 
-    private static void deleteDirectory(File dir){
-        for(File file: dir.listFiles()){
-            if(file.isFile()){
-                file.delete();
-            } else if(file.isDirectory()){
-                deleteDirectory(file);
-            }
-        }
-        dir.delete();
-    }
+//    private static void deleteDirectory(File dir){
+//        for(File file: dir.listFiles()){
+//            if(file.isFile()){
+//                file.delete();
+//            } else if(file.isDirectory()){
+//                deleteDirectory(file);
+//            }
+//        }
+//        dir.delete();
+//    }
 
     private static Handler addStatisticsHandler(Handler handler) {
         // The graceful shutdown is implemented via the statistics handler.

--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -134,17 +134,6 @@ public class JettyLauncher {
         return new File(System.getProperty("user.home"), ".gitbucket");
     }
 
-//    private static void deleteDirectory(File dir){
-//        for(File file: dir.listFiles()){
-//            if(file.isFile()){
-//                file.delete();
-//            } else if(file.isDirectory()){
-//                deleteDirectory(file);
-//            }
-//        }
-//        dir.delete();
-//    }
-
     private static Handler addStatisticsHandler(Handler handler) {
         // The graceful shutdown is implemented via the statistics handler.
         // See the following: https://bugs.eclipse.org/bugs/show_bug.cgi?id=420142

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -220,24 +220,6 @@ object SystemSettingsService {
   private val LdapSsl = "ldap.ssl"
   private val LdapKeystore = "ldap.keystore"
 
-//  private def getEnvironmentVariable[A](key: String): Option[A] = {
-//    val value = System.getenv("GITBUCKET_" + key.toUpperCase.replace('.', '_'))
-//    if(value != null && value.nonEmpty){
-//      Some(convertType(value)).asInstanceOf[Option[A]]
-//    } else {
-//      None
-//    }
-//  }
-//
-//  private def getSystemProperty[A](key: String): Option[A] = {
-//    val value = System.getProperty("gitbucket." + key)
-//    if(value != null && value.nonEmpty){
-//      Some(convertType(value)).asInstanceOf[Option[A]]
-//    } else {
-//      None
-//    }
-//  }
-
   private def getValue[A: ClassTag](props: java.util.Properties, key: String, default: A): A = {
     getSystemProperty(key).getOrElse(getEnvironmentVariable(key).getOrElse {
       defining(props.getProperty(key)){ value =>
@@ -261,12 +243,5 @@ object SystemSettingsService {
       }
     })
   }
-
-//  private def convertType[A: ClassTag](value: String) =
-//    defining(implicitly[ClassTag[A]].runtimeClass){ c =>
-//      if(c == classOf[Boolean])  value.toBoolean
-//      else if(c == classOf[Int]) value.toInt
-//      else value
-//    }
 
 }


### PR DESCRIPTION
This pull request makes all settings in `gitbucket.conf` and `database.conf` by system property or environment variable.

For example, GitBucket resolves `ldap.mail_attribute` as following order:

1. System property `gitbucket.ldap.mail_attribute`
2. Environment variable `GITBUCKET_LDAP_MAIL_ATTRIBUTE`
3. `ldap.mail_attribute` property in `gitbucket.conf`

In other words, if a system property or an environment variable is specified, a configured value in `gitbucket.conf` or `database.conf` is ignored.

Maybe this pull request covers #1577.

