### PR TITLE
Add assignee entry to the result of pull request related api

### DIFF
--- a/src/main/scala/gitbucket/core/api/JsonFormat.scala
+++ b/src/main/scala/gitbucket/core/api/JsonFormat.scala
@@ -20,7 +20,7 @@ object JsonFormat {
       { case x: Date => JString(parserISO.print(new DateTime(x).withZone(DateTimeZone.UTC))) }
     )
   ) + FieldSerializer[ApiUser]() +
-    FieldSerializer[ApiPullRequest]() +
+    FieldSerializer[ApiPullRequest](FieldSerializer.ignore("gitbucket$core$service$AccountService$$logger")) +
     FieldSerializer[ApiRepository]() +
     FieldSerializer[ApiCommitListItem.Parent]() +
     FieldSerializer[ApiCommitListItem]() +

--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -498,7 +498,7 @@ trait ApiControllerBase extends ControllerBase {
     val condition = IssueSearchCondition(request)
     val baseOwner = getAccountByUserName(repository.owner).get
 
-    val issues: List[(Issue, Account, Int, PullRequest, Repository, Account)] =
+    val issues: List[(Issue, Account, Int, PullRequest, Repository, Account, Account)] =
       searchPullRequestByApi(
         condition = condition,
         offset    = (page - 1) * PullRequestLimit,
@@ -506,7 +506,7 @@ trait ApiControllerBase extends ControllerBase {
         repos     = repository.owner -> repository.name
       )
 
-    JsonFormat(issues.map { case (issue, issueUser, commentCount, pullRequest, headRepo, headOwner) =>
+    JsonFormat(issues.map { case (issue, issueUser, commentCount, pullRequest, headRepo, headOwner, assignee) =>
       ApiPullRequest(
         issue         = issue,
         pullRequest   = pullRequest,

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -199,15 +199,16 @@ trait IssuesService {
    * @return (issue, issueUser, commentCount, pullRequest, headRepo, headOwner)
    */
   def searchPullRequestByApi(condition: IssueSearchCondition, offset: Int, limit: Int, repos: (String, String)*)
-                            (implicit s: Session): List[(Issue, Account, Int, PullRequest, Repository, Account)] = {
+                            (implicit s: Session): List[(Issue, Account, Int, PullRequest, Repository, Account, Account)] = {
     // get issues and comment count and labels
     searchIssueQueryBase(condition, true, offset, limit, repos)
       .join(PullRequests).on { case t1 ~ t2 ~ i ~ t3                => t3.byPrimaryKey(t1.userName, t1.repositoryName, t1.issueId) }
       .join(Repositories).on { case t1 ~ t2 ~ i ~ t3 ~ t4           => t4.byRepository(t1.userName, t1.repositoryName) }
       .join(Accounts    ).on { case t1 ~ t2 ~ i ~ t3 ~ t4 ~ t5      => t5.userName === t1.openedUserName }
       .join(Accounts    ).on { case t1 ~ t2 ~ i ~ t3 ~ t4 ~ t5 ~ t6 => t6.userName === t4.userName }
-      .sortBy { case t1 ~ t2 ~ i ~ t3 ~ t4 ~ t5 ~ t6 => i asc }
-      .map    { case t1 ~ t2 ~ i ~ t3 ~ t4 ~ t5 ~ t6 => (t1, t5, t2.commentCount, t3, t4, t6) }
+      .join(Accounts    ).on { case t1 ~ t2 ~ i ~ t3 ~ t4 ~ t5 ~ t6 ~ t7 => t7.userName === t1.assignedUserName}
+      .sortBy { case t1 ~ t2 ~ i ~ t3 ~ t4 ~ t5 ~ t6 ~ t7 => i asc }
+      .map    { case t1 ~ t2 ~ i ~ t3 ~ t4 ~ t5 ~ t6 ~ t7 => (t1, t5, t2.commentCount, t3, t4, t6, t7) }
       .list
   }
 

--- a/src/main/scala/gitbucket/core/service/WebHookService.scala
+++ b/src/main/scala/gitbucket/core/service/WebHookService.scala
@@ -430,7 +430,7 @@ object WebHookService {
         baseRepository: RepositoryInfo,
         baseOwner: Account,
         sender: Account,
-        mergedComment: Option[(IssueComment, Account)]): WebHookPullRequestPayload = {
+        mergedComment: Option[(IssueComment, Account)])(implicit s: Session): WebHookPullRequestPayload = {
 
       val headRepoPayload = ApiRepository(headRepository, headOwner)
       val baseRepoPayload = ApiRepository(baseRepository, baseOwner)
@@ -502,7 +502,7 @@ object WebHookService {
       baseOwner: Account,
       sender: Account,
       mergedComment: Option[(IssueComment, Account)]
-    ) : WebHookPullRequestReviewCommentPayload = {
+    )(implicit s: Session) : WebHookPullRequestReviewCommentPayload = {
       val headRepoPayload = ApiRepository(headRepository, headOwner)
       val baseRepoPayload = ApiRepository(baseRepository, baseOwner)
       val senderPayload = ApiUser(sender)

--- a/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
+++ b/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
@@ -281,7 +281,8 @@ class JsonFormatSpec extends FunSuite {
     merged_by     = Some(apiUser),
     title         = "new-feature",
     body          = "Please pull these awesome changes",
-    user          = apiUser
+    user          = apiUser,
+    assignee      = Left(apiUser)
   )
 
   val apiPullRequestJson = s"""{
@@ -311,6 +312,7 @@ class JsonFormatSpec extends FunSuite {
     "title": "new-feature",
     "body": "Please pull these awesome changes",
     "user": $apiUserJson,
+    "assignee": $apiUserJson,
     "html_url": "${context.baseUrl}/octocat/Hello-World/pull/1347",
     "url": "${context.baseUrl}/api/v3/repos/octocat/Hello-World/pulls/1347",
     "commits_url": "${context.baseUrl}/api/v3/repos/octocat/Hello-World/pulls/1347/commits",


### PR DESCRIPTION
Now, gitbucket does not return assignee entry in the result of pull request related api.
This patch enables to add assignee entry.

If no assignee is assigned, that entry is  "assignee":null.
This is same result as GitHub.

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
