### PR TITLE
Allow anonymous access to github style git url redirect. fix #1701

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PreProcessController.scala
+++ b/src/main/scala/gitbucket/core/controller/PreProcessController.scala
@@ -29,7 +29,7 @@ trait PreProcessControllerBase extends ControllerBase {
    */
   get(!context.settings.allowAnonymousAccess, context.loginAccount.isEmpty) {
     if(!context.currentPath.startsWith("/assets") && !context.currentPath.startsWith("/signin") &&
-      !context.currentPath.startsWith("/register")) {
+      !context.currentPath.startsWith("/register") && !context.currentPath.endsWith("/info/refs")) {
       Unauthorized()
     } else {
       pass()


### PR DESCRIPTION
This PR fix #1701. Allow `git clone http://server/owner/repo.git`.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
