### PR TITLE
Truncate long branch names

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/branchcontrol.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/branchcontrol.scala.html
@@ -4,7 +4,8 @@
 @import gitbucket.core.view.helpers
 @gitbucket.core.helper.html.dropdown(
   value  = if(branch.length == 40) branch.substring(0, 10) else branch,
-  prefix = if(branch.length == 40) "tree" else if(repository.branchList.contains(branch)) "branch" else "tree"
+  prefix = if(branch.length == 40) "tree" else if(repository.branchList.contains(branch)) "branch" else "tree",
+  maxValueWidth = "200px"
 ) {
   <li><div id="branch-control-title">Switch branches<button id="branch-control-close" class="pull-right">&times</button></div></li>
   <li><input id="branch-control-input" type="text" class="form-control input-sm dropdown-filter-input" placeholder="Find or create branch ..."/></li>

--- a/src/main/twirl/gitbucket/core/helper/dropdown.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/dropdown.scala.html
@@ -1,11 +1,12 @@
 @(value : String  = "",
   prefix: String  = "",
   style : String  = "",
+  maxValueWidth : String  = "",
   right : Boolean = false,
   filter: (String, String)  = ("",""))(body: Html)
 @defining(if(filter._1.isEmpty) "" else filter._1 + "-" + scala.util.Random.alphanumeric.take(4).mkString){ filterId =>
   <div class="btn-group" @if(style.nonEmpty){style="@style"}>
-    <button
+    <button id = "test"
         class="dropdown-toggle btn btn-default btn-sm" data-toggle="dropdown">
       @if(value.isEmpty){
         <i class="octicon octicon-gear"></i>
@@ -13,7 +14,10 @@
         @if(prefix.nonEmpty){
           <span class="muted">@prefix:</span>
         }
-        <span class="strong">@value</span>
+        <span class="strong"
+              @if(maxValueWidth.nonEmpty){style="display:inline-block; vertical-align:bottom; overflow-x:hidden; max-width:@maxValueWidth; text-overflow:ellipsis"}>
+          @value
+        </span>
       }
       <span class="caret"></span>
     </button>


### PR DESCRIPTION
Fix #1135 

I limited the text area in branch names to 200px, which seems to be the same limit used by GitHub.

Old:
![](https://i.imgur.com/aiI6OUk.png)

New:
![](https://i.imgur.com/tPmh8kO.png)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
