### PR TITLE
Show mail address in profile page

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -229,13 +229,15 @@ trait AccountControllerBase extends AccountManagementControllerBase {
   get("/:userName") {
     val userName = params("userName")
     getAccountByUserName(userName).map { account =>
+      val extraMailAddresses = getAccountExtraMailAddresses(userName)
       params.getOrElse("tab", "repositories") match {
         // Public Activity
         case "activity" =>
           gitbucket.core.account.html.activity(
             account,
             if (account.isGroupAccount) Nil else getGroupsByUserName(userName),
-            getActivitiesByUser(userName, true)
+            getActivitiesByUser(userName, true),
+            extraMailAddresses
           )
 
         // Members
@@ -244,6 +246,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
           gitbucket.core.account.html.members(
             account,
             members,
+            extraMailAddresses,
             context.loginAccount.exists(
               x =>
                 members.exists { member =>
@@ -260,6 +263,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
             account,
             if (account.isGroupAccount) Nil else getGroupsByUserName(userName),
             getVisibleRepositories(context.loginAccount, Some(userName)),
+            extraMailAddresses,
             context.loginAccount.exists(
               x =>
                 members.exists { member =>

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -89,7 +89,8 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
         "jwsAlgorithm" -> trim(label("Signature algorithm", optional(text())))
       )(OIDC.apply)
     ),
-    "skinName" -> trim(label("AdminLTE skin name", text(required)))
+    "skinName" -> trim(label("AdminLTE skin name", text(required))),
+    "showMailAddress" -> trim(label("Show mail address", boolean()))
   )(SystemSettings.apply).verifying { settings =>
     Vector(
       if (settings.ssh && settings.baseUrl.isEmpty) {

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -68,6 +68,7 @@ trait SystemSettingsService {
         }
       }
       props.setProperty(SkinName, settings.skinName.toString)
+      props.setProperty(ShowMailAddress, settings.showMailAddress.toString)
       using(new java.io.FileOutputStream(GitBucketConf)) { out =>
         props.store(out, null)
       }
@@ -144,7 +145,8 @@ trait SystemSettingsService {
         } else {
           None
         },
-        getValue(props, SkinName, "skin-blue")
+        getValue(props, SkinName, "skin-blue"),
+        getValue(props, ShowMailAddress, false)
       )
     }
   }
@@ -174,7 +176,8 @@ object SystemSettingsService {
     ldap: Option[Ldap],
     oidcAuthentication: Boolean,
     oidc: Option[OIDC],
-    skinName: String
+    skinName: String,
+    showMailAddress: Boolean
   ) {
 
     def baseUrl(request: HttpServletRequest): String =
@@ -283,6 +286,7 @@ object SystemSettingsService {
   private val OidcClientSecret = "oidc.client_secret"
   private val OidcJwsAlgorithm = "oidc.jws_algorithm"
   private val SkinName = "skinName"
+  private val ShowMailAddress = "showMailAddress"
 
   private def getValue[A: ClassTag](props: java.util.Properties, key: String, default: A): A = {
     getSystemProperty(key).getOrElse(getEnvironmentVariable(key).getOrElse {

--- a/src/main/twirl/gitbucket/core/account/activity.scala.html
+++ b/src/main/twirl/gitbucket/core/account/activity.scala.html
@@ -1,8 +1,9 @@
 @(account: gitbucket.core.model.Account,
   groupNames: List[String],
-  activities: List[gitbucket.core.model.Activity])(implicit context: gitbucket.core.controller.Context)
+  activities: List[gitbucket.core.model.Activity],
+  extraMailAddresses: List[String])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
-@gitbucket.core.account.html.main(account, groupNames, "activity"){
+@gitbucket.core.account.html.main(account, groupNames, "activity", extraMailAddresses){
   <div class="pull-right">
     <a href="@context.path/@{account.userName}.atom"><img src="@helpers.assets("/common/images/feed.png")" alt="activities"></a>
   </div>

--- a/src/main/twirl/gitbucket/core/account/main.scala.html
+++ b/src/main/twirl/gitbucket/core/account/main.scala.html
@@ -1,4 +1,4 @@
-@(account: gitbucket.core.model.Account, groupNames: List[String], active: String,
+@(account: gitbucket.core.model.Account, groupNames: List[String], active: String, extraMailAddresses: List[String],
   isGroupManager: Boolean = false)(body: Html)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main(account.userName){
@@ -19,6 +19,16 @@
           <p style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
             <i class="octicon octicon-home"></i> <a href="@account.url">@account.url</a>
           </p>
+        }
+        @if(context.settings.showMailAddress){
+          <p style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+            <i class="octicon octicon-mail"></i> <a href="mailto: @account.mailAddress">@account.mailAddress</a>
+          </p>
+          @extraMailAddresses.map{ mail =>
+            <p style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+              <i class="octicon octicon-mail"></i> <a href="mailto: @mail">@mail</a>
+            </p>
+          }
         }
         <p style="color: #999">
           <i class="octicon octicon-clock"></i> Joined on @helpers.date(account.registeredDate)

--- a/src/main/twirl/gitbucket/core/account/members.scala.html
+++ b/src/main/twirl/gitbucket/core/account/members.scala.html
@@ -1,6 +1,6 @@
-@(account: gitbucket.core.model.Account, members: List[gitbucket.core.model.GroupMember], isGroupManager: Boolean)(implicit context: gitbucket.core.controller.Context)
+@(account: gitbucket.core.model.Account, members: List[gitbucket.core.model.GroupMember], extraMailAddresses: List[String], isGroupManager: Boolean)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
-@gitbucket.core.account.html.main(account, Nil, "members", isGroupManager){
+@gitbucket.core.account.html.main(account, Nil, "members", extraMailAddresses, isGroupManager){
   @if(members.isEmpty){
     No members
   } else {

--- a/src/main/twirl/gitbucket/core/account/repositories.scala.html
+++ b/src/main/twirl/gitbucket/core/account/repositories.scala.html
@@ -1,8 +1,9 @@
 @(account: gitbucket.core.model.Account, groupNames: List[String],
   repositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
+  extraMailAddresses: List[String],
   isGroupManager: Boolean)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
-@gitbucket.core.account.html.main(account, groupNames, "repositories", isGroupManager){
+@gitbucket.core.account.html.main(account, groupNames, "repositories", extraMailAddresses, isGroupManager){
   @if(repositories.isEmpty){
     No repositories
   } else {

--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -132,6 +132,21 @@
   </label>
 </fieldset>
 <!--====================================================================-->
+<!-- Show mail address -->
+<!--====================================================================-->
+<hr>
+<label class="strong">Show mail address</label>
+<fieldset>
+  <label class="radio">
+    <input type="radio" name="showMailAddress" value="true"@if(context.settings.showMailAddress){ checked}>
+    <span class="strong">Show</span> <span class="normal">- Anyone can view mail address by user's profile page.</span>
+  </label>
+  <label class="radio">
+    <input type="radio" name="allowAnonymousAccess" value="false"@if(!context.settings.showMailAddress){ checked}>
+    <span class="strong">Hide</span> <span class="normal">- Hide mail address in user's profile page.</span>
+  </label>
+</fieldset>
+<!--====================================================================-->
 <!-- Activity -->
 <!--====================================================================-->
 <hr>

--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -142,7 +142,7 @@
     <span class="strong">Show</span> <span class="normal">- Anyone can view mail address by user's profile page.</span>
   </label>
   <label class="radio">
-    <input type="radio" name="allowAnonymousAccess" value="false"@if(!context.settings.showMailAddress){ checked}>
+    <input type="radio" name="showMailAddress" value="false"@if(!context.settings.showMailAddress){ checked}>
     <span class="strong">Hide</span> <span class="normal">- Hide mail address in user's profile page.</span>
   </label>
 </fieldset>

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -134,7 +134,8 @@ class AvatarImageProviderSpec extends FunSpec with MockitoSugar {
       ldap = None,
       oidcAuthentication = false,
       oidc = None,
-      skinName = "skin-blue"
+      skinName = "skin-blue",
+      showMailAddress = false
     )
 
   /**


### PR DESCRIPTION
Discussed in #673. It can be controlled by system settings. And it also show extra mail address introduced in #1939

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
