### PR TITLE
Render by plugin even if file is binary

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/blob.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/blob.scala.html
@@ -70,31 +70,31 @@
         }
       </div>
     </div>
-      @if(content.viewType == "text"){
-        @defining(helpers.isRenderable(pathList.last)){ isRenderable =>
-          @if(!isBlame && isRenderable) {
-            <div class="box-content-bottom markdown-body" style="padding-left: 20px; padding-right: 20px;">
-              @helpers.renderMarkup(pathList, content.content.get, branch, repository, false, false, true)
-            </div>
-          } else {
-            <div class="box-content-bottom">
-              <pre class="prettyprint linenums blob @if(!isRenderable){ no-renderable } ">@content.content.map(_.replaceAll("^(\r?\n)", "$1$1"))</pre>
-            </div>
-          }
+    @defining(helpers.isRenderable(pathList.last)){ isRenderable =>
+      @if(!isBlame && isRenderable) {
+        <div class="box-content-bottom @if(content.viewType == "text"){ markdown-body } " style="padding-left: 20px; padding-right: 20px;">
+          @helpers.renderMarkup(pathList, content.content.getOrElse(""), branch, repository, false, false, true)
+        </div>
+      }else{
+        @if(content.viewType == "text"){
+          <div class="box-content-bottom">
+            <pre class="prettyprint linenums blob @if(!isRenderable){ no-renderable } ">@content.content.map(_.replaceAll("^(\r?\n)", "$1$1"))</pre>
+          </div>
+        }
+        @if(content.viewType == "image"){
+          <div class="box-content-bottom">
+            <img src="@helpers.url(repository)/raw/@helpers.encodeRefName((branch :: pathList).mkString("/"))"/>
+          </div>
+        }
+        @if(content.viewType == "large" || content.viewType == "binary"){
+          <div class="box-content-bottom" style="text-align: center; padding-top: 20px; padding-bottom: 20px;">
+            <a href="@helpers.url(repository)/raw/@helpers.encodeRefName((branch :: pathList).mkString("/"))">View Raw</a><br>
+            <br>
+            (Sorry about that, but we can't show files that are this big right now)
+          </div>
         }
       }
-      @if(content.viewType == "image"){
-        <div class="box-content-bottom">
-          <img src="@helpers.url(repository)/raw/@helpers.encodeRefName((branch :: pathList).mkString("/"))"/>
-        </div>
-      }
-      @if(content.viewType == "large" || content.viewType == "binary"){
-        <div class="box-content-bottom" style="text-align: center; padding-top: 20px; padding-bottom: 20px;">
-          <a href="@helpers.url(repository)/raw/@helpers.encodeRefName((branch :: pathList).mkString("/"))">View Raw</a><br>
-          <br>
-          (Sorry about that, but we can't show files that are this big right now)
-        </div>
-      }
+    }
   }
 }
 <script>


### PR DESCRIPTION
I wrote [gitbucket-html5media-plugin](https://github.com/kounoike/gitbucket-html5media-plugin). But sometimes it can't render media file.

This PR changes rendering logic. Current version checks isText first. When merged this PR, it checks isRenderable first.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
