### PR TITLE
fix 1872.

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -145,12 +145,13 @@ trait ApiControllerBase extends ControllerBase {
    */
   get("/api/v3/repos/:owner/:repo/contents/*")(referrersOnly { repository =>
     def getFileInfo(git: Git, revision: String, pathStr: String): Option[FileInfo] = {
-      val path = new java.io.File(pathStr)
-      val dirName = path.getParent match {
-        case null => "."
-        case s => s
+      val (dirName, fileName) = pathStr.lastIndexOf('/') match {
+        case -1 =>
+          (".", pathStr)
+        case n =>
+          (pathStr.take(n), pathStr.drop(n + 1))
       }
-      getFileList(git, revision, dirName).find(f => f.name.equals(path.getName))
+      getFileList(git, revision, dirName).find(f => f.name.equals(fileName))
     }
 
     val path = multiParams("splat").head match {


### PR DESCRIPTION
java.io.File#getParent returns path with "\" instead of "/".
so don't use this method.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
