### PR TITLE
Treat LFS files as large binaries in the web viewer

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -400,13 +400,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
   })
 
   private def isLfsFile(git: Git, objectId: ObjectId): Boolean = {
-    JGitUtil.getObjectLoaderFromId(git, objectId){ loader =>
-      if(loader.isLarge){
-        false
-      } else {
-        new String(loader.getCachedBytes, "UTF-8").startsWith("version https://git-lfs.github.com/spec/v1")
-      }
-    }.getOrElse(false)
+    JGitUtil.getObjectLoaderFromId(git, objectId)(JGitUtil.isLfsPointer).getOrElse(false)
   }
 
   get("/:owner/:repository/blame/*"){


### PR DESCRIPTION
Currently in master, if you point the web ui to a file stored with LFS, it will dump the pointer file instead of the actual content (except for images). This PR makes the viewer treats LFS files as binaries, allow users to download them without seeing the gibberish text (does not affect images).

Another solution would be treating the LFS file the same as normal file, show the content if it's a text file.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
