### PR TITLE
Fix a bug that fails to get the list of files of the repository root

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -161,7 +161,18 @@ trait ApiControllerBase extends ControllerBase {
   /*
    * https://developer.github.com/v3/repos/contents/#get-contents
    */
+  get("/api/v3/repos/:owner/:repo/contents")(referrersOnly { repository =>
+    getContents(repository, ".", params.getOrElse("ref", repository.repository.defaultBranch))
+  })
+
+  /*
+   * https://developer.github.com/v3/repos/contents/#get-contents
+   */
   get("/api/v3/repos/:owner/:repo/contents/*")(referrersOnly { repository =>
+    getContents(repository, multiParams("splat").head, params.getOrElse("ref", repository.repository.defaultBranch))
+  })
+
+  private def getContents(repository: RepositoryService.RepositoryInfo, path: String, refStr: String) = {
     def getFileInfo(git: Git, revision: String, pathStr: String): Option[FileInfo] = {
       val (dirName, fileName) = pathStr.lastIndexOf('/') match {
         case -1 =>
@@ -172,69 +183,61 @@ trait ApiControllerBase extends ControllerBase {
       getFileList(git, revision, dirName).find(f => f.name.equals(fileName))
     }
 
-    val path = multiParams("splat").head match {
-      case s if s.isEmpty => "."
-      case s              => s
-    }
-    val refStr = params.getOrElse("ref", repository.repository.defaultBranch)
-
-    using(Git.open(getRepositoryDir(params("owner"), params("repo")))) {
-      git =>
-        val fileList = getFileList(git, refStr, path)
-        if (fileList.isEmpty) { // file or NotFound
-          getFileInfo(git, refStr, path)
-            .flatMap(f => {
-              val largeFile = params.get("large_file").exists(s => s.equals("true"))
-              val content = getContentFromId(git, f.id, largeFile)
-              request.getHeader("Accept") match {
-                case "application/vnd.github.v3.raw" => {
-                  contentType = "application/vnd.github.v3.raw"
-                  content
-                }
-                case "application/vnd.github.v3.html" if isRenderable(f.name) => {
-                  contentType = "application/vnd.github.v3.html"
-                  content.map(
-                    c =>
-                      List(
-                        "<div data-path=\"",
-                        path,
-                        "\" id=\"file\">",
-                        "<article>",
-                        renderMarkup(path.split("/").toList, new String(c), refStr, repository, false, false, true).body,
-                        "</article>",
-                        "</div>"
-                      ).mkString
-                  )
-                }
-                case "application/vnd.github.v3.html" => {
-                  contentType = "application/vnd.github.v3.html"
-                  content.map(
-                    c =>
-                      List(
-                        "<div data-path=\"",
-                        path,
-                        "\" id=\"file\">",
-                        "<div class=\"plain\">",
-                        "<pre>",
-                        play.twirl.api.HtmlFormat.escape(new String(c)).body,
-                        "</pre>",
-                        "</div>",
-                        "</div>"
-                      ).mkString
-                  )
-                }
-                case _ =>
-                  Some(JsonFormat(ApiContents(f, RepositoryName(repository), content)))
+    using(Git.open(getRepositoryDir(params("owner"), params("repo")))) { git =>
+      val fileList = getFileList(git, refStr, path)
+      if (fileList.isEmpty) { // file or NotFound
+        getFileInfo(git, refStr, path)
+          .flatMap { f =>
+            val largeFile = params.get("large_file").exists(s => s.equals("true"))
+            val content = getContentFromId(git, f.id, largeFile)
+            request.getHeader("Accept") match {
+              case "application/vnd.github.v3.raw" => {
+                contentType = "application/vnd.github.v3.raw"
+                content
               }
-            })
-            .getOrElse(NotFound())
-        } else { // directory
-          JsonFormat(fileList.map { f =>
-            ApiContents(f, RepositoryName(repository), None)
-          })
-        }
+              case "application/vnd.github.v3.html" if isRenderable(f.name) => {
+                contentType = "application/vnd.github.v3.html"
+                content.map { c =>
+                  List(
+                    "<div data-path=\"",
+                    path,
+                    "\" id=\"file\">",
+                    "<article>",
+                    renderMarkup(path.split("/").toList, new String(c), refStr, repository, false, false, true).body,
+                    "</article>",
+                    "</div>"
+                  ).mkString
+                }
+              }
+              case "application/vnd.github.v3.html" => {
+                contentType = "application/vnd.github.v3.html"
+                content.map { c =>
+                  List(
+                    "<div data-path=\"",
+                    path,
+                    "\" id=\"file\">",
+                    "<div class=\"plain\">",
+                    "<pre>",
+                    play.twirl.api.HtmlFormat.escape(new String(c)).body,
+                    "</pre>",
+                    "</div>",
+                    "</div>"
+                  ).mkString
+                }
+              }
+              case _ =>
+                Some(JsonFormat(ApiContents(f, RepositoryName(repository), content)))
+            }
+          }
+          .getOrElse(NotFound())
+
+      } else { // directory
+        JsonFormat(fileList.map { f =>
+          ApiContents(f, RepositoryName(repository), None)
+        })
+      }
     }
-  })
+  }
 
   /*
    * https://developer.github.com/v3/git/refs/#get-a-reference


### PR DESCRIPTION
Caused by changing tail slash handling in GitBucket 4.23.0.

Reported in the Japanese gitter room:
https://gitter.im/gitbucket/gitbucket_ja?at=5ac1e74f1130fe3d36919b4a