### PR TITLE
SELinux policy module, deploy script and instructions

### DIFF
--- a/contrib/linux/redhat/selinux/gitbucket.te
+++ b/contrib/linux/redhat/selinux/gitbucket.te
@@ -1,0 +1,21 @@
+module gitbucket 1.0;
+
+require {
+	type smtp_port_t;
+	type tomcat_t;
+	type tomcat_var_lib_t;
+	type unreserved_port_t;
+
+	class file { execute };
+	class tcp_socket { name_bind };
+	class tcp_socket { name_connect };
+}
+
+# allow tomcat to send emails
+allow tomcat_t smtp_port_t:tcp_socket { name_connect };
+
+# allow file executes, required during repo creation
+allow tomcat_t tomcat_var_lib_t:file { execute };
+
+# allow tomcat to serve repositories via SSH
+allow tomcat_t unreserved_port_t:tcp_socket { name_bind };

--- a/contrib/linux/redhat/selinux/readme.md
+++ b/contrib/linux/redhat/selinux/readme.md
@@ -1,0 +1,32 @@
+# Red Hat Enterprise Linux / CentOS SELinux policy module for GitBucket
+
+One way to run GitBucket on Enterprise Linux is under Tomcat. Since EL 7.4, Tomcat is no longer unconfined.
+Thus since 7.4, Enterprise Linux blocks certain operations that are required for GitBucket to work properly:
+
+* Tomcat is not allowed to connect to SMTP ports, which is required to send email notifications.
+* Tomcat is not allowed to execute files, which is required for creating repositories.
+* Tomcat is not allowed to act as a server on unreserved ports, which is required for serving repositories via SSH.
+
+To mitigate this, you can use the SELinux policy module provided as `gitbucket.te`. You can deploy the module with the
+attached script, e.g.:
+
+~~~
+./sedeploy.sh gitbucket
+~~~
+
+You most likely also need to fix file contexts on your system. Assuming a new, default Tomcat installation on 7.4, you
+can do so by issuing the following commands:
+
+~~~
+GITBUCKET_HOME='/usr/share/tomcat/.gitbucket'
+mkdir -p ${GITBUCKET_HOME}
+chown tomcat.tomcat ${GITBUCKET_HOME}
+semanage fcontext -a -t tomcat_var_lib_t "${GITBUCKET_HOME}(/.*)?"
+restorecon -rv ${GITBUCKET_HOME}
+
+JAVA_CONF='/usr/share/tomcat/.java'
+mkdir -p ${JAVA_CONF}
+chown tomcat.tomcat ${JAVA_CONF}
+semanage fcontext -a -t tomcat_cache_t "${JAVA_CONF}(/.*)?"
+restorecon -rv ${JAVA_CONF}
+~~~

--- a/contrib/linux/redhat/selinux/sedeploy.sh
+++ b/contrib/linux/redhat/selinux/sedeploy.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+MODULE=${1}
+
+# this will create a .mod file
+checkmodule -M -m -o ${MODULE}.mod ${MODULE}.te
+
+# this will create a compiled semodule
+semodule_package -m ${MODULE}.mod -o ${MODULE}.pp
+
+# this will install the module
+semodule -i ${MODULE}.pp


### PR DESCRIPTION
To make it easier for EL Tomcat users to deploy GitBucket with SELinux enabled.