### PR TITLE
Add query string for redirect, required by git-2.11-1.

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/GHCompatRepositoryAccessFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/GHCompatRepositoryAccessFilter.scala
@@ -23,10 +23,11 @@ class GHCompatRepositoryAccessFilter extends Filter with SystemSettingsService {
     val agent = request.getHeader("USER-AGENT")
     val response = res.asInstanceOf[HttpServletResponse]
     val requestPath = request.getRequestURI.substring(request.getContextPath.length)
+    val queryString = if (request.getQueryString != null) "?" + request.getQueryString else ""
 
     requestPath match {
       case githubRepositoryPattern() if agent != null && agent.toLowerCase.indexOf("git") >= 0 =>
-        response.sendRedirect(baseUrl + "/git" + requestPath)
+        response.sendRedirect(baseUrl + "/git" + requestPath + queryString)
       case _ =>
         chain.doFilter(req, res)
     }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

GitBucket 4.15.0 redirects `(context path)/user/repo.git` to `(context path)/git/user/repo.git`
but,  git-2.11.1 or higher  version, it doesn't accept this redirect. Because, GitBucket 4.15.0 drops query string.

in this PR, I added query string to redirect URL. git-2.14.1 works correctly.
