### PR TITLE
Display commit message of tags in the release page

### DIFF
--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -143,8 +143,9 @@ object JGitUtil {
    * @param name the tag name
    * @param time the tagged date
    * @param id the commit id
+   * @param message the message of the tagged commit
    */
-  case class TagInfo(name: String, time: Date, id: String)
+  case class TagInfo(name: String, time: Date, id: String, message: String)
 
   /**
    * The submodule data
@@ -233,7 +234,7 @@ object JGitUtil {
           git.tagList.call.asScala.flatMap { ref =>
             try {
               val revCommit = getRevCommitFromId(git, ref.getObjectId)
-              Some(TagInfo(ref.getName.stripPrefix("refs/tags/"), revCommit.getCommitterIdent.getWhen, revCommit.getName))
+              Some(TagInfo(ref.getName.stripPrefix("refs/tags/"), revCommit.getCommitterIdent.getWhen, revCommit.getName, revCommit.getShortMessage))
             } catch {
               case _: IncorrectObjectTypeException =>
                 None

--- a/src/main/twirl/gitbucket/core/releases/form.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/form.scala.html
@@ -1,5 +1,5 @@
 @(repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
-  tag: String,
+  tag: gitbucket.core.util.JGitUtil.TagInfo,
   release: Option[(gitbucket.core.model.Release, Seq[gitbucket.core.model.ReleaseAsset])])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main(s"New Release - ${repository.owner}/${repository.name}", Some(repository)){
@@ -8,15 +8,15 @@
       <div class="row-fluid">
         <div class="co`l-md-12">
           @if(release.isEmpty){
-            <h3>New release for @tag</h3>
+            <h3>New release for @tag.name</h3>
           } else {
-            <h3>Update release for @tag</h3>
+            <h3>Update release for @tag.name</h3>
           }
           <span id="error-name" class="error"></span>
-          <input type="text" id="release-name" name="name" class="form-control" value="@release.map { case (release, _) => @release.name }.getOrElse(tag)" placeholder="Title" style="margin-bottom: 6px;" autofocus/>
+          <input type="text" id="release-name" name="name" class="form-control" value="@release.map { case (release, _) => @release.name }.getOrElse(tag.name)" placeholder="Title" style="margin-bottom: 6px;" autofocus/>
           @gitbucket.core.helper.html.preview(
             repository         = repository,
-            content            = release.flatMap { case (release, _) => release.content }.getOrElse(""),
+            content            = release.flatMap { case (release, _) => release.content }.getOrElse(tag.message),
             enableWikiLink     = false,
             enableRefsLink     = true,
             enableLineBreaks   = true,
@@ -31,7 +31,7 @@
             @release.map { case (release, assets) =>
               @assets.map { asset =>
                 <li>
-                  <a href="@context.baseUrl/@repository.owner/@repository.name/_release/@helpers.encodeRefName(tag)/@asset.fileName"><i class="octicon octicon-file"></i>@asset.label</a>
+                  <a href="@context.baseUrl/@repository.owner/@repository.name/_release/@helpers.encodeRefName(tag.name)/@asset.fileName"><i class="octicon octicon-file"></i>@asset.label</a>
                   <a href="#" class="remove pull-right" style="padding-top: 0px;">(remove)</a>
                   <input type="hidden" name="file:@asset.fileName" value="@asset.label"/>
                 </li>
@@ -43,9 +43,9 @@
           </div>
           <div class="align-right" style="margin-top: 12px;">
             @if(release.isEmpty){
-              <input type="submit" class="btn btn-success" value="Submit new release" formaction="@helpers.url(repository)/releases/@helpers.encodeRefName(tag)/create"/>
+              <input type="submit" class="btn btn-success" value="Submit new release" formaction="@helpers.url(repository)/releases/@helpers.encodeRefName(tag.name)/create"/>
             } else {
-              <input type="submit" class="btn btn-success" value="Update release" formaction="@helpers.url(repository)/releases/@helpers.encodeRefName(tag)/edit"/>
+              <input type="submit" class="btn btn-success" value="Update release" formaction="@helpers.url(repository)/releases/@helpers.encodeRefName(tag.name)/edit"/>
             }
           </div>
         </div>
@@ -61,11 +61,11 @@ $(function(){
 
   $("#drop").dropzone({
     maxFilesize: @{gitbucket.core.util.FileUtil.MaxFileSize / 1024 / 1024},
-    url: '@context.path/upload/release/@repository.owner/@repository.name/@helpers.encodeRefName(tag)',
+    url: '@context.path/upload/release/@repository.owner/@repository.name/@helpers.encodeRefName(tag.name)',
     previewTemplate: "<div class=\"dz-preview\">\n  <div class=\"dz-progress\"><span class=\"dz-upload\" data-dz-uploadprogress>Uploading your files...</span></div>\n  <div class=\"dz-error-message\"><span data-dz-errormessage></span></div>\n</div>",
     success: function(file, id) {
       var attach =
-        '<li><a href="@context.baseUrl/@repository.owner/@repository.name/_release/@helpers.encodeRefName(tag)/' + id + '">' +
+        '<li><a href="@context.baseUrl/@repository.owner/@repository.name/_release/@helpers.encodeRefName(tag.name)/' + id + '">' +
         '<i class="octicon octicon-file"></i>' + escapeHtml(file.name) + '</a>' +
         '<a href="#" class="remove pull-right" style="padding-top: 0px;">(remove)</a>' +
         '<input type="hidden" name="file:' + id + '" value="' + escapeHtml(file.name) + '"/>'

--- a/src/main/twirl/gitbucket/core/releases/list.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/list.scala.html
@@ -39,8 +39,11 @@
                       <a class="btn btn-success" href="@helpers.url(repository)/releases/@{helpers.encodeRefName(tag.name)}/create" id="edit">Create release</a>
                     </div>
                   }
+                  <div>@tag.message<br><br></div>
                 }
+                @*
                 <h4>Downloads</h4>
+                *@
                 <ul style="list-style: none; padding-left: 8px;">
                   @release.map { case (release, assets) =>
                     @assets.map { asset =>

--- a/src/main/twirl/gitbucket/core/releases/list.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/list.scala.html
@@ -41,9 +41,6 @@
                   }
                   <div>@tag.message<br><br></div>
                 }
-                @*
-                <h4>Downloads</h4>
-                *@
                 <ul style="list-style: none; padding-left: 8px;">
                   @release.map { case (release, assets) =>
                     @assets.map { asset =>

--- a/src/main/twirl/gitbucket/core/releases/release.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/release.scala.html
@@ -40,7 +40,6 @@
             enableTaskList     = true,
             hasWritePermission = hasWritePermission
           )
-          <h4>Downloads</h4>
           <ul style="list-style: none; padding-left: 8px;" id="attachedFiles">
             @assets.map{ asset =>
               <li>


### PR DESCRIPTION
Closes #1898

In default, a commit message is displayed for each tags in the releases page:

![releases_message_1](https://user-images.githubusercontent.com/1094760/37244829-e1b31b6a-24d1-11e8-9b2c-4ae4990cb747.png)

When creating a release, the commit message of the tag is displayed as the initial value of the release description.

![releases_message_2](https://user-images.githubusercontent.com/1094760/37244831-f453c2ce-24d1-11e8-958f-5551a6ecba78.png)
