### PR TITLE
Prevent parsing filename as Markdown in conflict message

### DIFF
--- a/src/main/scala/gitbucket/core/service/MergeService.scala
+++ b/src/main/scala/gitbucket/core/service/MergeService.scala
@@ -298,7 +298,7 @@ object MergeService{
 
     s"Can't merge ${mergeTip.name} into ${mergeBaseTip.name}\n\n" +
       "Conflicting files:\n" +
-      mergeResults.asScala.map { case (key, _) => "- " + key + "\n" }.mkString
+      mergeResults.asScala.map { case (key, _) => "- `" + key + "`\n" }.mkString
   }
 
 }


### PR DESCRIPTION
Filenames shown in conflict message are parsed as Markdown. 
ex. `module/__init__.py` is displayed like module/__init__.py
I set filename in conflict message as code.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct