### PR TITLE
Add plugin list API

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiPlugin.scala
+++ b/src/main/scala/gitbucket/core/api/ApiPlugin.scala
@@ -1,0 +1,17 @@
+package gitbucket.core.api
+
+import gitbucket.core.plugin.{PluginRegistry, PluginInfo}
+
+case class ApiPlugin(
+  id: String,
+  name: String,
+  versino: String,
+  description: String,
+  jarFileName: String
+)
+
+object ApiPlugin{
+  def apply(plugin: PluginInfo): ApiPlugin = {
+    ApiPlugin(plugin.pluginId, plugin.pluginName, plugin.pluginVersion, plugin.description, plugin.pluginJar.getName)
+  }
+}

--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -721,7 +721,7 @@ trait ApiControllerBase extends ControllerBase {
   /**
     * non-GitHub compatible API for listing plugins
     */
-  get("/api/v3/plugins"){
+  get("/api/v3/gitbucket/plugins"){
     PluginRegistry().getPlugins().map{ApiPlugin(_)}
   }
 }

--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -10,6 +10,7 @@ import gitbucket.core.util.Implicits._
 import gitbucket.core.util.JGitUtil._
 import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util._
+import gitbucket.core.plugin.PluginRegistry
 import gitbucket.core.view.helpers.{isRenderable, renderMarkup}
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.revwalk.RevWalk
@@ -717,5 +718,11 @@ trait ApiControllerBase extends ControllerBase {
     }
   })
 
+  /**
+    * non-GitHub compatible API for listing plugins
+    */
+  get("/api/v3/plugins"){
+    PluginRegistry().getPlugins().map{ApiPlugin(_)}
+  }
 }
 


### PR DESCRIPTION
I want this feature to use in plugin building farm.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
