### PR TITLE
Links submodule to the online repository viewer

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -841,7 +841,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
           defining(JGitUtil.getRevCommitFromId(git, objectId)) { revCommit =>
             val lastModifiedCommit = if(path == ".") revCommit else JGitUtil.getLastModifiedCommit(git, revCommit, path)
             // get files
-            val files = JGitUtil.getFileList(git, revision, path)
+            val files = JGitUtil.getFileList(git, revision, path, context.settings.baseUrl)
             val parentPath = if (path == ".") Nil else path.split("/").toList
             // process README.md or README.markdown
             val readme = files.find { file =>

--- a/src/main/scala/gitbucket/core/util/StringUtil.scala
+++ b/src/main/scala/gitbucket/core/util/StringUtil.scala
@@ -123,17 +123,22 @@ object StringUtil {
     "(?i)(?<!\\w)(?:fix(?:e[sd])?|resolve[sd]?|close[sd]?)\\s+#(\\d+)(?!\\w)".r
       .findAllIn(message).matchData.map(_.group(1)).toSeq.distinct
 
+  private val GitBucketUrlPattern = "^(https?://.+)/git/(.+?)/(.+?)\\.git$".r
+  private val GitHubUrlPattern    = "^https://(.+@)?github\\.com/(.+?)/(.+?)\\.git$".r
+  private val BitBucketUrlPattern = "^https?://(.+@)?bitbucket\\.org/(.+?)/(.+?)\\.git$".r
+  private val GitLabUrlPattern    = "^https?://(.+@)?gitlab\\.com/(.+?)/(.+?)\\.git$".r
 
-//  /**
-//   * Encode search string for LIKE condition.
-//   * This method has been copied from Slick's SqlUtilsComponent.
-//   */
-//  def likeEncode(s: String) = {
-//    val b = new StringBuilder
-//    for(c <- s) c match {
-//      case '%' | '_' | '^' => b append '^' append c
-//      case _ => b append c
-//    }
-//    b.toString
-//  }
+  def getRepositoryViewerUrl(gitRepositoryUrl: String, baseUrl: Option[String]): String = {
+    def removeUserName(baseUrl: String): String = baseUrl.replaceFirst("(https?://).+@", "$1")
+
+    gitRepositoryUrl match {
+      case GitBucketUrlPattern(base, user, repository) if baseUrl.map(removeUserName(base).startsWith).getOrElse(false)
+                                                    => s"${removeUserName(base)}/$user/$repository"
+      case GitHubUrlPattern   (_, user, repository) => s"https://github.com/$user/$repository"
+      case BitBucketUrlPattern(_, user, repository) => s"https://bitbucket.org/$user/$repository"
+      case GitLabUrlPattern   (_, user, repository) => s"https://gitlab.com/$user/$repository"
+      case _ => gitRepositoryUrl
+    }
+  }
+
 }

--- a/src/test/scala/gitbucket/core/util/StringUtilSpec.scala
+++ b/src/test/scala/gitbucket/core/util/StringUtilSpec.scala
@@ -63,4 +63,24 @@ class StringUtilSpec extends FunSpec {
       assert(StringUtil.extractCloseId("(refs #123)").toSeq == Nil)
     }
   }
+
+  describe("getRepositoryViewerUrl") {
+    val baseUrl = Some("http://localhost:8080")
+    it("should convert GitBucket repository url"){
+      assert(StringUtil.getRepositoryViewerUrl("http://localhost:8080/git/root/gitbucket.git", baseUrl) == "http://localhost:8080/root/gitbucket")
+      assert(StringUtil.getRepositoryViewerUrl("http://root@localhost:8080/git/root/gitbucket.git", baseUrl) == "http://localhost:8080/root/gitbucket")
+    }
+    it("should convert GitHub repository url"){
+      assert(StringUtil.getRepositoryViewerUrl("https://github.com/root/gitbucket.git", baseUrl) == "https://github.com/root/gitbucket")
+      assert(StringUtil.getRepositoryViewerUrl("https://root@github.com/root/gitbucket.git", baseUrl) == "https://github.com/root/gitbucket")
+    }
+    it("should convert BitBucket repository url"){
+      assert(StringUtil.getRepositoryViewerUrl("https://bitbucket.org/root/gitbucket.git", baseUrl) == "https://bitbucket.org/root/gitbucket")
+      assert(StringUtil.getRepositoryViewerUrl("https://root@bitbucket.org/root/gitbucket.git", baseUrl) == "https://bitbucket.org/root/gitbucket")
+    }
+    it("should convert GitLab repository url"){
+      assert(StringUtil.getRepositoryViewerUrl("https://gitlab.com/root/gitbucket.git", baseUrl) == "https://gitlab.com/root/gitbucket")
+      assert(StringUtil.getRepositoryViewerUrl("https://root@gitlab.com/root/gitbucket.git", baseUrl) == "https://gitlab.com/root/gitbucket")
+    }
+  }
 }


### PR DESCRIPTION
Links submodule to the online repository viewer instead of the git repository itself.

Supports following services:

- GitBucket (need to set the base url at the system settings)
- GitHub
- BitBucket
- GitLab.com

If a repository url doesn't match above services, generate a link to the git repository as before.

Fixes #1832
