### PR TITLE
Add extra mail address support.

### DIFF
--- a/src/main/resources/update/gitbucket-core_4.24.xml
+++ b/src/main/resources/update/gitbucket-core_4.24.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeSet>
+  <createTable tableName="ACCOUNT_EXTRA_MAIL_ADDRESS">
+    <column name="USER_NAME" type="varchar(100)" nullable="false"/>
+    <column name="EXTRA_MAIL_ADDRESS" type="varchar(100)" nullable="false"/>
+  </createTable>
+
+  <addPrimaryKey constraintName="IDX_ACCOUNT_EXTRA_MAIL_ADDRESS_PK" tableName="ACCOUNT_EXTRA_MAIL_ADDRESS" columnNames="USER_NAME, EXTRA_MAIL_ADDRESS"/>
+  <addUniqueConstraint constraintName="IDX_ACCOUNT_EXTRA_MAIL_ADDRESS_1" tableName="ACCOUNT_EXTRA_MAIL_ADDRESS" columnNames="EXTRA_MAIL_ADDRESS"/>
+</changeSet>

--- a/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
+++ b/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
@@ -50,5 +50,6 @@ object GitBucketCoreModule
       new Version("4.21.1"),
       new Version("4.21.2"),
       new Version("4.22.0", new LiquibaseMigration("update/gitbucket-core_4.22.xml")),
-      new Version("4.23.0", new LiquibaseMigration("update/gitbucket-core_4.23.xml"))
+      new Version("4.23.0", new LiquibaseMigration("update/gitbucket-core_4.23.xml")),
+      new Version("4.24.0", new LiquibaseMigration("update/gitbucket-core_4.24.xml"))
     )

--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -2,7 +2,7 @@ package gitbucket.core.controller
 
 import gitbucket.core.account.html
 import gitbucket.core.helper
-import gitbucket.core.model.{AccountWebHook, GroupMember, RepositoryWebHook, Role, WebHook, WebHookContentType}
+import gitbucket.core.model._
 import gitbucket.core.plugin.PluginRegistry
 import gitbucket.core.service._
 import gitbucket.core.service.WebHookService._
@@ -54,6 +54,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
     password: String,
     fullName: String,
     mailAddress: String,
+    extraMailAddresses: List[String],
     description: Option[String],
     url: Option[String],
     fileId: Option[String]
@@ -63,6 +64,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
     password: Option[String],
     fullName: String,
     mailAddress: String,
+    extraMailAddresses: List[String],
     description: Option[String],
     url: Option[String],
     fileId: Option[String],
