### PR TITLE
Fix  #1871: Fixed breaking newlines when starting with multiple blank…

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/diff.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/diff.scala.html
@@ -103,8 +103,8 @@
         } else {
           @if(diff.newContent != None || diff.oldContent != None){
             <div id="diffText-@i" class="diffText"></div>
-            <textarea id="newText-@i" style="display: none;" data-file-name="@diff.oldPath">@diff.newContent.getOrElse("")</textarea>
-            <textarea id="oldText-@i" style="display: none;" data-file-name="@diff.newPath">@diff.oldContent.getOrElse("")</textarea>
+            <textarea id="newText-@i" style="display: none;" data-file-name="@diff.oldPath" data-val='@diff.newContent.getOrElse("")'></textarea>
+            <textarea id="oldText-@i" style="display: none;" data-file-name="@diff.newPath" data-val='@diff.oldContent.getOrElse("")'></textarea>
           } else {
             @if(diff.newIsImage || diff.oldIsImage){
               <div class="diff-image-render diff2up">

--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -78,9 +78,9 @@ function displayErrors(data, elem){
 function diffUsingJS(oldTextId, newTextId, outputId, viewType, ignoreSpace) {
   var old = $('#'+oldTextId), head = $('#'+newTextId);
   var render = new JsDiffRender({
-    oldText: old.val(),
+    oldText: old.data('val'),
     oldTextName: old.data('file-name'),
-    newText: head.val(),
+    newText: head.data('val'),
     newTextName: head.data('file-name'),
     ignoreSpace: ignoreSpace,
     contextSize: 4
@@ -116,7 +116,7 @@ function JsDiffRender(params){
     return function(ln){
       if(dom===null){
         var html = prettyPrintOne(
-          text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;').replace(/>/g,'&gt;'),
+          text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;').replace(/>/g,'&gt;').replace(/^\n/, '\n\n'),
           (/\.([^.]*)$/.exec(fileName)||[])[1],
           true);
         var re = /<li[^>]*id="?L([0-9]+)"?[^>]*>(.*?)<\/li>/gi, h;


### PR DESCRIPTION
Fix for [#1871](https://github.com/gitbucket/gitbucket/issues/1871)
By entering directly in the textarea tag, the first line feed is omitted, so use the custom data attribute

When calling prettyPrintOne, since two leading carriage returns were treated as one, replace only the leading newline

testing environment
 Mac
  Firefox 59.0.2 (64 bit)
  Chrome 65.0.3325.181（64 bit）
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

