### PR TITLE
Add new initialize option as `git commit -m "..." --allow-empty"`

### DIFF
--- a/src/main/scala/gitbucket/core/service/RepositoryCreationService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryCreationService.scala
@@ -89,23 +89,26 @@ trait RepositoryCreationService {
         val gitdir = getRepositoryDir(owner, name)
         JGitUtil.initRepository(gitdir)
 
-        if (initOption == "README") {
+        if (initOption == "README" || initOption == "EMPTY_COMMIT") {
           using(Git.open(gitdir)) { git =>
             val builder = DirCache.newInCore.builder()
             val inserter = git.getRepository.newObjectInserter()
             val headId = git.getRepository.resolve(Constants.HEAD + "^{commit}")
-            val content = if (description.nonEmpty) {
-              name + "\n" +
-                "===============\n" +
-                "\n" +
-                description.get
-            } else {
-              name + "\n" +
-                "===============\n"
-            }
 
-            builder.add(JGitUtil.createDirCacheEntry("README.md", FileMode.REGULAR_FILE,
-              inserter.insert(Constants.OBJ_BLOB, content.getBytes("UTF-8"))))
+            if (initOption == "README") {
+              val content = if (description.nonEmpty) {
+                name + "\n" +
+                  "===============\n" +
+                  "\n" +
+                  description.get
+              } else {
+                name + "\n" +
+                  "===============\n"
+              }
+
+              builder.add(JGitUtil.createDirCacheEntry("README.md", FileMode.REGULAR_FILE,
+                inserter.insert(Constants.OBJ_BLOB, content.getBytes("UTF-8"))))
+            }
             builder.finish()
 
             JGitUtil.createNewCommit(git, inserter, headId, builder.getDirCache.writeTree(inserter),

--- a/src/main/twirl/gitbucket/core/account/newrepo.scala.html
+++ b/src/main/twirl/gitbucket/core/account/newrepo.scala.html
@@ -66,6 +66,13 @@ isCreateRepoOptionPublic: Boolean)(implicit context: gitbucket.core.controller.C
           </div>
         </label>
         <label class="radio">
+          <input type="radio" name="initOption" value="EMPTY_COMMIT"/>
+          <span class="strong">Initialize this repository with an empty commit</span>
+          <div class="normal muted">
+            Create an empty repository with empty commit. You can clone the repository immediately.
+          </div>
+        </label>
+        <label class="radio">
           <input type="radio" name="initOption" value="README"/>
           <span class="strong">Initialize this repository with a README</span>
           <div class="normal muted">


### PR DESCRIPTION

![20180128-185751](https://user-images.githubusercontent.com/6997928/35480969-99ed20e4-045d-11e8-931c-173fec2062a8.png)


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
