### PR TITLE
Fix branch API did not accept branch name with slash

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -5,14 +5,15 @@ import gitbucket.core.model._
 import gitbucket.core.service.IssuesService.IssueSearchCondition
 import gitbucket.core.service.PullRequestService._
 import gitbucket.core.service._
-import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.Directory._
-import gitbucket.core.util.JGitUtil._
-import gitbucket.core.util._
 import gitbucket.core.util.Implicits._
-import gitbucket.core.view.helpers.{renderMarkup, isRenderable}
+import gitbucket.core.util.JGitUtil._
+import gitbucket.core.util.SyntaxSugars._
+import gitbucket.core.util._
+import gitbucket.core.view.helpers.{isRenderable, renderMarkup}
 import org.eclipse.jgit.api.Git
-import org.scalatra.{NoContent, UnprocessableEntity, Created}
+import org.scalatra.{Created, NoContent, UnprocessableEntity}
+
 import scala.collection.JavaConverters._
 
 class ApiController extends ApiControllerBase
@@ -124,10 +125,10 @@ trait ApiControllerBase extends ControllerBase {
   /**
     * https://developer.github.com/v3/repos/branches/#get-branch
     */
-  get ("/api/v3/repos/:owner/:repo/branches/:branch")(referrersOnly { repository =>
+  get ("/api/v3/repos/:owner/:repo/branches/*")(referrersOnly { repository =>
     //import gitbucket.core.api._
     (for{
-      branch     <- params.get("branch") if repository.branchList.contains(branch)
+      branch <- params.get("splat") if repository.branchList.contains(branch)
       br <- getBranches(repository.owner, repository.name, repository.repository.defaultBranch, repository.repository.originUserName.isEmpty).find(_.name == branch)
     } yield {
       val protection = getProtectedBranchInfo(repository.owner, repository.name, branch)
@@ -286,10 +287,10 @@ trait ApiControllerBase extends ControllerBase {
   /**
    * https://developer.github.com/v3/repos/#enabling-and-disabling-branch-protection
    */
-  patch("/api/v3/repos/:owner/:repo/branches/:branch")(ownerOnly { repository =>
+  patch("/api/v3/repos/:owner/:repo/branches/*")(ownerOnly { repository =>
     import gitbucket.core.api._
     (for{
-      branch     <- params.get("branch") if repository.branchList.contains(branch)
+      branch     <- params.get("splat") if repository.branchList.contains(branch)
       protection <- extractFromJsonBody[ApiBranchProtection.EnablingAndDisabling].map(_.protection)
       br <- getBranches(repository.owner, repository.name, repository.repository.defaultBranch, repository.repository.originUserName.isEmpty).find(_.name == branch)
     } yield {


### PR DESCRIPTION
This pull request fixes the branch API did not accept branch name with slash such as `feature/foo`. It improves Jenkins Multi-branch Pipeline can handle branch name with slash.

### Test result

Prerequisite:

- Create a repository `hello/foo`
- Create branches `master` and `feature/foo`

Result:

- http://localhost:8080/api/v3/repos/hello/foo/branches/master -> 200
- http://localhost:8080/api/v3/repos/hello/foo/branches/feature/foo -> 200
- http://localhost:8080/api/v3/repos/hello/foo/branches/feature/notexists -> 404

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
