### PR TITLE
Assign dummy password to newly created users

### DIFF
--- a/src/main/scala/gitbucket/core/service/AccountFederationService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountFederationService.scala
@@ -34,7 +34,7 @@ trait AccountFederationService {
         None
       case None =>
         findAvailableUserName(preferredUserName, mailAddress) flatMap { userName =>
-          createAccount(userName, "", fullName.getOrElse(userName), mailAddress, isAdmin = false, None, None)
+          createAccount(userName, "JUNKJUNK", fullName.getOrElse(userName), mailAddress, isAdmin = false, None, None)
           createAccountFederation(issuer, subject, userName)
           getAccountByUserName(userName)
         }

--- a/src/main/scala/gitbucket/core/service/AccountFederationService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountFederationService.scala
@@ -34,7 +34,7 @@ trait AccountFederationService {
         None
       case None =>
         findAvailableUserName(preferredUserName, mailAddress) flatMap { userName =>
-          createAccount(userName, "JUNKJUNK", fullName.getOrElse(userName), mailAddress, isAdmin = false, None, None)
+          createAccount(userName, "[DUMMY]", fullName.getOrElse(userName), mailAddress, isAdmin = false, None, None)
           createAccountFederation(issuer, subject, userName)
           getAccountByUserName(userName)
         }

--- a/src/test/scala/gitbucket/core/service/AccountFederationServiceSpec.scala
+++ b/src/test/scala/gitbucket/core/service/AccountFederationServiceSpec.scala
@@ -9,7 +9,7 @@ class AccountFederationServiceSpec extends FunSpec with ServiceSpecBase {
       withTestDB { implicit session =>
         val actual = AccountFederationService.getOrCreateFederatedUser("someIssuer", "someSubject", "dummy@example.com", Some("foo"), Some("Foo"))
         assert(actual.get.userName == "foo")
-        assert(actual.get.password == "")
+        assert(actual.get.password == "[DUMMY]")
         assert(actual.get.fullName == "Foo")
         assert(actual.get.mailAddress == "dummy@example.com")
         assert(!actual.get.isAdmin)


### PR DESCRIPTION
Closes #1877 

Set's the passwords of users created through OpenId connect to a dummy value.  This allows the user
to reset their passwords at their convenience.  This then let's them use "git" command line to
authenticate push/pull requests. 

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

