### PR TITLE
Fix #1707.

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/blob.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/blob.scala.html
@@ -214,6 +214,9 @@ $(window).on('load', function(){
     });
     return false;
   };
+  $(document).on('expanded.pushMenu collapsed.pushMenu', function(e){
+    setTimeout(updateBlame, 300);
+  });
   updateBlame();
 });
 


### PR DESCRIPTION
This PR fixes #1707. `div.source-line-num` doesn't updated when collapsed/expanded.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
