### PR TITLE
Fix typo in style attribute

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/uploadavatar.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/uploadavatar.scala.html
@@ -1,7 +1,7 @@
 @(account: Option[gitbucket.core.model.Account])(implicit context: gitbucket.core.controller.Context)
 <div id="avatar" class="muted">
   @if(account.nonEmpty && account.get.image.nonEmpty){
-    <img src="@context.path/@account.get.userName/_avatar" style="with: 120px; height: 120px;"/>
+    <img src="@context.path/@account.get.userName/_avatar" style="width: 120px; height: 120px;"/>
   } else {
     <div id="clickable">Upload Image</div>
   }


### PR DESCRIPTION
Because of the typo, image displayed in unintended aspect ratio, in some case.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
