### PR TITLE
add 'state' attribute to ApiPullRequest object

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiPullRequest.scala
+++ b/src/main/scala/gitbucket/core/api/ApiPullRequest.scala
@@ -8,6 +8,7 @@ import java.util.Date
  */
 case class ApiPullRequest(
   number: Int,
+  state: String,
   updated_at: Date,
   created_at: Date,
   head: ApiPullRequest.Commit,
@@ -44,6 +45,7 @@ object ApiPullRequest{
   ): ApiPullRequest =
     ApiPullRequest(
       number     = issue.issueId,
+      state      = if (issue.closed) "closed" else "open",
       updated_at = issue.updatedDate,
       created_at = issue.registeredDate,
       head       = Commit(

--- a/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
+++ b/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
@@ -265,6 +265,7 @@ class JsonFormatSpec extends FunSuite {
 
   val apiPullRequest = ApiPullRequest(
     number        = 1347,
+    state         = "open",
     updated_at    = date1,
     created_at    = date1,
     head          = ApiPullRequest.Commit(
@@ -287,6 +288,7 @@ class JsonFormatSpec extends FunSuite {
 
   val apiPullRequestJson = s"""{
     "number": 1347,
+    "state" : "open",
     "updated_at": "2011-04-14T16:00:49Z",
     "created_at": "2011-04-14T16:00:49Z",
   //  "closed_at": "2011-04-14T16:00:49Z",


### PR DESCRIPTION
fixes #1844

### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
