### PR TITLE
Make preview-able comment editing forms

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/preview.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/preview.scala.html
@@ -16,7 +16,7 @@
 <div class="tabbable">
   <ul class="nav nav-tabs fill-width" style="margin-bottom: 10px;">
     <li class="active"><a href="#tab@uid" data-toggle="tab">Write</a></li>
-    <li><a href="#tab@(uid+1)" data-toggle="tab" id="preview@uid">Preview</a></li>
+    <li><a href="#tab@(uid + 1)" data-toggle="tab" id="preview@uid">Preview</a></li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane active" style="margin-top: 4px;" id="tab@uid">
@@ -32,7 +32,7 @@
         generateScript    = !enableWikiLink
       )(textarea)
     </div>
-    <div class="tab-pane" id="tab@(uid+1)">
+    <div class="tab-pane" id="tab@(uid + 1)">
       <div class="markdown-body" id="preview-area@uid">
       </div>
     </div>

--- a/src/main/twirl/gitbucket/core/issues/editcomment.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/editcomment.scala.html
@@ -1,9 +1,19 @@
 @(content: String, commentId: Int,
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo)(implicit context: gitbucket.core.controller.Context)
 <span id="error-edit-content-@commentId" class="error"></span>
-@gitbucket.core.helper.html.attached(repository, "issues"){
-  <textarea id="edit-content-@commentId" class="form-control">@content</textarea>
-}
+@gitbucket.core.helper.html.preview(
+  repository         = repository,
+  content            = content,
+  enableWikiLink     = false,
+  enableRefsLink     = true,
+  enableLineBreaks   = true,
+  enableTaskList     = true,
+  hasWritePermission = true,
+  completionContext  = "issues",
+  style              = "",
+  elastic            = true,
+  tabIndex           = 1
+)
 <div>
   <input type="button" id="cancel-comment-@commentId" class="btn btn-danger" value="Cancel"/>
   <input type="button" id="update-comment-@commentId" class="btn btn-default pull-right" value="Update comment"/>
