### PR TITLE
[WIP] Copy bundled plugins in initialization process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ libraryDependencies ++= Seq(
   "org.cache2k"                     %  "cache2k-all"                  % "1.0.0.CR1",
   "com.enragedginger"               %% "akka-quartz-scheduler"        % "1.6.0-akka-2.4.x" exclude("c3p0","c3p0"),
   "net.coobird"                     %  "thumbnailator"                % "0.4.8",
+  "com.github.zafarkhaja"           %  "java-semver"                  % "0.9.0",
   "org.eclipse.jetty"               %  "jetty-webapp"                 % JettyVersion     % "provided",
   "javax.servlet"                   %  "javax.servlet-api"            % "3.1.0"          % "provided",
   "junit"                           %  "junit"                        % "4.12"           % "test",

--- a/src/main/resources/plugins/plugins
+++ b/src/main/resources/plugins/plugins
@@ -1,0 +1,1 @@
+#gitbucket-gist-plugin_2.12-4.9.0.jar


### PR DESCRIPTION
The purpose of this pull request is making posisble to bundle default plugins with the GitBucket distribution.

The basic concept is copying bundled plugin jars to `GITBUCKET_HOME/plugins` before plugin initialization, but there are two concerns to be considered:

- The current implementation needs to include plugin jars in the gitbucket jar which published to the Maven Central repository. It's desireble to be included in only gitbucket.war.
- Bundled plugins are always enabled. It's impossible to disable. It might have to make the plugin hot deployment (#1487) to disable bundled plugins.

Close #1625