### PR TITLE
close and mark as merged PR by pushed commits

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
@@ -303,6 +303,19 @@ class CommitLogHook(owner: String, repository: String, pusher: String, baseUrl: 
               } else None
             }
 
+            // set PR as merged
+            val pulls = getPullRequestsByBranch(owner, repository, branchName, Some(false))
+            pulls.foreach { pull =>
+              if (commits.find { c =>
+                    c.id == pull.commitIdTo
+                  }.isDefined) {
+                markMergeAndClosePullRequest(pusher, owner, repository, pull)
+                getAccountByUserName(pusher).map { pusherAccount =>
+                  callPullRequestWebHook("closed", repositoryInfo, pull.issueId, baseUrl, pusherAccount)
+                }
+              }
+            }
+
             // record activity
             if (refName(1) == "heads") {
               command.getType match {


### PR DESCRIPTION
In [git-flow](https://github.com/nvie/gitflow), developer creates feature branch and make PR on web UI. and reviewer merges it by `git flow feature finish`. `git flow feature finish` merges feature branch into develop branch locally.

In this flow, created PR isn't closed automatically. Of course, user can close PR manually, but it doesn't show that this PR is merged or not.

This PR solves this problem. PRs are marked as merged and closed if:

- PR is open
- PR's branch is pushed branch
- pushed commits contains PR's commitIdTo

I can't decide last condition is valid or not. Perhaps, it should be change to "pushed commits contains all commits in PR"...?

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
