### PR TITLE
limits tags just on commit, show tags on commits page. close #1968

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -237,6 +237,10 @@ trait RepositoryViewerControllerBase extends ControllerBase {
 
     using(Git.open(getRepositoryDir(repository.owner, repository.name))) {
       git =>
+        def getTags(sha: String): List[String] = {
+          JGitUtil.getTagsOfCommit(git, sha)
+        }
+
         JGitUtil.getCommitLog(git, branchName, page, 30, path) match {
           case Right((logs, hasNext)) =>
             html.commits(
@@ -250,7 +254,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
               hasNext,
               hasDeveloperRole(repository.owner, repository.name, context.loginAccount),
               getStatuses,
-              getSummary
+              getSummary,
+              getTags
             )
           case Left(_) => NotFound()
         }

--- a/src/main/twirl/gitbucket/core/repo/commits.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commits.scala.html
@@ -6,7 +6,8 @@
   hasNext: Boolean,
   hasWritePermission: Boolean,
   getStatuses: String => List[gitbucket.core.model.CommitStatus],
-  getSummary: List[gitbucket.core.model.CommitStatus] => (gitbucket.core.model.CommitState, String))(implicit context: gitbucket.core.controller.Context)
+  getSummary: List[gitbucket.core.model.CommitStatus] => (gitbucket.core.model.CommitState, String),
+  getTags: String => List[String])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main(s"${repository.owner}/${repository.name}", Some(repository)) {
   @gitbucket.core.html.menu("files", repository){
@@ -39,7 +40,18 @@
           @if(i != 0){ <tr> }
           <td>
             <div class="pull-right text-right">
-              <a href="@helpers.url(repository)/commit/@commit.id" class="monospace commit-message strong"><i class="octicon octicon-diff" style="color: black;"></i>@commit.id.substring(0, 7)</a><br>
+              @defining(getTags(commit.id)) { tags =>
+                @if(tags.nonEmpty){
+                  <span class="muted">
+                    <i class="octicon octicon-tag"></i>
+                    @tags.zipWithIndex.map { case (tag, i) =>
+                    <a href="@helpers.url(repository)/tree/@tag" class="tag" id="tag-@i">@tag</a>
+                    }
+                  </span>
+                }
+              }
+              <a href="@helpers.url(repository)/commit/@commit.id" class="monospace commit-message strong"><i class="octicon octicon-diff" style="color: black;"></i>@commit.id.substring(0, 7)</a>
+              <br>
               <a href="@helpers.url(repository)/tree/@commit.id" class="button-link">Browse files »</a>
             </div>
             <div>


### PR DESCRIPTION
This PR is answer for #1968. It limits tags on commit.

![image](https://user-images.githubusercontent.com/6997928/39200252-9beca4ac-4826-11e8-8409-684c184e0842.png)


And this PR also provide tag list on commit history page.

![image](https://user-images.githubusercontent.com/6997928/39200148-497b4f02-4826-11e8-8306-70bbc67d8896.png)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
