### PR TITLE
don't separate user:branch in PR message

### DIFF
--- a/src/main/twirl/gitbucket/core/pulls/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/menu.scala.html
@@ -44,8 +44,8 @@
         <span class="muted">
           @helpers.user(comment.commentedUserName, styleClass = "username strong")
           merged @commits.size @helpers.plural(commits.size, "commit")
-          into <code>@pullreq.userName:@pullreq.branch</code> from <code>@pullreq.requestUserName
-          :@pullreq.requestBranch</code>
+          into <code>@pullreq.userName:@pullreq.branch</code>
+          from <code>@pullreq.requestUserName:@pullreq.requestBranch</code>
           @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
         </span>
         }.getOrElse {
@@ -53,8 +53,8 @@
           <span class="muted">
             @helpers.user(issue.openedUserName, styleClass = "username strong")
             wants to merge @commits.size @helpers.plural(commits.size, "commit")
-            into <code>@pullreq.userName:@pullreq.branch</code> from <code>@pullreq.requestUserName
-            :@pullreq.requestBranch</code>
+            into <code>@pullreq.userName:@pullreq.branch</code>
+            from <code>@pullreq.requestUserName:@pullreq.requestBranch</code>
           </span>
         }
       } else {
@@ -62,8 +62,8 @@
         <span class="muted">
           @helpers.user(issue.openedUserName, styleClass = "username strong")
           wants to merge @commits.size @helpers.plural(commits.size, "commit")
-          into <code>@pullreq.userName:@pullreq.branch</code> from <code>@pullreq.requestUserName
-          :@pullreq.requestBranch</code>
+          into <code>@pullreq.userName:@pullreq.branch</code>
+          from <code>@pullreq.requestUserName:@pullreq.requestBranch</code>
         </span>
       }
       </div>


### PR DESCRIPTION
PR message shows "into user:branch from user :branch". There is unexpected space.

![image](https://user-images.githubusercontent.com/6997928/39396607-1c07d294-4b2c-11e8-9fe3-a2e7e2f7af2b.png)

This PR removes it.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
