### PR TITLE
call issue closed webhook when pushed commit contains keywords

### DIFF
--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -700,11 +700,12 @@ trait IssuesService {
 
   def closeIssuesFromMessage(message: String, userName: String, owner: String, repository: String)(
     implicit s: Session
-  ): Unit = {
-    extractCloseId(message).foreach { issueId =>
-      for (issue <- getIssue(owner, repository, issueId) if !issue.closed) {
+  ): Seq[Int] = {
+    extractCloseId(message).flatMap { issueId =>
+      for (issue <- getIssue(owner, repository, issueId) if !issue.closed) yield {
         createComment(owner, repository, userName, issue.issueId, "Close", "close")
         updateClosed(owner, repository, issue.issueId, true)
+        issue.issueId
       }
     }
   }

--- a/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
@@ -296,7 +296,13 @@ class CommitLogHook(owner: String, repository: String, pusher: String, baseUrl: 
                   createIssueComment(owner, repository, commit)
                   // close issues
                   if (refName(1) == "heads" && branchName == defaultBranch && command.getType == ReceiveCommand.Type.UPDATE) {
-                    closeIssuesFromMessage(commit.fullMessage, pusher, owner, repository)
+                    getAccountByUserName(pusher).map { pusherAccount =>
+                      closeIssuesFromMessage(commit.fullMessage, pusher, owner, repository).foreach { issueId =>
+                        getIssue(owner, repository, issueId.toString).map { issue =>
+                          callIssuesWebHook("closed", repositoryInfo, issue, baseUrl, pusherAccount)
+                        }
+                      }
+                    }
                   }
                 }
                 Some(commit)


### PR DESCRIPTION
This PR fixes #1880.

But, it doesn't call plugin's hooks.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
