### PR TITLE
Add "include group accounts" checkbox in User management

### DIFF
--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -331,12 +331,17 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
 
   get("/admin/users")(adminOnly {
     val includeRemoved = params.get("includeRemoved").map(_.toBoolean).getOrElse(false)
-    val users          = getAllUsers(includeRemoved)
-    val members        = users.collect { case account if(account.isGroupAccount) =>
-      account.userName -> getGroupMembers(account.userName).map(_.userName)
-    }.toMap
+    val includeGroups = params.get("includeGroups").map(_.toBoolean).getOrElse(false)
+    val users          = getAllUsers(includeRemoved, includeGroups)
+    if(includeGroups){
+      val members        = users.collect { case account if(account.isGroupAccount) =>
+        account.userName -> getGroupMembers(account.userName).map(_.userName)
+      }.toMap
 
-    html.userlist(users, members, includeRemoved)
+      html.userlist(users, members, includeRemoved, includeGroups)
+    }else{
+      html.userlist(users, Map[String, List[String]](), includeRemoved, includeGroups)
+    }
   })
 
   get("/admin/users/_newuser")(adminOnly {

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -333,15 +333,11 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
     val includeRemoved = params.get("includeRemoved").map(_.toBoolean).getOrElse(false)
     val includeGroups = params.get("includeGroups").map(_.toBoolean).getOrElse(false)
     val users          = getAllUsers(includeRemoved, includeGroups)
-    if(includeGroups){
-      val members        = users.collect { case account if(account.isGroupAccount) =>
-        account.userName -> getGroupMembers(account.userName).map(_.userName)
-      }.toMap
+    val members        = users.collect { case account if(account.isGroupAccount) =>
+      account.userName -> getGroupMembers(account.userName).map(_.userName)
+    }.toMap
 
-      html.userlist(users, members, includeRemoved, includeGroups)
-    }else{
-      html.userlist(users, Map[String, List[String]](), includeRemoved, includeGroups)
-    }
+    html.userlist(users, members, includeRemoved, includeGroups)
   })
 
   get("/admin/users/_newuser")(adminOnly {

--- a/src/main/scala/gitbucket/core/service/AccountService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountService.scala
@@ -96,12 +96,19 @@ trait AccountService {
   def getAccountByMailAddress(mailAddress: String, includeRemoved: Boolean = false)(implicit s: Session): Option[Account] =
     Accounts filter(t => (t.mailAddress.toLowerCase === mailAddress.toLowerCase.bind) && (t.removed === false.bind, !includeRemoved)) firstOption
 
-  def getAllUsers(includeRemoved: Boolean = true)(implicit s: Session): List[Account] =
-    if(includeRemoved){
-      Accounts sortBy(_.userName) list
-    } else {
-      Accounts filter (_.removed === false.bind) sortBy(_.userName) list
-    }
+  def getAllUsers(includeRemoved: Boolean = true, includeGroups: Boolean = true)(implicit s: Session): List[Account] =
+  {
+    ((includeRemoved, includeGroups) match {
+      case (true, true) =>
+        Accounts
+      case (true, false) =>
+        Accounts filter (_.groupAccount === false.bind)
+      case (false, true) =>
+        Accounts filter (_.removed === false.bind)
+      case (false, false) =>
+        Accounts filter (t => t.removed === false.bind && t.groupAccount === false.bind)
+    }) sortBy(_.userName) list
+  }
 
   def isLastAdministrator(account: Account)(implicit s: Session): Boolean = {
     if(account.isAdmin){

--- a/src/main/scala/gitbucket/core/service/AccountService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountService.scala
@@ -98,16 +98,11 @@ trait AccountService {
 
   def getAllUsers(includeRemoved: Boolean = true, includeGroups: Boolean = true)(implicit s: Session): List[Account] =
   {
-    ((includeRemoved, includeGroups) match {
-      case (true, true) =>
-        Accounts
-      case (true, false) =>
-        Accounts filter (_.groupAccount === false.bind)
-      case (false, true) =>
-        Accounts filter (_.removed === false.bind)
-      case (false, false) =>
-        Accounts filter (t => t.removed === false.bind && t.groupAccount === false.bind)
-    }) sortBy(_.userName) list
+    Accounts filter { t =>
+      (1.bind === 1.bind) &&
+        (t.groupAccount === false.bind, !includeGroups) &&
+        (t.removed === false.bind, !includeRemoved)
+    } sortBy(_.userName) list
   }
 
   def isLastAdministrator(account: Account)(implicit s: Session): Boolean = {

--- a/src/main/twirl/gitbucket/core/admin/userlist.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/userlist.scala.html
@@ -1,4 +1,4 @@
-@(users: List[gitbucket.core.model.Account], members: Map[String, List[String]], includeRemoved: Boolean)(implicit context: gitbucket.core.controller.Context)
+@(users: List[gitbucket.core.model.Account], members: Map[String, List[String]], includeRemoved: Boolean, includeGroups: Boolean)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main("Manage Users"){
   @gitbucket.core.admin.html.menu("users"){
@@ -9,6 +9,10 @@
     <label for="includeRemoved">
       <input type="checkbox" id="includeRemoved" name="includeRemoved" @if(includeRemoved){checked}/>
       Include removed users
+    </label>
+    <label for="includeGroups">
+      <input type="checkbox" id="includeGroups" name="includeGroups" @if(includeGroups){checked}/>
+      Include group accounts
     </label>
     <table class="table table-bordered table-hover">
       @users.map { account =>
@@ -63,8 +67,9 @@
 }
 <script>
 $(function(){
-  $('#includeRemoved').click(function(){
-    location.href = '@context.path/admin/users?includeRemoved=' + this.checked;
+  $('#includeRemoved,#includeGroups').click(function(){
+    location.href = '@context.path/admin/users?includeRemoved=' + $('#includeRemoved').prop('checked')
+      + '&includeGroups=' + $('#includeGroups').prop('checked');
   });
 });
 </script>


### PR DESCRIPTION
A few days ago, I worked disabling about 10 users. In such work, the group accounts in the list are noisy for me.

In this PR, add "Include group accounts" checkbox in Manage Users page. It hides group accounts from the list.

![20180120-130452](https://user-images.githubusercontent.com/6997928/35179700-a42bc078-fde2-11e7-8084-b410137f6af3.png)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
