### PR TITLE
Confirmation dialog for password changing

### DIFF
--- a/src/main/twirl/gitbucket/core/account/edit.scala.html
+++ b/src/main/twirl/gitbucket/core/account/edit.scala.html
@@ -55,13 +55,21 @@
         <div class="pull-right">
           <a href="@context.path/@account.userName/_delete" class="btn btn-danger" id="delete">Delete account</a>
         </div>
-        <input type="submit" class="btn btn-success" value="Save"/>
+        <input type="submit" class="btn btn-success" value="Save" id="save"/>
       </div>
     </form>
   }
 }
 <script>
 $(function(){
+  $('#save').click(function(){
+    if($('#password').val() != ''){
+      return confirm('Are you sure you want to change password?');
+    } else {
+      return true;
+    }
+  });
+
   $('#delete').click(function(){
     return confirm('Once you delete your account, there is no going back.\nAre you sure?');
   });

--- a/src/main/twirl/gitbucket/core/admin/user.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/user.scala.html
@@ -85,10 +85,21 @@
         @if(account.isEmpty){
           <input type="submit" class="btn btn-success" value="Create user" formaction="@context.path/admin/users/_newuser"/>
         } else {
-          <input type="submit" class="btn btn-success" value="Update user" formaction="@context.path/admin/users/@account.get.userName/_edituser"/>
+          <input type="submit" class="btn btn-success" value="Update user" formaction="@context.path/admin/users/@account.get.userName/_edituser" id="update"/>
         }
         <a href="@context.path/admin/users" class="btn btn-default">Cancel</a>
       </fieldset>
     </form>
   }
 }
+<script>
+$(function(){
+  $('#update').click(function(){
+    if($('#password').val() != ''){
+      return confirm('Are you sure you want to change password of this user?');
+    } else {
+      return true;
+    }
+  });
+});
+</script>


### PR DESCRIPTION
If something filled in he password field when account modification form is going to be submitted, a confirmation dialog is shown to conform you are sure that you want to change password. It works at the account maintenance form for administrators as well.

![confirm-password-changing-1](https://user-images.githubusercontent.com/1094760/36583255-3edb5594-18b8-11e8-9566-8adfc939f30f.png)

![confirm-password-changing-2](https://user-images.githubusercontent.com/1094760/36583262-45d26ed2-18b8-11e8-9f35-d962593498b5.png)

