### PR TITLE
Show SMTP Error message in testing email settings

### DIFF
--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -15,6 +15,7 @@ import gitbucket.core.util.StringUtil._
 import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.{AdminAuthenticator, Mailer}
 import org.apache.commons.io.IOUtils
+import org.apache.commons.mail.EmailException
 import org.json4s.jackson.Serialization
 import org.scalatra._
 import org.scalatra.forms._
@@ -312,6 +313,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
       "Test mail has been sent to: " + form.testAddress
 
     } catch {
+      case e: EmailException => s"[Error] ${e.getCause}"
       case e: Exception => "[Error] " + e.toString
     }
   })


### PR DESCRIPTION
This PR add show SMTP error message as follows:

before:

![image](https://user-images.githubusercontent.com/6997928/39505995-028d94e2-4e11-11e8-876f-540374337786.png)



after:
![image](https://user-images.githubusercontent.com/6997928/39505977-db182724-4e10-11e8-8aa3-d43021970886.png)


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
