### PR TITLE
Use account.fullName instead of userName for Web UI edit, Wiki uploads.

### DIFF
--- a/src/main/scala/gitbucket/core/controller/FileUploadController.scala
+++ b/src/main/scala/gitbucket/core/controller/FileUploadController.scala
@@ -80,7 +80,7 @@ class FileUploadController extends ScalatraServlet with FileUploadSupport with R
               builder.finish()
 
               val newHeadId = JGitUtil.createNewCommit(git, inserter, headId, builder.getDirCache.writeTree(inserter),
-                Constants.HEAD, loginAccount.userName, loginAccount.mailAddress, s"Uploaded ${fileName}")
+                Constants.HEAD, loginAccount.fullName, loginAccount.mailAddress, s"Uploaded ${fileName}")
 
               fileName
             }

--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -717,7 +717,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
         f(git, headTip, builder, inserter)
 
         val commitId = JGitUtil.createNewCommit(git, inserter, headTip, builder.getDirCache.writeTree(inserter),
-          headName, loginAccount.userName, loginAccount.mailAddress, message)
+          headName, loginAccount.fullName, loginAccount.mailAddress, message)
 
         inserter.flush()
         inserter.close()


### PR DESCRIPTION
In editing file by Web UI, GitBucket adds account name to commit's author (ex. kounoike). But in merging PR, initializing repository and wiki editing, GitBucket uses user's fullname as author (ex. KOUNOIKE Yuusuke). These actions should be use same rule.

This PR changes author from userName to fullName for editing file and uploading to Wiki.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
