### PR TITLE
Return 401 for non-browsers when authentication is failed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,8 @@ libraryDependencies ++= Seq(
   "org.mockito"                     %  "mockito-core"                 % "2.13.0"         % "test",
   "com.wix"                         %  "wix-embedded-mysql"           % "3.0.0"          % "test",
   "ru.yandex.qatools.embed"         %  "postgresql-embedded"          % "2.6"            % "test",
-  "net.i2p.crypto"                  % "eddsa"                         % "0.2.0"
+  "net.i2p.crypto"                  % "eddsa"                         % "0.2.0",
+  "is.tagomor.woothee"              % "woothee-java"                  % "1.7.0"
 )
 
 // Compiler settings


### PR DESCRIPTION
The current version of GitBucket redirects to the sign-in page when authentication is failed. By this behavior, if we try to download a zip file from a repository using CLI tool like curl and authentication is failed, CLI gets HTML of the sign-in page with 200.  It confuses us because request appears to be successful.

This pull request makes the authentication error doesn't redirect for non-browser clients and just returns 401 to them.