@@ -78,6 +80,9 @@ trait AccountControllerBase extends AccountManagementControllerBase {
     "password" -> trim(label("Password", text(required, maxlength(20), password))),
     "fullName" -> trim(label("Full Name", text(required, maxlength(100)))),
     "mailAddress" -> trim(label("Mail Address", text(required, maxlength(100), uniqueMailAddress()))),
+    "extraMailAddresses" -> list(
+      trim(label("Additional Mail Address", text(maxlength(100), uniqueExtraMailAddress())))
+    ),
     "description" -> trim(label("bio", optional(text()))),
     "url" -> trim(label("URL", optional(text(maxlength(200))))),
     "fileId" -> trim(label("File ID", optional(text())))
@@ -87,6 +92,9 @@ trait AccountControllerBase extends AccountManagementControllerBase {
     "password" -> trim(label("Password", optional(text(maxlength(20), password)))),
     "fullName" -> trim(label("Full Name", text(required, maxlength(100)))),
     "mailAddress" -> trim(label("Mail Address", text(required, maxlength(100), uniqueMailAddress("userName")))),
+    "extraMailAddresses" -> list(
+      trim(label("Additional Mail Address", text(maxlength(100), uniqueExtraMailAddress("userName"))))
+    ),
     "description" -> trim(label("bio", optional(text()))),
     "url" -> trim(label("URL", optional(text(maxlength(200))))),
     "fileId" -> trim(label("File ID", optional(text()))),
@@ -295,26 +303,29 @@ trait AccountControllerBase extends AccountManagementControllerBase {
   get("/:userName/_edit")(oneselfOnly {
     val userName = params("userName")
     getAccountByUserName(userName).map { x =>
-      html.edit(x, flash.get("info"), flash.get("error"))
+      val extraMails = getAccountExtraMailAddresses(userName)
+      html.edit(x, extraMails, flash.get("info"), flash.get("error"))
     } getOrElse NotFound()
   })
 
   post("/:userName/_edit", editForm)(oneselfOnly { form =>
     val userName = params("userName")
-    getAccountByUserName(userName).map { account =>
-      updateAccount(
-        account.copy(
-          password = form.password.map(sha1).getOrElse(account.password),
-          fullName = form.fullName,
-          mailAddress = form.mailAddress,
-          description = form.description,
-          url = form.url
+    getAccountByUserName(userName).map {
+      account =>
+        updateAccount(
+          account.copy(
+            password = form.password.map(sha1).getOrElse(account.password),
+            fullName = form.fullName,
+            mailAddress = form.mailAddress,
+            description = form.description,
+            url = form.url
+          )
         )
-      )
 
-      updateImage(userName, form.fileId, form.clearImage)
-      flash += "info" -> "Account information has been updated."
-      redirect(s"/${userName}/_edit")
+        updateImage(userName, form.fileId, form.clearImage)
+        updateAccountExtraMailAddresses(userName, form.extraMailAddresses.filter(_ != ""))
+        flash += "info" -> "Account information has been updated."
+        redirect(s"/${userName}/_edit")
 
     } getOrElse NotFound()
   })
@@ -552,6 +563,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
         form.url
       )
       updateImage(form.userName, form.fileId, false)
+      updateAccountExtraMailAddresses(form.userName, form.extraMailAddresses)
       redirect("/signin")
     } else NotFound()
   }

--- a/src/main/scala/gitbucket/core/controller/ControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/ControllerBase.scala
@@ -371,6 +371,23 @@ trait AccountManagementControllerBase extends ControllerBase {
     }
   }
 
+  protected def uniqueExtraMailAddress(paramName: String = ""): Constraint = new Constraint() {
+    override def validate(
+      name: String,
+      value: String,
+      params: Map[String, Seq[String]],
+      messages: Messages
+    ): Option[String] = {
+      getAccountByMailAddress(value, true)
+        .filter { x =>
+          if (paramName.isEmpty) true else Some(x.userName) != params.optionValue(paramName)
+        }
+        .map { _ =>
+          "Mail address is already registered."
+        }
+    }
+  }
+
   val allReservedNames = Set(
     "git",
     "admin",

--- a/src/main/scala/gitbucket/core/model/AccountExtraMailAddress.scala
+++ b/src/main/scala/gitbucket/core/model/AccountExtraMailAddress.scala
@@ -1,0 +1,19 @@
+package gitbucket.core.model
+
+trait AccountExtraMailAddressComponent { self: Profile =>
+  import profile.api._
+
+  lazy val AccountExtraMailAddresses = TableQuery[AccountExtraMailAddresses]
+
+  class AccountExtraMailAddresses(tag: Tag) extends Table[AccountExtraMailAddress](tag, "ACCOUNT_EXTRA_MAIL_ADDRESS") {
+    val userName = column[String]("USER_NAME", O PrimaryKey)
+    val extraMailAddress = column[String]("EXTRA_MAIL_ADDRESS", O PrimaryKey)
+    def * =
+      (userName, extraMailAddress) <> (AccountExtraMailAddress.tupled, AccountExtraMailAddress.unapply)
+  }
+}
+
+case class AccountExtraMailAddress(
+  userName: String,
+  extraMailAddress: String
+)

--- a/src/main/scala/gitbucket/core/model/Profile.scala
+++ b/src/main/scala/gitbucket/core/model/Profile.scala
@@ -68,5 +68,6 @@ trait CoreProfile
     with DeployKeyComponent
     with ReleaseTagComponent
     with ReleaseAssetComponent
+    with AccountExtraMailAddressComponent
 
 object Profile extends CoreProfile

--- a/src/main/twirl/gitbucket/core/account/edit.scala.html
+++ b/src/main/twirl/gitbucket/core/account/edit.scala.html
@@ -1,4 +1,4 @@
-@(account: gitbucket.core.model.Account, info: Option[Any], error: Option[Any])(implicit context: gitbucket.core.controller.Context)
+@(account: gitbucket.core.model.Account, extraMailAddresses: List[String], info: Option[Any], error: Option[Any])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.util.LDAPUtil
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main("Edit your profile"){
@@ -31,6 +31,13 @@
                 <input type="text" name="mailAddress" id="mailAddress" class="form-control" value="@if(!LDAPUtil.isDummyMailAddress(account)){@account.mailAddress}"/>
                 <span id="error-mailAddress" class="error"></span>
               </fieldset>
+              <fieldset class="form-group" id="extraMailAddresses">
+                <span class="strong">Additional Mail Address:</span>
+                @extraMailAddresses.zipWithIndex.map { case (mail, idx) =>
+                  <input type="text" name="extraMailAddresses[@idx]" id="extraMailAddresses[@idx]" class="form-control extraMailAddress" value="@mail"/>
+                  <span id="error-extraMailAddresses_@idx" class="error"></span>
+                }
+              </fieldset>
               <fieldset class="form-group">
                 <label for="url" class="strong">URL (optional):</label>
                 <input type="text" name="url" id="url" class="form-control" value="@account.url"/>
@@ -62,6 +69,8 @@
 }
 <script>
 $(function(){
+  addExtraMailAddress();
+  $('#extraMailAddresses').on('change', '.extraMailAddress', checkExtraMailAddress);
   $('#save').click(function(){
     if($('#password').val() != ''){
       return confirm('Are you sure you want to change password?');

--- a/src/main/twirl/gitbucket/core/account/register.scala.html
+++ b/src/main/twirl/gitbucket/core/account/register.scala.html
@@ -28,6 +28,9 @@
             <input type="text" name="mailAddress" id="mailAddress" class="form-control" value=""/>
             <span id="error-mailAddress" class="error"></span>
           </fieldset>
+          <div id="extraMailAddresses">
+            <span class="strong">Additional Mail Address:</span>
+          </div>
           <fieldset>
             <label for="url" class="strong">URL (optional):</label>
             <input type="text" name="url" id="url" class="form-control" value=""/>
@@ -52,4 +55,10 @@
     </form>
   </div>
 </div>
+<script>
+  $(function() {
+    addExtraMailAddress();
+    $('#extraMailAddresses').on('change', '.extraMailAddress', checkExtraMailAddress);
+  });
+</script>
 }

--- a/src/main/twirl/gitbucket/core/admin/user.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/user.scala.html
@@ -1,4 +1,4 @@
-@(account: Option[gitbucket.core.model.Account], error: Option[Any] = None)(implicit context: gitbucket.core.controller.Context)
+@(account: Option[gitbucket.core.model.Account], extraMailAddresses: List[String], error: Option[Any] = None)(implicit context: gitbucket.core.controller.Context)
 @gitbucket.core.html.main(if(account.isEmpty) "New user" else "Update user"){
   @gitbucket.core.admin.html.menu("users"){
     @gitbucket.core.helper.html.error(error)
@@ -50,6 +50,13 @@
             </div>
             <input type="text" name="mailAddress" id="mailAddress" class="form-control" value="@account.map(_.mailAddress)"/>
           </fieldset>
+          <fieldset class="form-group" id="extraMailAddresses">
+            <span class="strong">Additional Mail Address:</span>
+            @extraMailAddresses.zipWithIndex.map { case (mail, idx) =>
+            <input type="text" name="extraMailAddresses[@idx]" id="extraMailAddresses[@idx]" class="form-control extraMailAddress" value="@mail"/>
+            <span id="error-extraMailAddresses_@idx" class="error"></span>
+            }
+          </fieldset>
           <fieldset class="form-group">
             <label class="strong">User Type:</label>
             <label class="radio" for="userType_Normal">
@@ -94,6 +101,8 @@
 }
 <script>
 $(function(){
+  addExtraMailAddress();
+  $('#extraMailAddresses').on('change', '.extraMailAddress', checkExtraMailAddress);
   $('#update').click(function(){
     if($('#password').val() != ''){
       return confirm('Are you sure you want to change password of this user?');

--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -694,3 +694,35 @@ var imageDiff ={
   }
 };
 
+/**
+ * function for account extra mail address form control.
+ */
+function addExtraMailAddress() {
+  var fieldset = $('#extraMailAddresses');
+  var count = $('.extraMailAddress').length;
+  var html =   '<input type="text" name="extraMailAddresses[' + count + ']" id="extraMailAddresses[' + count + ']" class="form-control extraMailAddress"/>'
+  + '<span id="error-extraMailAddresses_' + count + '" class="error"></span>';
+  fieldset.append(html);
+}
+
+/**
+ * function for check account extra mail address form control.
+ */
+function checkExtraMailAddress(){
+  if ($(this).val() != ""){
+    var needAdd = true;
+    $('.extraMailAddress').each(function(){
+      if($(this).val() == ""){
+        needAdd = false;
+        return false;
+      }
+      return true;
+    });
+    if (needAdd){
+      addExtraMailAddress();
+    }
+  }
+  else {
+    $(this).remove();
+  }
+}


### PR DESCRIPTION
This PR adds extra mail address support. If merged this PR, we can close #652.

User can fill "Additional mail address" fields. If user inputs mail address to empty field, new empty input field added automatically. And empty field automatically removed when user deletes mail address.

![20180402-010417](https://user-images.githubusercontent.com/6997928/38175089-fbf538c2-3611-11e8-96c8-5975f470bbd7.png)

Additional mail addresses are used for resolving account from commit log. For example, this repository has two commits as:

1. root's primary mail address: root@localhost
2. root's additional mail address: root+1@localhost

![20180402-010916](https://user-images.githubusercontent.com/6997928/38175136-c697c522-3612-11e8-9a28-26c02cfff805.png)

In history view, These two addresses are resolved to root account.

![20180402-011142](https://user-images.githubusercontent.com/6997928/38175162-dc439a68-3612-11e8-9257-97c3022fbb68.png)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