@@ -17,13 +27,14 @@ $(function(){
   };
 
   $('#update-comment-@commentId').click(function(){
+    var content = $(this).parent().parent().find('textarea[name=content]').val();
     $('#update-comment-@commentId, #cancel-comment-@commentId').attr('disabled', 'disabled');
     $.ajax({
       url: '@context.path/@repository.owner/@repository.name/issue_comments/edit/@commentId',
       type: 'POST',
       data: {
         issueId : 0,	// TODO
-        content : $('#edit-content-@commentId').val()
+        content : content
       }
     }).done(
       callback

--- a/src/main/twirl/gitbucket/core/issues/editcomment.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/editcomment.scala.html
@@ -14,9 +14,9 @@
   elastic            = true,
   tabIndex           = 1
 )
-<div>
-  <input type="button" id="cancel-comment-@commentId" class="btn btn-danger" value="Cancel"/>
-  <input type="button" id="update-comment-@commentId" class="btn btn-default pull-right" value="Update comment"/>
+<div class="pull-right">
+  <input type="button" id="cancel-comment-@commentId" class="btn btn-default" value="Cancel"/>
+  <input type="button" id="update-comment-@commentId" class="btn btn-success" value="Update comment"/>
 </div>
 <script>
 $(function(){

--- a/src/main/twirl/gitbucket/core/issues/editissue.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/editissue.scala.html
@@ -13,9 +13,9 @@
   elastic            = true,
   tabIndex           = 1
 )
-<div>
-  <input type="button" id="cancel-issue" class="btn btn-danger" value="Cancel"/>
-  <input type="button" id="update-issue" class="btn btn-default pull-right" value="Update comment"/>
+<div class="pull-right">
+  <input type="button" id="cancel-issue" class="btn btn-default" value="Cancel"/>
+  <input type="button" id="update-issue" class="btn btn-success" value="Update comment"/>
 </div>
 <script>
 $(function(){

--- a/src/main/twirl/gitbucket/core/issues/editissue.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/editissue.scala.html
@@ -1,8 +1,18 @@
 @(content: Option[String], issueId: Int,
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo)(implicit context: gitbucket.core.controller.Context)
-@gitbucket.core.helper.html.attached(repository, "issues"){
-  <textarea id="edit-content" class="form-control">@content.getOrElse("")</textarea>
-}
+@gitbucket.core.helper.html.preview(
+  repository         = repository,
+  content            = content.getOrElse(""),
+  enableWikiLink     = false,
+  enableRefsLink     = true,
+  enableLineBreaks   = true,
+  enableTaskList     = true,
+  hasWritePermission = true,
+  completionContext  = "issues",
+  style              = "",
+  elastic            = true,
+  tabIndex           = 1
+)
 <div>
   <input type="button" id="cancel-issue" class="btn btn-danger" value="Cancel"/>
   <input type="button" id="update-issue" class="btn btn-default pull-right" value="Update comment"/>
@@ -16,13 +26,12 @@ $(function(){
   };
 
   $('#update-issue').click(function(){
+    var content = $(this).parent().parent().find('textarea[name=content]').val();
     $('#update, #cancel').attr('disabled', 'disabled');
     $.ajax({
       url: '@context.path/@repository.owner/@repository.name/issues/edit/@issueId',
       type: 'POST',
-      data: {
-        content : $('#edit-content').val()
-      }
+      data: { content : content }
     }).done(
       callback
     ).fail(function(req) {

--- a/src/main/twirl/gitbucket/core/repo/editcomment.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editcomment.scala.html
@@ -1,9 +1,19 @@
 @(content: String, commentId: Int,
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo)(implicit context: gitbucket.core.controller.Context)
 <span class="error-edit-content-@commentId error"></span>
-@gitbucket.core.helper.html.attached(repository, "issues"){
-  <textarea style="height: 100px;" id="edit-content-@commentId" class="form-control">@content</textarea>
-}
+@gitbucket.core.helper.html.preview(
+  repository         = repository,
+  content            = content,
+  enableWikiLink     = false,
+  enableRefsLink     = true,
+  enableLineBreaks   = true,
+  enableTaskList     = true,
+  hasWritePermission = true,
+  completionContext  = "issues",
+  style              = "",
+  elastic            = true,
+  tabIndex           = 1
+)
 <div>
   <input type="button" class="cancel-comment-@commentId btn btn-small btn-danger" value="Cancel"/>
   <input type="button" class="update-comment-@commentId btn btn-small btn-default pull-right" value="Update comment"/>
@@ -19,13 +29,14 @@ $(function(){
   }
 
   $(document).on('click', '.update-comment-@commentId', function(){
+    var content = $(this).parent().parent().find('textarea[name=content]').val();
     $box = $(this).closest('.commit-comment-box');
     $('.update-comment-@commentId, .cancel-comment-@commentId', $box).attr('disabled', 'disabled');
     $.ajax({
       url: '@context.path/@repository.owner/@repository.name/commit_comments/edit/@commentId',
       type: 'POST',
       data: {
-        content : $('#edit-content-@commentId', $box).val()
+        content : content
       }
     }).done(
       curriedCallback($box)

--- a/src/main/twirl/gitbucket/core/repo/editcomment.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editcomment.scala.html
@@ -14,9 +14,9 @@
   elastic            = true,
   tabIndex           = 1
 )
-<div>
-  <input type="button" class="cancel-comment-@commentId btn btn-small btn-danger" value="Cancel"/>
-  <input type="button" class="update-comment-@commentId btn btn-small btn-default pull-right" value="Update comment"/>
+<div class="pull-right">
+  <input type="button" class="cancel-comment-@commentId btn btn-small btn-default" value="Cancel"/>
+  <input type="button" class="update-comment-@commentId btn btn-small btn-success" value="Update comment"/>
 </div>
 <script>
 $(function(){


### PR DESCRIPTION
New issue or comment forms are preview-able, but editing forms are just a textarea. This pull request makes preview-able editing forms as well.