### PR TITLE
add AdminLTE skin selection feature.

### DIFF
--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -63,7 +63,8 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
         "tls"                      -> trim(label("Enable TLS", optional(boolean()))),
         "ssl"                      -> trim(label("Enable SSL", optional(boolean()))),
         "keystore"                 -> trim(label("Keystore", optional(text())))
-    )(Ldap.apply))
+    )(Ldap.apply)),
+    "skinName" -> trim(label("AdminLTE skin name", text(required)))
   )(SystemSettings.apply).verifying { settings =>
     Vector(
       if(settings.ssh && settings.baseUrl.isEmpty){

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -54,6 +54,7 @@ trait SystemSettingsService {
           ldap.keystore.foreach(x => props.setProperty(LdapKeystore, x))
         }
       }
+      props.setProperty(SkinName, settings.skinName.toString)
       using(new java.io.FileOutputStream(GitBucketConf)){ out =>
         props.store(out, null)
       }
@@ -111,7 +112,8 @@ trait SystemSettingsService {
             getOptionValue(props, LdapKeystore, None)))
         } else {
           None
-        }
+        },
+        getValue(props, SkinName, "skin-blue")
       )
     }
   }
@@ -136,7 +138,8 @@ object SystemSettingsService {
     useSMTP: Boolean,
     smtp: Option[Smtp],
     ldapAuthentication: Boolean,
-    ldap: Option[Ldap]){
+    ldap: Option[Ldap],
+    skinName: String){
     def baseUrl(request: HttpServletRequest): String = baseUrl.fold(request.baseUrl)(_.stripSuffix("/"))
 
     def sshAddress:Option[SshAddress] =
@@ -219,6 +222,7 @@ object SystemSettingsService {
   private val LdapTls = "ldap.tls"
   private val LdapSsl = "ldap.ssl"
   private val LdapKeystore = "ldap.keystore"
+  private val SkinName = "skinName"
 
   private def getValue[A: ClassTag](props: java.util.Properties, key: String, default: A): A = {
     getSystemProperty(key).getOrElse(getEnvironmentVariable(key).getOrElse {

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -412,4 +412,10 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
    */
   def readableSize(size: Option[Long]): String = FileUtil.readableSize(size.getOrElse(0))
 
+
+  /**
+    * returns selected skin-name
+    */
+  def skinName(implicit context: Context): String = context.settings.skinName
+
 }

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -412,10 +412,4 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
    */
   def readableSize(size: Option[Long]): String = FileUtil.readableSize(size.getOrElse(0))
 
-
-  /**
-    * returns selected skin-name
-    */
-  def skinName(implicit context: Context): String = context.settings.skinName
-
 }

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -1,5 +1,6 @@
 @(info: Option[Any])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.util.DatabaseConfig
+@import gitbucket.core.view.helpers
 @gitbucket.core.html.main("System settings"){
   @gitbucket.core.admin.html.menu("system"){
     @gitbucket.core.helper.html.information(info)
@@ -344,6 +345,36 @@
             </div>
           </div>
           *@
+          <!--====================================================================-->
+          <!-- AdminLTE SkinName -->
+          <!--====================================================================-->
+          <hr>
+          <label class="strong">
+            AdminLTE skin name
+          </label>
+          <div class="form-group">
+            <label class="control-label col-md-3" for="skinName">Skin name</label>
+            <div class="col-md-9">
+              <select id="skinName" name="skinName">
+                @Seq(
+                "skin-black",
+                "skin-black-light",
+                "skin-blue",
+                "skin-blue-light",
+                "skin-green",
+                "skin-green-light",
+                "skin-purple",
+                "skin-purple-light",
+                "skin-red",
+                "skin-red-light",
+                "skin-yellow",
+                "skin-yellow-light",
+                ).map{ skin =>
+                  <option @if(skin == helpers.skinName){selected}>@skin</option>
+                }
+              </select>
+            </div>
+          </div>
         </div>
       </div>
       <div class="align-right" style="margin-top: 20px;">

--- a/src/main/twirl/gitbucket/core/admin/system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/system.scala.html
@@ -370,7 +370,7 @@
                 "skin-yellow",
                 "skin-yellow-light",
                 ).map{ skin =>
-                  <option @if(skin == helpers.skinName){selected}>@skin</option>
+                  <option @if(skin == context.settings.skinName){selected}>@skin</option>
                 }
               </select>
             </div>

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -16,7 +16,7 @@
     <link href="@helpers.assets("/vendors/google-code-prettify/prettify.css")" type="text/css" rel="stylesheet"/>
     <link href="@helpers.assets("/vendors/facebox/facebox.css")" rel="stylesheet"/>
     <link href="@helpers.assets("/vendors/AdminLTE-2.3.11/css/AdminLTE.min.css")" rel="stylesheet">
-    <link href="@helpers.assets(s"/vendors/AdminLTE-2.3.11/css/skins/${helpers.skinName}.min.css")" rel="stylesheet">
+    <link href="@helpers.assets(s"/vendors/AdminLTE-2.3.11/css/skins/${context.settings.skinName}.min.css")" rel="stylesheet">
     <link href="@helpers.assets("/vendors/font-awesome-4.6.3/css/font-awesome.min.css")" rel="stylesheet">
     <link href="@helpers.assets("/vendors/jquery-ui/jquery-ui.min.css")" rel="stylesheet">
     <link href="@helpers.assets("/vendors/jquery-ui/jquery-ui.structure.min.css")" rel="stylesheet">
@@ -42,7 +42,7 @@
     }
     <script src="@helpers.assets("/vendors/AdminLTE-2.3.11/js/app.js")" type="text/javascript"></script>
   </head>
-  <body class="@helpers.skinName page-load @if(body.toString.contains("menu-item-hover")){sidebar-mini} @if(context.sidebarCollapse){sidebar-collapse}">
+  <body class="@context.settings.skinName page-load @if(body.toString.contains("menu-item-hover")){sidebar-mini} @if(context.sidebarCollapse){sidebar-collapse}">
     <div class="wrapper">
       <header class="main-header">
         <a href="@context.path/" class="logo">

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -16,7 +16,7 @@
     <link href="@helpers.assets("/vendors/google-code-prettify/prettify.css")" type="text/css" rel="stylesheet"/>
     <link href="@helpers.assets("/vendors/facebox/facebox.css")" rel="stylesheet"/>
     <link href="@helpers.assets("/vendors/AdminLTE-2.3.11/css/AdminLTE.min.css")" rel="stylesheet">
-    <link href="@helpers.assets("/vendors/AdminLTE-2.3.11/css/skins/skin-blue.min.css")" rel="stylesheet">
+    <link href="@helpers.assets(s"/vendors/AdminLTE-2.3.11/css/skins/${helpers.skinName}.min.css")" rel="stylesheet">
     <link href="@helpers.assets("/vendors/font-awesome-4.6.3/css/font-awesome.min.css")" rel="stylesheet">
     <link href="@helpers.assets("/vendors/jquery-ui/jquery-ui.min.css")" rel="stylesheet">
     <link href="@helpers.assets("/vendors/jquery-ui/jquery-ui.structure.min.css")" rel="stylesheet">
@@ -42,7 +42,7 @@
     }
     <script src="@helpers.assets("/vendors/AdminLTE-2.3.11/js/app.js")" type="text/javascript"></script>
   </head>
-  <body class="skin-blue page-load @if(body.toString.contains("menu-item-hover")){sidebar-mini} @if(context.sidebarCollapse){sidebar-collapse}">
+  <body class="@helpers.skinName page-load @if(body.toString.contains("menu-item-hover")){sidebar-mini} @if(context.sidebarCollapse){sidebar-collapse}">
     <div class="wrapper">
       <header class="main-header">
         <a href="@context.path/" class="logo">

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -118,7 +118,9 @@ class AvatarImageProviderSpec extends FunSpec with MockitoSugar {
       useSMTP                  = false,
       smtp                     = None,
       ldapAuthentication       = false,
-      ldap                     = None)
+      ldap                     = None,
+      skinName                 = "skin-blue"
+    )
 
   /**
    * Adapter to test AvatarImageProviderImpl.


### PR DESCRIPTION
This PR is simplified version of #1489. This PR can change only AdminLTE's default skins:

- black(-light)
- blue(-light)
- green(-light)
- purple(-light)
- red(-light)
- yellow(-light)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
