### PR TITLE
Show fullName in userName suggestion.

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -112,16 +112,19 @@ trait IndexControllerBase extends ControllerBase {
     contentType = formats("json")
     val user  = params("user").toBoolean
     val group = params("group").toBoolean
+    val allUsers = getAllUsers(false)
+      .withFilter { t => (user, group) match {
+        case (true, true) => true
+        case (true, false) => !t.isGroupAccount
+        case (false, true) => t.isGroupAccount
+        case (false, false) => false
+      }}
     org.json4s.jackson.Serialization.write(
       Map("options" -> (
-        getAllUsers(false)
-          .withFilter { t => (user, group) match {
-            case (true, true) => true
-            case (true, false) => !t.isGroupAccount
-            case (false, true) => t.isGroupAccount
-            case (false, false) => false
-          }}.map { t => t.userName }
-      ))
+        allUsers.map { t => t.userName }
+      ),
+        "nameMap" -> allUsers.map{t => t.userName -> t.fullName}.toMap
+      )
     )
   })
 

--- a/src/main/scala/gitbucket/core/plugin/SuggestionProvider.scala
+++ b/src/main/scala/gitbucket/core/plugin/SuggestionProvider.scala
@@ -21,7 +21,7 @@ class UserNameSuggestionProvider extends SuggestionProvider {
   override val prefix: String = "@"
   override val context: Seq[String] = Seq("issues")
   override def values(repository: RepositoryInfo): Seq[String] = Nil
-  override def template(implicit context: Context): String = "'@' + value"
+  override def template(implicit context: Context): String = "'@' + value + '/' + nameMap[value]"
   override def additionalScript(implicit context: Context): String =
-    s"""$$.get('${context.path}/_user/proposals', { query: '', user: true, group: false }, function (data) { user = data.options; });"""
+    s"""var nameMap = {};$$.get('${context.path}/_user/proposals', { query: '', user: true, group: false }, function (data) { user = data.options; nameMap = data.nameMap;});"""
 }


### PR DESCRIPTION
This PR add display fullName to userName suggestion provider.

![20170814-152808 -](https://user-images.githubusercontent.com/6997928/29260502-463741ea-8105-11e7-8018-ff646d821a9b.png)

It is useful if many TANAKA/SATO/SUZUKI/... in your team.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
