### PR TITLE
Capitalize GitBucket in plugin description

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -41,7 +41,7 @@
   {
     "id": "pages",
     "name": "Pages Plugin",
-    "description": "Project pages for gitbucket",
+    "description": "Project pages for GitBucket",
     "versions": [
       {
         "version": "1.5.0",


### PR DESCRIPTION
Could you fix a comment in Pages plugin description?