### PR TITLE
fix getMergedComment for PR API merged field.

### DIFF
--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -36,8 +36,7 @@ trait IssuesService {
       .filter(_.action === "merge".bind)
       .join(Accounts).on { case  t1 ~ t2 => t1.commentedUserName === t2.userName }
       .map { case t1 ~ t2 => (t1, t2)}
-      .list
-      .collectFirst { case (comment, account) if comment.action == "merge" => (comment, account) }
+      .firstOption
   }
 
   def getComment(owner: String, repository: String, commentId: String)(implicit s: Session): Option[IssueComment] = {


### PR DESCRIPTION
For merged-PR, `/api/v3/repos/:owner/:repo/pulls` API returns `"merged": false`.

Because, getMergedComment finds comment with action = merged, but getCommentsForApi filters action = comment/close_comment/reopen_comment.
(and finds "merged", not "merge")

And I'm not used to Slick, if there is more smart way to find merged comment, please teach me!

### Before submitting a pull-request to Gitbucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
