### PR TITLE
Change URL with commit ID when user selects line(s).

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/blob.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/blob.scala.html
@@ -29,6 +29,7 @@
         </ol>
         <span>Older</span>
       </div>
+      <div id="branchCtrlWrapper" style="display:inline;">
       @gitbucket.core.helper.html.branchcontrol(
         branch,
         repository,
@@ -38,6 +39,7 @@
           <li><a href="@helpers.url(repository)/blob/@helpers.encodeRefName(x)/@pathList.mkString("/")">@gitbucket.core.helper.html.checkicon(x == branch) @x</a></li>
         }
       }
+      </div>
       <a href="@helpers.url(repository)/tree/@helpers.encodeRefName(branch)">@repository.name</a> /
       @pathList.zipWithIndex.map { case (section, i) =>
         @if(i == pathList.length - 1){
@@ -130,14 +132,18 @@ $(window).load(function(){
         }
         var line = pos[i].id.replace(/^L/,'');
         var hash = location.hash;
+        var commitUrl = '@helpers.url(repository)/blob/@latestCommit.id/@pathList.mkString("/")';
         if(e.shiftKey == true && hash.match(/#L\d+(-L\d+)?/)){
           var lines = hash.split('-');
-          location.hash = lines[0] + '-L' + line;
+          window.history.pushState('', '', commitUrl + lines[0] + '-L' + line);
         } else {
           var p = $("#L"+line).attr('id',"");
-          location.hash = '#L' + line;
+          window.history.pushState('', '', commitUrl + '#L' + line);
           p.attr('id','L'+line);
         }
+        $("#branchCtrlWrapper .btn .muted").text("tree:");
+        $("#branchCtrlWrapper .btn .strong").text("@latestCommit.id.substring(0, 10)");
+        updateHighlighting();
       }).appendTo(pre);
     }
   }


### PR DESCRIPTION
related to #1702.
In GitHub, if user select lines in blob view, user needs to switch commit URL by 'y' key. Because it maybe changes after some commits pushed to the branch.
But, I assume '/user/repo/blob/branch/path/to/file.ext#L1-L3' link is BAD URL. It should be changed to URL with commit ID automatically.
This PR implements such behavior.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
