### PR TITLE
Change Close/Reopen button to dropdown-selectable button.

### DIFF
--- a/src/main/twirl/gitbucket/core/issues/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentform.scala.html
@@ -22,12 +22,24 @@
           elastic            = true,
           tabIndex           = 1
         )
-        <div class="text-right">
-          <input type="hidden" name="issueId" value="@issue.issueId"/>
-          @if((reopenable || !issue.closed) && (isManageable || issue.openedUserName == context.loginAccount.get.userName)){
-            <input type="submit" class="btn btn-default" tabindex="3" formaction="@helpers.url(repository)/issue_comments/state" value="@{if(issue.closed) "Reopen" else "Close"}" id="action"/>
-          }
-          <input type="submit" class="btn btn-success" tabindex="2" formaction="@helpers.url(repository)/issue_comments/new" value="Comment"/>
+          <div class="text-right">
+            <input type="hidden" name="issueId" value="@issue.issueId"/>
+            @if((reopenable || !issue.closed) && (isManageable || issue.openedUserName == context.loginAccount.get.userName)){
+              <input type="hidden" id="action" name="action" value="comment"/>
+              <div class="btn-group dropup">
+                <input type="submit" class="btn btn-success" tabindex="2" formaction="@helpers.url(repository)/issue_comments/new" value="Comment" id="submit-button"/>
+                <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <span class="caret"></span>
+                </button>
+              <ul class="dropdown-menu dropdown-menu-right">
+                <li><a id="menu-comment">Comment</a></li>
+                <li><a id="menu-x-and-comment">@{if(issue.closed) "Reopen" else "Close"} and comment</a></li>
+              </ul>
+              </div>
+            } else {
+              <input type="submit" class="btn btn-success" tabindex="2" formaction="@helpers.url(repository)/issue_comments/new" value="Comment"/>
+            }
+          </div>
         </div>
       </div>
     </div>
@@ -35,8 +47,13 @@
 }
 <script>
 $(function(){
-  $('#action').click(function(){
-    $('<input type="hidden">').attr('name', 'action').val($(this).val().toLowerCase()).appendTo('form');
+  $('#menu-comment').click(function(){
+    $('#submit-button').attr('value', 'Comment').attr('formaction', '@helpers.url(repository)/issue_comments/new');
+    $('#action').val('comment');
+  });
+  $('#menu-x-and-comment').click(function(){
+    $('#submit-button').attr('value', '@{if(issue.closed) "Reopen" else "Close"} and comment').attr('formaction', '@helpers.url(repository)/issue_comments/state');
+    $('#action').val('@{if(issue.closed) "reopen" else "close"}');
   });
 });
 </script>


### PR DESCRIPTION
Now, GitBucket (and GitHub) shows "Close" or "Reopen" button at left side on "Comment" button.
Some users confused this button as "Cancel".

In this PR, change this button to dropdown menu. (I use dropup by scroll reason)

![20180104-004640 png](https://user-images.githubusercontent.com/6997928/34527721-d6ffe71e-f0e9-11e7-8df1-2aaf93d36b3b.png)

![20180104-004645 png](https://user-images.githubusercontent.com/6997928/34527731-dc6ab68e-f0e9-11e7-9bf8-ce5722a0a546.png)


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
