### PR TITLE
[WIP]Fix column type and validation for long webhook URL

### DIFF
--- a/src/main/resources/update/gitbucket-core_4.24.xml
+++ b/src/main/resources/update/gitbucket-core_4.24.xml
@@ -7,4 +7,7 @@
 
   <addPrimaryKey constraintName="IDX_ACCOUNT_EXTRA_MAIL_ADDRESS_PK" tableName="ACCOUNT_EXTRA_MAIL_ADDRESS" columnNames="USER_NAME, EXTRA_MAIL_ADDRESS"/>
   <addUniqueConstraint constraintName="IDX_ACCOUNT_EXTRA_MAIL_ADDRESS_1" tableName="ACCOUNT_EXTRA_MAIL_ADDRESS" columnNames="EXTRA_MAIL_ADDRESS"/>
+
+  <modifyDataType tableName="WEB_HOOK" columnName="URL" newDataType="text"/>
+  <modifyDataType tableName="WEB_HOOK_EVENT" columnName="URL" newDataType="text"/>
 </changeSet>

--- a/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositorySettingsController.scala
@@ -96,10 +96,10 @@ trait RepositorySettingsControllerBase extends ControllerBase {
 
   def webHookForm(update: Boolean) =
     mapping(
-      "url" -> trim(label("url", text(required, webHook(update)))),
+      "url" -> trim(label("url", text(required, maxlength(1000), webHook(update)))),
       "events" -> webhookEvents,
       "ctype" -> label("ctype", text()),
-      "token" -> optional(trim(label("token", text(maxlength(100)))))
+      "token" -> optional(trim(label("token", text(maxlength(2000)))))
     )(
       (url, events, ctype, token) => WebHookForm(url, events, WebHookContentType.valueOf(ctype), token)
     )


### PR DESCRIPTION
This fixes #1951.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
