### PR TITLE
Delete/Move RepositoryFilesDir, instead of LFS/comments dir.

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
@@ -343,20 +343,12 @@ trait RepositorySettingsControllerBase extends ControllerBase {
             FileUtils.moveDirectory(dir, getWikiRepositoryDir(form.newOwner, repository.name))
           }
         }
-        // Move lfs directory
-        defining(getLfsDir(repository.owner, repository.name)){ dir =>
-          if(dir.isDirectory()) {
-            FileUtils.moveDirectory(dir, getLfsDir(form.newOwner, repository.name))
-          }
-        }
-        // Move attached directory
-        defining(getAttachedDir(repository.owner, repository.name)){ dir =>
+        // Move files directory
+        defining(getRepositoryFilesDir(repository.owner, repository.name)){ dir =>
           if(dir.isDirectory) {
-            FileUtils.moveDirectory(dir, getAttachedDir(form.newOwner, repository.name))
+            FileUtils.moveDirectory(dir, getRepositoryFilesDir(form.newOwner, repository.name))
           }
         }
-        // Delete parent directory
-        FileUtil.deleteDirectoryIfEmpty(getRepositoryFilesDir(repository.owner, repository.name))
 
         // Call hooks
         PluginRegistry().getRepositoryHooks.foreach(_.transferred(repository.owner, form.newOwner, repository.name))
@@ -376,9 +368,7 @@ trait RepositorySettingsControllerBase extends ControllerBase {
       FileUtils.deleteDirectory(getRepositoryDir(repository.owner, repository.name))
       FileUtils.deleteDirectory(getWikiRepositoryDir(repository.owner, repository.name))
       FileUtils.deleteDirectory(getTemporaryDir(repository.owner, repository.name))
-      val lfsDir = getLfsDir(repository.owner, repository.name)
-      FileUtils.deleteDirectory(lfsDir)
-      FileUtil.deleteDirectoryIfEmpty(lfsDir.getParentFile())
+      FileUtils.deleteDirectory(getRepositoryFilesDir(repository.owner, repository.name))
 
       // Call hooks
       PluginRegistry().getRepositoryHooks.foreach(_.deleted(repository.owner, repository.name))


### PR DESCRIPTION
Delete/Move RepositoryFilesDir, instead of LFS/comments directory. It is useful for storing additional files under RepositoryFilesDir such as Release pages feature, ci-plugin's artifacts or something else.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
