### PR TITLE
Show banner to create a personal access token for OIDC users

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -25,6 +25,7 @@ class IndexController extends IndexControllerBase
   with PrioritiesService
   with UsersAuthenticator
   with ReferrerAuthenticator
+  with AccessTokenService
   with AccountFederationService
   with OpenIDConnectService
 
@@ -36,6 +37,8 @@ trait IndexControllerBase extends ControllerBase {
     with RepositorySearchService
     with UsersAuthenticator
     with ReferrerAuthenticator
+    with AccessTokenService
+    with AccountFederationService
     with OpenIDConnectService =>
 
   case class SignInForm(userName: String, password: String, hash: Option[String])
@@ -59,9 +62,17 @@ trait IndexControllerBase extends ControllerBase {
   get("/"){
     context.loginAccount.map { account =>
       val visibleOwnerSet: Set[String] = Set(account.userName) ++ getGroupsByUserName(account.userName)
-      gitbucket.core.html.index(getRecentActivitiesByOwners(visibleOwnerSet), Nil, getUserRepositories(account.userName, withoutPhysicalInfo = true))
+      gitbucket.core.html.index(
+        getRecentActivitiesByOwners(visibleOwnerSet),
+        Nil,
+        getUserRepositories(account.userName, withoutPhysicalInfo = true),
+        showBannerToCreatePersonalAccessToken = hasAccountFederation(account.userName) && !hasAccessToken(account.userName))
     }.getOrElse {
-      gitbucket.core.html.index(getRecentActivities(), getVisibleRepositories(None, withoutPhysicalInfo = true), Nil)
+      gitbucket.core.html.index(
+        getRecentActivities(),
+        getVisibleRepositories(None, withoutPhysicalInfo = true),
+        Nil,
+        showBannerToCreatePersonalAccessToken = false)
     }
   }
 

--- a/src/main/scala/gitbucket/core/service/AccessTokenService.scala
+++ b/src/main/scala/gitbucket/core/service/AccessTokenService.scala
@@ -2,7 +2,7 @@ package gitbucket.core.service
 
 import gitbucket.core.model.Profile._
 import gitbucket.core.model.Profile.profile.blockingApi._
-import gitbucket.core.model.{Account, AccessToken}
+import gitbucket.core.model.{AccessToken, Account}
 import gitbucket.core.util.StringUtil
 
 import scala.util.Random
@@ -47,6 +47,9 @@ trait AccessTokenService {
 
   def getAccessTokens(userName: String)(implicit s: Session): List[AccessToken] =
     AccessTokens.filter(_.userName === userName.bind).sortBy(_.accessTokenId.desc).list
+
+  def hasAccessToken(userName: String)(implicit s: Session): Boolean =
+    AccessTokens.filter(_.userName === userName.bind).exists.run
 
   def deleteAccessToken(userName: String, accessTokenId: Int)(implicit s: Session): Unit =
     AccessTokens filter (t => t.userName === userName.bind && t.accessTokenId === accessTokenId) delete

--- a/src/main/scala/gitbucket/core/service/AccountFederationService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountFederationService.scala
@@ -70,6 +70,9 @@ trait AccountFederationService {
       .map { case _ ~ ac => ac }
       .firstOption
 
+  def hasAccountFederation(userName: String)(implicit s: Session): Boolean =
+    AccountFederations.filter(_.userName === userName.bind).exists.run
+
   def createAccountFederation(issuer: String, subject: String, userName: String)(implicit s: Session): Unit =
     AccountFederations insert AccountFederation(issuer, subject, userName)
 }

--- a/src/main/twirl/gitbucket/core/index.scala.html
+++ b/src/main/twirl/gitbucket/core/index.scala.html
@@ -1,6 +1,7 @@
 @(activities: List[gitbucket.core.model.Activity],
   recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
-  userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
+  userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
+  showBannerToCreatePersonalAccessToken: Boolean)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main("GitBucket"){
   @gitbucket.core.dashboard.html.sidebar(recentRepositories, userRepositories){
@@ -8,6 +9,15 @@
       <div class="alert alert-info" style="background-color: white; color: #555; border-color: #4183c4; font-size: small; line-height: 120%;">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         @Html(information)
+      </div>
+    }
+    @if(showBannerToCreatePersonalAccessToken){
+      <div class="alert alert-info" style="background-color: white; color: #555; border-color: #4183c4; font-size: small; line-height: 120%;">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        You can
+        <a href="@context.path/@context.loginAccount.map(_.userName)/_application" style="color: inherit;">
+          <strong>create a personal access token</strong>
+        </a> and use it in place of a password on the <code>git</code> command line.
       </div>
     }
     @gitbucket.core.dashboard.html.tab()


### PR DESCRIPTION
This pull request adds a banner to create a personal access token for OpenID Connect (OIDC) users. It improves OIDC users easily understand how to use the `git` command line.

### Screentshots

If the current user is logged in via OIDC and does not have any token, the banner is shown:

![image](https://user-images.githubusercontent.com/321266/37201384-e35599dc-23ca-11e8-9e3e-46b7d247e564.png)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
