### PR TITLE
Remove extra close div tag which introduced by #1829

### DIFF
--- a/src/main/twirl/gitbucket/core/issues/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentform.scala.html
@@ -39,7 +39,6 @@
             } else {
               <input type="submit" class="btn btn-success" tabindex="2" formaction="@helpers.url(repository)/issue_comments/new" value="Comment"/>
             }
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR removes extra close div tag which introduced by #1829.
It was breaking pull request page's tab pane markup.