### PR TITLE
Add support for new JRebel agent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,13 @@ assemblyMergeStrategy in assembly := {
 //jrebel.webLinks += (target in webappPrepare).value
 //jrebel.enabled := System.getenv().get("JREBEL") != null
 javaOptions in Jetty ++= Option(System.getenv().get("JREBEL")).toSeq.flatMap { path =>
- Seq("-noverify", "-XX:+UseConcMarkSweepGC", "-XX:+CMSClassUnloadingEnabled", s"-javaagent:${path}")
+  if (path.endsWith(".jar")) {
+    // Legacy JRebel agent
+    Seq("-noverify", "-XX:+UseConcMarkSweepGC", "-XX:+CMSClassUnloadingEnabled", s"-javaagent:${path}")
+  } else {
+    // New JRebel agent
+    Seq(s"-agentpath:${path}")
+  }
 }
 
 // Exclude a war file from published artifacts

--- a/doc/jrebel.md
+++ b/doc/jrebel.md
@@ -28,17 +28,16 @@ You don't need to integrate with your IDE, since we're using sbt to do the servl
 Fortunately, the gitbucket project is already set up to use JRebel.
 You only need to tell jvm where to find the jrebel jar.
 
-To do so, edit your shell resource file (usually `~/.bash_profile` on Mac, and `~/.bashrc` on Linux), and add the following line:
+To do so, edit your shell resource file (usually `~/.bash_profile` on Mac, and `~/.bashrc` on Linux) and set the environment variable `JREBEL`.
+For example, if you unzipped your JRebel download in your home directory, you would use:
 
 ```bash
-export JREBEL=/path/to/jrebel/legacy/jrebel.jar
+export JREBEL=~/jrebel/legacy/jrebel.jar      # legacy agent
+export JREBEL=~/jrebel/lib/libjrebel64.dylib  # new agent
 ```
 
-For example, if you unzipped your JRebel download in your home directory, you whould use:
-
-```bash
-export JREBEL=~/jrebel/legacy/jrebel.jar
-```
+You can choose the legacy JRebel agent or the new one.
+See [the document](https://zeroturnaround.com/software/jrebel/jrebel7-agent-upgrade-cli/) for details.
 
 Now reload your shell:
 


### PR DESCRIPTION
This allows using [the new JRebel agent](https://zeroturnaround.com/software/jrebel/jrebel7-agent-upgrade-cli/). The legacy agent does not run on Java 9. This is tested on JRebel 7.1.4, Java 9 and macOS.

```
sbt:gitbucket> jetty:quickstart
[info] Generating .../gitbucket/target/scala-2.12/resource_managed/main/rebel.xml.
[info] waiting for server to shut down...
[info] starting server ...
[success] Total time: 2 s, completed Jan 20, 2018, 2:54:59 PM
sbt:gitbucket> 2018-01-20 14:55:03 JRebel: Directory '.../gitbucket/target/scala-2.12/classes' will be monitored for changes.
2018-01-20 14:55:03 JRebel: Directory '.../gitbucket/target/scala-2.12/test-classes' will be monitored for changes.
2018-01-20 14:55:03 JRebel: Directory '.../gitbucket/target/webapp' will be monitored for changes.
2018-01-20 14:55:04 JRebel:
2018-01-20 14:55:04 JRebel: A newer version '7.1.5' is available for download
2018-01-20 14:55:04 JRebel: from http://zeroturnaround.com/software/jrebel/download/
2018-01-20 14:55:04 JRebel:
2018-01-20 14:55:04 JRebel: Contacting myJRebel server ..
14:55:05.598 [main] INFO  org.eclipse.jetty.util.log - Logging initialized @7164ms to org.eclipse.jetty.util.log.Slf4jLog
14:55:05.932 [main] INFO  org.eclipse.jetty.runner.Runner - Runner
14:55:07.034 [main] INFO  org.eclipse.jetty.server.Server - jetty-9.4.6.v20170531
14:55:07.766 [main] INFO  o.e.j.a.AnnotationConfiguration - Scanning elapsed time=4ms
2018-01-20 14:55:07 JRebel:  Starting logging to file: .../.jrebel/jrebel.log
2018-01-20 14:55:07 JRebel:
2018-01-20 14:55:07 JRebel:  #############################################################
2018-01-20 14:55:07 JRebel:
2018-01-20 14:55:07 JRebel:  JRebel Agent 7.1.4 (201712200830)
2018-01-20 14:55:07 JRebel:  (c) Copyright ZeroTurnaround AS, Estonia, Tartu.
2018-01-20 14:55:07 JRebel:
2018-01-20 14:55:07 JRebel:  Over the last 2 days JRebel prevented
2018-01-20 14:55:07 JRebel:  at least 5 redeploys/restarts saving you about 0.2 hours.
2018-01-20 14:55:07 JRebel:
2018-01-20 14:55:07 JRebel:  Licensed to Hidetake Iwata (using myJRebel).
2018-01-20 14:55:07 JRebel:
2018-01-20 14:55:07 JRebel:
2018-01-20 14:55:07 JRebel:  #############################################################
2018-01-20 14:55:07 JRebel:
14:55:10.397 [main] INFO  org.eclipse.jetty.server.session - DefaultSessionIdManager workerName=node0
14:55:10.397 [main] INFO  org.eclipse.jetty.server.session - No SessionScavenger set, using defaults
14:55:10.400 [main] INFO  org.eclipse.jetty.server.session - Scavenging every 600000ms
```

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
