### PR TITLE
Fix editor preview bug

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -157,8 +157,8 @@ $(function(){
       // Show diff
       $('#preview').empty()
         .append($('<div id="diffText">'))
-        .append($('<textarea id="newText" style="display: none;">').data('file-name',$("#newFileName").val()).html(editor.getValue()))
-        .append($('<textarea id="oldText" style="display: none;">').data('file-name',$("#oldFileName").val()).html($('#initial').val()));
+        .append($('<textarea id="newText" style="display: none;">').data('file-name',$("#newFileName").val()).data('val', editor.getValue()))
+        .append($('<textarea id="oldText" style="display: none;">').data('file-name',$("#oldFileName").val()).data('val', $('#initial').val()));
       diffUsingJS('oldText', 'newText', 'diffText', 1);
     }
   });


### PR DESCRIPTION
This bug introduced by #1962. It changed [diffUsingJS](https://github.com/gitbucket/gitbucket/pull/1962/files#diff-be5f4a4353aa2e21e8c7b9ccfb598651) but it didn't fix `editor.scala.html`.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
