### PR TITLE
set ace editor mode by ext-modelist.js

### DIFF
--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -316,44 +316,6 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
    */
   def isPast(date: Date): Boolean = System.currentTimeMillis > date.getTime
 
-  /**
-   * Returns file type for AceEditor.
-   */
-  def editorType(fileName: String): String = {
-    fileName.toLowerCase match {
-      case x if (x.endsWith(".bat"))     => "batchfile"
-      case x if (x.endsWith(".java"))    => "java"
-      case x if (x.endsWith(".scala"))   => "scala"
-      case x if (x.endsWith(".js"))      => "javascript"
-      case x if (x.endsWith(".css"))     => "css"
-      case x if (x.endsWith(".md"))      => "markdown"
-      case x if (x.endsWith(".html"))    => "html"
-      case x if (x.endsWith(".xml"))     => "xml"
-      case x if (x.endsWith(".c"))       => "c_cpp"
-      case x if (x.endsWith(".cpp"))     => "c_cpp"
-      case x if (x.endsWith(".coffee"))  => "coffee"
-      case x if (x.endsWith(".ejs"))     => "ejs"
-      case x if (x.endsWith(".hs"))      => "haskell"
-      case x if (x.endsWith(".json"))    => "json"
-      case x if (x.endsWith(".jsp"))     => "jsp"
-      case x if (x.endsWith(".jsx"))     => "jsx"
-      case x if (x.endsWith(".cl"))      => "lisp"
-      case x if (x.endsWith(".clojure")) => "lisp"
-      case x if (x.endsWith(".lua"))     => "lua"
-      case x if (x.endsWith(".php"))     => "php"
-      case x if (x.endsWith(".py"))      => "python"
-      case x if (x.endsWith(".rdoc"))    => "rdoc"
-      case x if (x.endsWith(".rhtml"))   => "rhtml"
-      case x if (x.endsWith(".ruby"))    => "ruby"
-      case x if (x.endsWith(".sh"))      => "sh"
-      case x if (x.endsWith(".sql"))     => "sql"
-      case x if (x.endsWith(".tcl"))     => "tcl"
-      case x if (x.endsWith(".vbs"))     => "vbscript"
-      case x if (x.endsWith(".yml"))     => "yaml"
-      case _                             => "plain_text"
-    }
-  }
-
   def pre(value: Html): Html = Html(s"<pre>${value.body.trim.split("\n").map(_.trim).mkString("\n")}</pre>")
 
   /**

--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -75,6 +75,7 @@
   }
 }
 <script src="@helpers.assets("/vendors/ace/ace.js")" type="text/javascript" charset="utf-8"></script>
+<script src="@helpers.assets("/vendors/ace/ext-modelist.js")" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript" src="@helpers.assets("/vendors/jsdifflib/difflib.js")"></script>
 <link href="@helpers.assets("/vendors/jsdifflib/diffview.css")" type="text/css" rel="stylesheet" />
 <script>
@@ -89,7 +90,9 @@ $(function(){
   }
 
   @if(fileName.isDefined){
-    editor.getSession().setMode("ace/mode/@helpers.editorType(fileName.get)");
+    var modelist = ace.require("ace/ext/modelist");
+    var mode = modelist.getModeForPath("@fileName.get");
+    editor.getSession().setMode(mode.mode);
   }
   @if(protectedBranch){
     editor.setReadOnly(true);


### PR DESCRIPTION
ace editor has [many modes](https://github.com/ajaxorg/ace/blob/0155d37327fd08b9b7c6d033621b7ba6d8918622/lib/ace/ext/modelist.js#L45-L195). This PR enables all modes by javascript mode lookup method instead of scala method.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
