### PR TITLE
Fix that Tomcat deployed with GitBucket can not shutdown.

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/InitializeListener.scala
+++ b/src/main/scala/gitbucket/core/servlet/InitializeListener.scala
@@ -37,6 +37,8 @@ class InitializeListener extends ServletContextListener with SystemSettingsServi
   private val system = ActorSystem("job", ConfigFactory.parseString(
     """
       |akka {
+      |  daemonic = on
+      |  coordinated-shutdown.run-by-jvm-shutdown-hook = off
       |  quartz {
       |    schedules {
       |      Daily {


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

When GitBucket is deployed to Tomcat, Tomcat will not be able to shutdown.
This seems to be caused by the JVM shutdown hook registered by Akka.
This problem was solved by preventing registration of Akka's JVM shutdown hook.

In addition, `daemonic = on` is set for just in case.