### PR TITLE
Introduce new Renderer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.pgp.PgpKeys._
 
 val Organization = "io.github.gitbucket"
 val Name = "gitbucket"
-val GitBucketVersion = "4.24.1"
+val GitBucketVersion = "4.25.0-SNAPSHOT"
 val ScalatraVersion = "2.6.1"
 val JettyVersion = "9.4.7.v20170914"
 

--- a/src/main/scala/gitbucket/core/api/ApiCommit.scala
+++ b/src/main/scala/gitbucket/core/api/ApiCommit.scala
@@ -3,10 +3,8 @@ package gitbucket.core.api
 import gitbucket.core.util.JGitUtil
 import gitbucket.core.util.JGitUtil.CommitInfo
 import gitbucket.core.util.RepositoryName
-
 import org.eclipse.jgit.diff.DiffEntry
 import org.eclipse.jgit.api.Git
-
 import java.util.Date
 
 /**
@@ -37,7 +35,7 @@ case class ApiCommit(
 
 object ApiCommit {
   def apply(git: Git, repositoryName: RepositoryName, commit: CommitInfo, urlIsHtmlUrl: Boolean = false): ApiCommit = {
-    val diffs = JGitUtil.getDiffs(git, None, commit.id, false, false)
+    val diffs = JGitUtil.getDiffs(git, repositoryName.owner, repositoryName.name, None, commit.id, false, false)
     ApiCommit(
       id = commit.id,
       message = commit.fullMessage,

--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -1,8 +1,8 @@
 package gitbucket.core.controller
 
 import java.io.File
-import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import gitbucket.core.plugin.PluginRegistry
 import gitbucket.core.repo.html
 import gitbucket.core.helper
@@ -277,7 +277,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
         repository = repository,
         pathList = if (path.length == 0) Nil else path.split("/").toList,
         fileName = None,
-        content = JGitUtil.ContentInfo("text", None, None, Some("UTF-8")),
+        content = None,
         protectedBranch = protectedBranch,
         commit = revCommit.getName
       )
@@ -328,7 +328,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
             repository = repository,
             pathList = paths.take(paths.size - 1).toList,
             fileName = Some(paths.last),
-            content = JGitUtil.getContentInfo(git, path, objectId),
+            content = Some(JGitUtil.getContentInfo(git, repository.owner, repository.name, branch, path, objectId)),
             protectedBranch = protectedBranch,
             commit = revCommit.getName
           )
@@ -349,7 +349,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
             repository = repository,
             pathList = paths.take(paths.size - 1).toList,
             fileName = paths.last,
-            content = JGitUtil.getContentInfo(git, path, objectId),
+            content = JGitUtil.getContentInfo(git, repository.owner, repository.name, branch, path, objectId),
             commit = revCommit.getName
           )
         } getOrElse NotFound()
@@ -446,7 +446,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
                 branch = id,
                 repository = repository,
                 pathList = path.split("/").toList,
-                content = JGitUtil.getContentInfo(git, path, objectId),
+                content = JGitUtil.getContentInfo(git, repository.owner, repository.name, id, path, objectId),
                 latestCommit = new JGitUtil.CommitInfo(JGitUtil.getLastModifiedCommit(git, revCommit, path)),
                 hasWritePermission = hasDeveloperRole(repository.owner, repository.name, context.loginAccount),
                 isBlame = request.paths(2) == "blame",
@@ -510,7 +510,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
         git =>
           defining(JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(id))) {
             revCommit =>
-              val diffs = JGitUtil.getDiffs(git, None, id, true, false)
+              val diffs = JGitUtil.getDiffs(git, repository.owner, repository.name, None, id, true, false)
               val oldCommitId = JGitUtil.getParentCommitId(git, id)
 
               html.commit(

--- a/src/main/scala/gitbucket/core/controller/WikiController.scala
+++ b/src/main/scala/gitbucket/core/controller/WikiController.scala
@@ -107,7 +107,9 @@ trait WikiControllerBase extends ControllerBase {
         Some(pageName),
         from,
         to,
-        JGitUtil.getDiffs(git, Some(from), to, true, false).filter(_.newPath == pageName + ".md"),
+        JGitUtil
+          .getDiffs(git, repository.owner, repository.name, Some(from), to, true, false)
+          .filter(_.newPath == pageName + ".md"),
         repository,
         isEditable(repository),
         flash.get("info")
@@ -123,7 +125,7 @@ trait WikiControllerBase extends ControllerBase {
         None,
         from,
         to,
-        JGitUtil.getDiffs(git, Some(from), to, true, false),
+        JGitUtil.getDiffs(git, repository.owner, repository.name, Some(from), to, true, false),
         repository,
         isEditable(repository),
         flash.get("info")

--- a/src/main/scala/gitbucket/core/plugin/EnhancedRenderer.scala
+++ b/src/main/scala/gitbucket/core/plugin/EnhancedRenderer.scala
@@ -1,0 +1,165 @@
+package gitbucket.core.plugin
+
+import java.util.Base64
+
+import gitbucket.core.controller.Context
+import gitbucket.core.service.RepositoryService
+import gitbucket.core.util.JGitUtil.ContentInfo
+import gitbucket.core.util.StringUtil
+import gitbucket.core.view.helpers
+import gitbucket.core.view.helpers.urlLink
+import org.apache.http.util.TextUtils
+import play.twirl.api.Html
+
+import scala.collection.immutable
+
+/**
+ * New style Renderer
+ */
+trait EnhancedRenderer {
+  def renderContent(request: EnhancedRenderRequest): Html = {
+    this match {
+      case r: TextRenderer =>
+        r.renderAsText(request)
+      case r: ImageRenderer =>
+        r.renderAsImage(request, "")
+      case r: ObjectRenderer =>
+        r.renderAsObject(request)
+      case _ =>
+        Html("??????")
+    }
+  }
+
+  val allowLargeFile: Boolean = false
+}
+
+trait TextRenderer extends EnhancedRenderer {
+  def renderAsText(request: EnhancedRenderRequest): Html
+  def renderMarkup(request: RenderRequest): Html
+}
+
+trait ImageRenderer extends EnhancedRenderer {
+  def renderAsImage(request: EnhancedRenderRequest, attr: String): Html
+}
+
+trait TextImageRenderer extends TextRenderer with ImageRenderer {
+  override def renderContent(request: EnhancedRenderRequest): Html = {
+    new Html(immutable.Seq[Html](renderAsImage(request, ""), renderAsText(request)))
+  }
+}
+
+trait ObjectRenderer extends EnhancedRenderer {
+  def renderAsObject(request: EnhancedRenderRequest): Html
+}
+
+trait DiffRenderer extends EnhancedRenderer {
+  def renderDiff(oldRequest: EnhancedRenderRequest, newRequest: EnhancedRenderRequest): Html
+}
+
+case class EnhancedRenderRequest(
+  filePath: List[String],
+  contentInfo: ContentInfo,
+  branch: String,
+  repository: RepositoryService.RepositoryInfo,
+  enableWikiLink: Boolean,
+  enableRefsLink: Boolean,
+  enableAnchor: Boolean,
+  context: Context
+) {
+  val rawPath = s"""${helpers.url(repository)(context)}/raw/${branch}/${filePath.mkString("/")}"""
+}
+
+object SVGRenderer extends TextImageRenderer {
+  override def renderAsText(request: EnhancedRenderRequest): Html = {
+    Html(s"""<pre class="xml">${StringUtil.escapeHtml(request.contentInfo.content)}</pre>""")
+  }
+
+  override def renderAsImage(request: EnhancedRenderRequest, attr: String): Html = {
+    Html(s"""<img src="${request.rawPath}" ${attr} />""")
+  }
+
+  override def renderMarkup(request: RenderRequest): Html = {
+    Html(request.fileContent)
+  }
+}
+
+class ImgRenderer(mimeType: String) extends ImageRenderer {
+  override def renderAsImage(request: EnhancedRenderRequest, attr: String): Html = {
+    val base64 = Base64.getEncoder.encodeToString(request.contentInfo.contentBytes)
+    Html(s"""<img src="data:${mimeType};base64,${base64}" ${attr}>""")
+  }
+}
+
+object VideoRenderer extends ObjectRenderer {
+  override val allowLargeFile: Boolean = true
+
+  override def renderAsObject(request: EnhancedRenderRequest): Html = {
+    Html(s"""<video src="${request.rawPath}" controls width="100%" />""")
+  }
+}
+
+object AudioRenderer extends ObjectRenderer {
+  override val allowLargeFile: Boolean = true
+
+  override def renderAsObject(request: EnhancedRenderRequest): Html = {
+    Html(s"""<audio src="${request.rawPath}" controls width="100%" />""")
+  }
+}
+
+object PdfRenderer extends ObjectRenderer {
+  override val allowLargeFile: Boolean = true
+
+  override def renderAsObject(request: EnhancedRenderRequest): Html = {
+    Html(s"""<object data="${request.rawPath}" width="100%" height="700">
+            |<p>Your browser does not support render inline PDF. Please download from this
+            | <a href="${request.rawPath}">Link</a></p>
+            |</object>""".stripMargin)
+  }
+}
+
+object LargeFileRenderer extends EnhancedRenderer {
+  override def renderContent(request: EnhancedRenderRequest): Html = {
+    Html(s"""<div class="box-content-bottom" style="text-align: center; padding-top: 20px; padding-bottom: 20px;">
+            |<a href="${request.rawPath}">View Raw</a>
+            |<br><br>(Sorry about that, but we can't show files that are this big right now)</div>""".stripMargin)
+  }
+}
+
+object DefaultBinaryRenderer extends EnhancedRenderer {
+  override def renderContent(request: EnhancedRenderRequest): Html = {
+    Html(s"""<div class="box-content-bottom" style="text-align: center; padding-top: 20px; padding-bottom: 20px;">
+            |<a href="${request.rawPath}">View Raw</a>
+            |<br><br>(Sorry about that, but we can't show files that are this big right now)</div>""".stripMargin)
+  }
+}
+
+object DefaultTextRenderer extends TextRenderer {
+  override def renderAsText(request: EnhancedRenderRequest): Html = {
+    Html(s"""<tt><pre class="plain">${urlLink(request.contentInfo.content)}</pre></tt>""")
+  }
+
+  override def renderMarkup(request: RenderRequest): Html = {
+    Html(s"""<tt><pre class="plain">${urlLink(request.fileContent)}</pre></tt>""")
+  }
+}
+
+class RendererWrapper(renderer: Renderer) extends TextRenderer {
+  override def renderMarkup(request: RenderRequest): Html = {
+    renderer.render(request)
+  }
+
+  override def renderAsText(request: EnhancedRenderRequest): Html = {
+    renderer.render(
+      RenderRequest(
+        request.filePath,
+        request.contentInfo.content,
+        request.branch,
+        request.repository,
+        request.enableWikiLink,
+        request.enableRefsLink,
+        request.enableAnchor,
+        request.context
+      )
+    )
+  }
+}

--- a/src/main/scala/gitbucket/core/plugin/Renderer.scala
+++ b/src/main/scala/gitbucket/core/plugin/Renderer.scala
@@ -2,8 +2,7 @@ package gitbucket.core.plugin
 
 import gitbucket.core.controller.Context
 import gitbucket.core.service.RepositoryService
-import gitbucket.core.view.Markdown
-import gitbucket.core.view.helpers.urlLink
+import gitbucket.core.view.{Markdown, helpers}
 import play.twirl.api.Html
 
 /**
@@ -34,12 +33,6 @@ object MarkdownRenderer extends Renderer {
   }
 }
 
-object DefaultRenderer extends Renderer {
-  override def render(request: RenderRequest): Html = {
-    Html(s"""<tt><pre class="plain">${urlLink(request.fileContent)}</pre></tt>""")
-  }
-}
-
 case class RenderRequest(
   filePath: List[String],
   fileContent: String,
@@ -49,4 +42,6 @@ case class RenderRequest(
   enableRefsLink: Boolean,
   enableAnchor: Boolean,
   context: Context
-)
+) {
+  val rawPath = s"""${helpers.url(repository)(context)}/raw/${branch}/${filePath.mkString("/")}"""
+}

--- a/src/main/scala/gitbucket/core/service/PullRequestService.scala
+++ b/src/main/scala/gitbucket/core/service/PullRequestService.scala
@@ -251,10 +251,10 @@ trait PullRequestService { self: IssuesService with CommitsService =>
         diffs
           .find(x => x.oldPath == file)
           .map { diff =>
-            (diff.oldContent, diff.newContent) match {
-              case (Some(oldContent), Some(newContent)) => {
-                val oldLines = oldContent.replace("\r\n", "\n").split("\n")
-                val newLines = newContent.replace("\r\n", "\n").split("\n")
+            (diff.oldContentInfo, diff.newContentInfo) match {
+              case (Some(oldContentInfo), Some(newContentInfo)) if oldContentInfo.isText && newContentInfo.isText => {
+                val oldLines = oldContentInfo.content.replace("\r\n", "\n").split("\n")
+                val newLines = newContentInfo.content.replace("\r\n", "\n").split("\n")
                 file -> Option(DiffUtils.diff(oldLines.toList.asJava, newLines.toList.asJava))
               }
               case _ =>
@@ -334,7 +334,15 @@ trait PullRequestService { self: IssuesService with CommitsService =>
         }
 
       // TODO Isolate to an another method?
-      val diffs = JGitUtil.getDiffs(newGit, Some(oldId.getName), newId.getName, true, false)
+      val diffs = JGitUtil.getDiffs(
+        newGit,
+        requestUserName,
+        requestRepositoryName,
+        Some(oldId.getName),
+        newId.getName,
+        true,
+        false
+      )
 
       (commits, diffs)
     }

--- a/src/main/scala/gitbucket/core/service/WebHookService.scala
+++ b/src/main/scala/gitbucket/core/service/WebHookService.scala
@@ -601,7 +601,8 @@ object WebHookService {
         before = ObjectId.toString(oldId),
         after = ObjectId.toString(newId),
         commits = commits.map { commit =>
-          ApiCommit.forWebhookPayload(git, RepositoryName(repositoryInfo), commit)
+          ApiCommit
+            .forWebhookPayload(git, RepositoryName(repositoryInfo), commit)
         },
         repository = ApiRepository.forWebhookPayload(repositoryInfo, owner = ApiUser(repositoryOwner))
       )

--- a/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
@@ -22,7 +22,6 @@ import org.eclipse.jgit.transport.resolver._
 import org.slf4j.LoggerFactory
 import javax.servlet.ServletConfig
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-
 import org.eclipse.jgit.diff.DiffEntry.ChangeType
 import org.json4s.jackson.Serialization._
 
@@ -441,7 +440,7 @@ class WikiCommitHook(owner: String, repository: String, pusher: String, baseUrl:
             case (oldCommitId, newCommitId) =>
               val commits = using(Git.open(Directory.getWikiRepositoryDir(owner, repository))) { git =>
                 JGitUtil.getCommitLog(git, oldCommitId, newCommitId).flatMap { commit =>
-                  val diffs = JGitUtil.getDiffs(git, None, commit.id, false, false)
+                  val diffs = JGitUtil.getDiffs(git, owner, repository, None, commit.id, false, false)
                   diffs.collect {
                     case diff if diff.newPath.toLowerCase.endsWith(".md") =>
                       val action = if (diff.changeType == ChangeType.ADD) "created" else "edited"

--- a/src/main/twirl/gitbucket/core/helper/diff.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/diff.scala.html
@@ -7,6 +7,8 @@
   hasWritePermission: Boolean,
   showLineNotes: Boolean)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
+@import gitbucket.core.util.JGitUtil.ContentInfo
+@import gitbucket.core.plugin.{EnhancedRenderer, DiffRenderer, TextRenderer, ImageRenderer, TextImageRenderer, ObjectRenderer}
 @import org.eclipse.jgit.diff.DiffEntry.ChangeType
 @if(showIndex){
   <div class="pull-right" style="margin-bottom: 10px;">
@@ -101,34 +103,113 @@
             <div class="diff-same">File mode changed</div>
           }
         } else {
-          @if(diff.newContent != None || diff.oldContent != None){
-            <div id="diffText-@i" class="diffText"></div>
-            <textarea id="newText-@i" style="display: none;" data-file-name="@diff.oldPath" data-val='@diff.newContent.getOrElse("")'></textarea>
-            <textarea id="oldText-@i" style="display: none;" data-file-name="@diff.newPath" data-val='@diff.oldContent.getOrElse("")'></textarea>
-          } else {
-            @if(diff.newIsImage || diff.oldIsImage){
-              <div class="diff-image-render diff2up">
-              @if(oldCommitId.isDefined && diff.oldIsImage){
-                <div class="diff-image-frame diff-old"><img src="@helpers.url(repository)/raw/@oldCommitId.get/@diff.oldPath" class="diff-image" onload="onLoadedDiffImages(this)" style="display:none" /></div>
-              } else {
-                @if(diff.changeType != ChangeType.ADD){
-                  <div style="padding: 12px;">Not supported</div>
-                }
+          @* TODO: too Large check *@
+          @(diff.oldContentInfo, diff.newContentInfo) match {
+            case (None, None) => {
+              <div>Error???</div>
+            }
+            case (Some(oldCI: ContentInfo), Some(newCI: ContentInfo)) if oldCI.renderer.isInstanceOf[DiffRenderer] && newCI.renderer.isInstanceOf[DiffRenderer] => {
+              @for(oldId <- oldCommitId; newId <- newCommitId; oldReq <- diff.getOldEnhancedRenderRequest(oldId, repository, false, false, false); newReq <- diff.getNewEnhancedRenderRequest(newId, repository, false, false, false)) {
+                @oldCI.renderer.asInstanceOf[DiffRenderer].renderDiff(oldReq, newReq)
               }
-              @if(newCommitId.isDefined && diff.newIsImage){
-                <div class="diff-image-frame diff-new"><img src="@helpers.url(repository)/raw/@newCommitId.get/@diff.newPath" class="diff-image" onload="onLoadedDiffImages(this)" style="display:none" /></div>
-              } else {
-                @if(diff.changeType != ChangeType.DELETE){
-                  <div style="padding: 12px;">Not supported</div>
-                }
-              }
+            }
+            case (oldCI: Option[ContentInfo], newCI: Option[ContentInfo]) if oldCI.map(_.renderer.isInstanceOf[TextImageRenderer]).getOrElse(true) && newCI.map(_.renderer.isInstanceOf[TextImageRenderer]).getOrElse(true) => {
+              <div>
+                <div class="diff-image-render diff2up">
+                  @for(ci <- oldCI; id <- oldCommitId; req <- diff.getOldEnhancedRenderRequest(id, repository, false, false, false) ) {
+                    <div class="diff-image-frame diff-old">
+                     @ci.renderer.asInstanceOf[ImageRenderer].renderAsImage(req, """class = "diff-image" onload = "onLoadedDiffImages(this)" style = "display:none" """)
+                    </div>
+                  }
+                  @for(ci <- newCI; id <- newCommitId; req <- diff.getNewEnhancedRenderRequest(id, repository, false, false, false)) {
+                    <div class="diff-image-frame diff-new">
+                      @ci.renderer.asInstanceOf[ImageRenderer].renderAsImage(req, """class = "diff-image" onload = "onLoadedDiffImages(this)" style = "display:none" """)
+                    </div>
+                  }
+                </div>
               </div>
-            } else {
-              @if(diff.tooLarge){
-                <div style="padding: 12px;">Too large</div>
-              } else {
-                <div style="padding: 12px;">Not supported</div>
+              <div id="diffText-@i" class="diffText"></div>
+              @defining(for(ci <- oldCI; id <- oldCommitId; req <- diff.getOldEnhancedRenderRequest(id, repository, false, false, false) ) yield {
+                ci.content
+              }){ x =>
+                @x.map{ content =>
+                <textarea id="oldText-@i" style="display: none;" data-file-name="@diff.oldPath" data-val='@content'></textarea>
+                }.getOrElse {
+                  <textarea id="oldText-@i" style="display: none;" data-file-name="" data-val=''></textarea>
+                }
               }
+              @defining(for(ci <- newCI; id <- newCommitId; req <- diff.getNewEnhancedRenderRequest(id, repository, false, false, false)) yield {
+                ci.content
+              }){ x =>
+                @x.map{ content =>
+                <textarea id="newText-@i" style="display: none;" data-file-name="@(diff.newPath)" data-val='@(content)'></textarea>
+                }.getOrElse {
+                  <textarea id="newText-@i" style="display: none;" data-file-name="" data-val=''></textarea>
+                }
+              }
+            }
+            case (oldCI: Option[ContentInfo], newCI: Option[ContentInfo]) if oldCI.map(_.renderer.isInstanceOf[TextRenderer]).getOrElse(true) && newCI.map(_.renderer.isInstanceOf[TextRenderer]).getOrElse(true) => {
+              <div id="diffText-@i" class="diffText"></div>
+              @defining(for(ci <- oldCI; id <- oldCommitId; req <- diff.getOldEnhancedRenderRequest(id, repository, false, false, false) ) yield {
+                ci.content
+              }){ x =>
+                @x.map{ content =>
+                  <textarea id="oldText-@i" style="display: none;" data-file-name="@diff.oldPath" data-val='@content'></textarea>
+                }.getOrElse {
+                  <textarea id="oldText-@i" style="display: none;" data-file-name="" data-val=''></textarea>
+                }
+              }
+              @defining(for(ci <- newCI; id <- newCommitId; req <- diff.getNewEnhancedRenderRequest(id, repository, false, false, false)) yield {
+                ci.content
+              }){ x =>
+                @x.map{ content =>
+                  <textarea id="newText-@i" style="display: none;" data-file-name="@(diff.newPath)" data-val='@(content)'></textarea>
+                }.getOrElse {
+                  <textarea id="newText-@i" style="display: none;" data-file-name="" data-val=''></textarea>
+                }
+              }
+            }
+            case (oldCI: Option[ContentInfo], newCI: Option[ContentInfo]) if oldCI.map(_.renderer.isInstanceOf[ImageRenderer]).getOrElse(true) && newCI.map(_.renderer.isInstanceOf[ImageRenderer]).getOrElse(true) => {
+              <div class="diff-image-render diff2up">
+                @for(ci <- oldCI; id <- oldCommitId; req <- diff.getOldEnhancedRenderRequest(id, repository, false, false, false) ) {
+                  <div class="diff-image-frame diff-old">
+                    @ci.renderer.asInstanceOf[ImageRenderer].renderAsImage(req, """class = "diff-image" onload = "onLoadedDiffImages(this)" style = "display:none" """)
+                  </div>
+                }
+                @for(ci <- newCI; id <- newCommitId; req <- diff.getNewEnhancedRenderRequest(id, repository, false, false, false)) {
+                  <div class="diff-image-frame diff-new">
+                    @ci.renderer.asInstanceOf[ImageRenderer].renderAsImage(req, """class = "diff-image" onload = "onLoadedDiffImages(this)" style = "display:none" """)
+                  </div>
+                }
+              </div>
+            }
+            case (oldCI: Option[ContentInfo], newCI: Option[ContentInfo]) if oldCI.map(_.renderer.isInstanceOf[ObjectRenderer]).getOrElse(true) && newCI.map(_.renderer.isInstanceOf[ObjectRenderer]).getOrElse(true) => {
+              <div>
+                @for(ci <- oldCI; id <- oldCommitId; req <- diff.getOldEnhancedRenderRequest(id, repository, false, false, false) ) {
+                  <div>
+                    @ci.renderer.asInstanceOf[ObjectRenderer].renderAsObject(req)
+                  </div>
+                }
+                @for(ci <- newCI; id <- newCommitId; req <- diff.getNewEnhancedRenderRequest(id, repository, false, false, false)) {
+                  <div>
+                    @ci.renderer.asInstanceOf[ObjectRenderer].renderAsObject(req)
+                  </div>
+                }
+              </div>
+            }
+            case (oldCI: Option[ContentInfo], newCI: Option[ContentInfo]) => {
+              <div>
+                @for(ci <- oldCI; id <- oldCommitId; req <- diff.getOldEnhancedRenderRequest(id, repository, false, false, false) ) {
+                  <div>
+                    @ci.renderer.renderContent(req)
+                  </div>
+                }
+                @for(ci <- newCI; id <- newCommitId; req <- diff.getNewEnhancedRenderRequest(id, repository, false, false, false)) {
+                  <div>
+                    @ci.renderer.renderContent(req)
+                  </div>
+                }
+              </div>
             }
           }
         }

--- a/src/main/twirl/gitbucket/core/repo/blob.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/blob.scala.html
@@ -8,30 +8,32 @@
   isLfsFile: Boolean)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main(s"${(repository.name :: pathList).mkString("/")} at ${branch} - ${repository.owner}/${repository.name}", Some(repository)) {
-  @gitbucket.core.html.menu("files", repository){
+  @gitbucket.core.html.menu("files", repository) {
     <div class="head">
       <div class="pull-right hide-if-blame"><div class="btn-group">
-        <a href="@helpers.url(repository)/blob/@helpers.encodeRefName((latestCommit.id :: pathList).mkString("/"))" data-hotkey="y" style="display: none;">Transfer to URL with SHA</a>
-        <a href="@helpers.url(repository)/find/@helpers.encodeRefName(branch)" class="btn btn-sm btn-default" data-hotkey="t">Find file</a>
+        <a href="@helpers.url(repository)/blob/@helpers.encodeRefName((latestCommit.id :: pathList).mkString("/"))" data-hotkey="y" style="display: none;">
+          Transfer to URL with SHA</a>
+        <a href="@helpers.url(repository)/find/@helpers.encodeRefName(branch)" class="btn btn-sm btn-default" data-hotkey="t">
+          Find file</a>
       </div></div>
       <div class="line-age-legend">
         <span>Newer</span>
         <ol>
-            <li class="heat1"></li>
-            <li class="heat2"></li>
-            <li class="heat3"></li>
-            <li class="heat4"></li>
-            <li class="heat5"></li>
-            <li class="heat6"></li>
-            <li class="heat7"></li>
-            <li class="heat8"></li>
-            <li class="heat9"></li>
-            <li class="heat10"></li>
+          <li class="heat1"></li>
+          <li class="heat2"></li>
+          <li class="heat3"></li>
+          <li class="heat4"></li>
+          <li class="heat5"></li>
+          <li class="heat6"></li>
+          <li class="heat7"></li>
+          <li class="heat8"></li>
+          <li class="heat9"></li>
+          <li class="heat10"></li>
         </ol>
         <span>Older</span>
       </div>
-      <div id="branchCtrlWrapper" style="display:inline;">
-      @gitbucket.core.helper.html.branchcontrol(branch, repository, hasWritePermission){
+      <div id="branchCtrlWrapper" style="display: inline;">
+      @gitbucket.core.helper.html.branchcontrol(branch, repository, hasWritePermission) {
         @repository.branchList.map { x =>
           <li><a href="@helpers.url(repository)/blob/@helpers.encodeRefName((x :: pathList).mkString("/"))">@gitbucket.core.helper.html.checkicon(x == branch) @x</a></li>
         }
@@ -39,13 +41,14 @@
       </div>
       <a href="@helpers.url(repository)/tree/@helpers.encodeRefName(branch)">@repository.name</a> /
       @pathList.zipWithIndex.map { case (section, i) =>
-        @if(i == pathList.length - 1){
+        @if(i == pathList.length - 1) {
           @section
         } else {
-          <a href="@helpers.url(repository)/tree/@helpers.encodeRefName((branch :: pathList.take(i + 1)).mkString("/"))">@section</a> /
+          <a href="@helpers.url(repository)/tree/@helpers.encodeRefName((branch :: pathList.take(i + 1)).mkString("/"))">@section</a>
+          /
         }
       }
-      @if(isLfsFile){
+      @if(isLfsFile) {
         <span class="label label-info">LFS</span>
       }
     </div>
@@ -53,47 +56,37 @@
       @helpers.avatar(latestCommit, 28)
       @helpers.user(latestCommit.authorName, latestCommit.authorEmailAddress, "username strong")
       <span class="muted">@gitbucket.core.helper.html.datetimeago(latestCommit.commitTime)</span>
-      <span class="label label-default">@helpers.readableSize(content.size)</span>
+      <span class="label label-default">@helpers.readableSize(Some(content.size))</span>
       <a href="@helpers.url(repository)/commit/@latestCommit.id" class="commit-message">@helpers.link(latestCommit.summary, repository)</a>
       <div class="btn-group pull-right">
-        @if(hasWritePermission && content.viewType == "text" && repository.branchList.contains(branch)){
-          <a class="btn btn-sm btn-default" href="@helpers.url(repository)/edit/@helpers.encodeRefName((branch :: pathList).mkString("/"))">Edit</a>
+        @if(hasWritePermission && content.isText && repository.branchList.contains(branch)) {
+          <a class="btn btn-sm btn-default" href="@helpers.url(repository)/edit/@helpers.encodeRefName((branch :: pathList).mkString("/"))">
+            Edit</a>
         }
-        <a class="btn btn-sm btn-default" href="@helpers.url(repository)/raw/@latestCommit.id/@helpers.encodeRefName(pathList.mkString("/"))">Raw</a>
-        @if(content.viewType == "text"){
+        <a class="btn btn-sm btn-default" href="@helpers.url(repository)/raw/@latestCommit.id/@helpers.encodeRefName(pathList.mkString("/"))">
+          Raw</a>
+        @if(content.isText) {
           <a class="btn btn-sm btn-default blame-action" href="@helpers.url(repository)/blame/@latestCommit.id/@helpers.encodeRefName(pathList.mkString("/"))"
-            data-url="@helpers.url(repository)/get-blame/@helpers.encodeRefName((latestCommit.id :: pathList).mkString("/"))" data-repository="@helpers.url(repository)">Blame</a>
+          data-url="@helpers.url(repository)/get-blame/@helpers.encodeRefName((latestCommit.id :: pathList).mkString("/"))" data-repository="@helpers.url(repository)">
+            Blame</a>
         }
-        <a class="btn btn-sm btn-default" href="@helpers.url(repository)/commits/@helpers.encodeRefName((branch :: pathList).mkString("/"))">History</a>
-        @if(hasWritePermission && repository.branchList.contains(branch)){
-          <a class="btn btn-sm btn-danger" href="@helpers.url(repository)/remove/@helpers.encodeRefName((branch :: pathList).mkString("/"))">Delete</a>
+        <a class="btn btn-sm btn-default" href="@helpers.url(repository)/commits/@helpers.encodeRefName((branch :: pathList).mkString("/"))">
+          History</a>
+        @if(hasWritePermission && repository.branchList.contains(branch)) {
+          <a class="btn btn-sm btn-danger" href="@helpers.url(repository)/remove/@helpers.encodeRefName((branch :: pathList).mkString("/"))">
+            Delete</a>
         }
       </div>
     </div>
-    @defining(helpers.isRenderable(pathList.last)){ isRenderable =>
-      @if(!isBlame && isRenderable) {
-        <div class="box-content-bottom @if(content.viewType == "text"){ markdown-body } " style="padding-left: 20px; padding-right: 20px;">
-          @helpers.renderMarkup(pathList, content.content.getOrElse(""), branch, repository, false, false, true)
-        </div>
-      }else{
-        @if(content.viewType == "text"){
-          <div class="box-content-bottom">
-            <pre class="prettyprint linenums blob @if(!isRenderable){ no-renderable } ">@content.content.map(_.replaceAll("^(\r?\n)", "$1$1"))</pre>
-          </div>
-        }
-        @if(content.viewType == "image"){
-          <div class="box-content-bottom">
-            <img src="@helpers.url(repository)/raw/@helpers.encodeRefName((branch :: pathList).mkString("/"))"/>
-          </div>
-        }
-        @if(content.viewType == "large" || content.viewType == "binary"){
-          <div class="box-content-bottom" style="text-align: center; padding-top: 20px; padding-bottom: 20px;">
-            <a href="@helpers.url(repository)/raw/@helpers.encodeRefName((branch :: pathList).mkString("/"))">View Raw</a><br>
-            <br>
-            (Sorry about that, but we can't show files that are this big right now)
-          </div>
-        }
-      }
+    @if(isBlame && content.isText) {
+      <div class="box-content-bottom">
+        <pre class="prettyprint linenums blob">@content.content.replaceAll("^(\r?\n)", "$1$1")</pre>
+      </div>
+    } else {
+      <div class="box-content-bottom @if(content.isText) { markdown-body } " style="padding-left: 20px;
+        padding-right: 20px;">
+      @helpers.renderContent(pathList, content, branch, repository, false, false, true)
+      </div>
     }
   }
 }

--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -2,7 +2,7 @@
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
   pathList: List[String],
   fileName: Option[String],
-  content: gitbucket.core.util.JGitUtil.ContentInfo,
+  content: Option[gitbucket.core.util.JGitUtil.ContentInfo],
   protectedBranch: Boolean,
   commit: String)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
@@ -63,10 +63,10 @@
               <a href="@helpers.url(repository)/blob/@helpers.encodeRefName((branch :: pathList ++ Seq(fileName.get)).mkString("/"))" class="btn btn-default">Cancel</a>
             }
             <input type="submit" id="commitButton" class="btn btn-success" value="Commit changes" disabled="true"/>
-            <input type="hidden" id="charset" name="charset" value="@content.charset"/>
-            <input type="hidden" id="lineSeparator" name="lineSeparator" value="@content.lineSeparator"/>
+            <input type="hidden" id="charset" name="charset" value="@content.map(_.charset).getOrElse("UTF-8")"/>
+            <input type="hidden" id="lineSeparator" name="lineSeparator" value="@content.map(_.lineSeparator).getOrElse("LF")"/>
             <input type="hidden" id="content" name="content" value=""/>
-            <input type="hidden" id="initial" value="@content.content"/>
+            <input type="hidden" id="initial" value="@content.map(_.content).getOrElse("")"/>
             <input type="hidden" id="commit" name="commit" value="@commit"/>
           </div>
         </div>
@@ -138,7 +138,7 @@ $(function(){
     $('#btn-code').removeClass('active');
     $('#btn-preview').addClass('active');
 
-    @if(fileName.map(helpers.isRenderable _).getOrElse(false)) {
+    @if(fileName.isDefined) {
       // update preview
       $('#preview').html('<img src="@helpers.assets("/common/images/indicator.gif")"> Previewing...');
       $.post('@helpers.url(repository)/_preview', {

--- a/src/test/scala/gitbucket/core/service/MergeServiceSpec.scala
+++ b/src/test/scala/gitbucket/core/service/MergeServiceSpec.scala
@@ -110,11 +110,13 @@ class MergeServiceSpec extends FunSpec {
   }
   describe("mergePullRequest") {
     it("can merge") {
-      val repo8Dir = initRepository("user1", "repo8")
+      val owner = "user1"
+      val repository = "repo8"
+      val repo8Dir = initRepository(owner, repository)
       using(Git.open(repo8Dir)) { git =>
         createFile(git, s"refs/pull/${issueId}/head", "test.txt", "hoge2")
         val committer = new PersonIdent("dummy2", "dummy2@example.com")
-        assert(getFile(git, branch, "test.txt").content.get == "hoge")
+        assert(getFile(git, owner, repository, branch, "test.txt").content == "hoge")
         val requestBranchId = git.getRepository.resolve(s"refs/pull/${issueId}/head")
         val masterId = git.getRepository.resolve(branch)
         service.mergePullRequest(git, branch, issueId, "merged", committer)
@@ -124,7 +126,7 @@ class MergeServiceSpec extends FunSpec {
         assert(commit.getAuthorIdent() == committer)
         assert(commit.getFullMessage() == "merged")
         assert(commit.getParents.toSet == Set(requestBranchId, masterId))
-        assert(getFile(git, branch, "test.txt").content.get == "hoge2")
+        assert(getFile(git, owner, repository, branch, "test.txt").content == "hoge2")
       }
     }
   }

--- a/src/test/scala/gitbucket/core/util/GitSpecUtil.scala
+++ b/src/test/scala/gitbucket/core/util/GitSpecUtil.scala
@@ -74,7 +74,7 @@ object GitSpecUtil {
     inserter.flush()
     inserter.close()
   }
-  def getFile(git: Git, branch: String, path: String) = {
+  def getFile(git: Git, owner: String, repository: String, branch: String, path: String) = {
     val revCommit = JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(branch))
     val objectId = using(new TreeWalk(git.getRepository)) { walk =>
       walk.addTree(revCommit.getTree)
@@ -87,7 +87,7 @@ object GitSpecUtil {
       }
       _getPathObjectId
     }
-    JGitUtil.getContentInfo(git, path, objectId)
+    JGitUtil.getContentInfo(git, owner, repository, branch, path, objectId)
   }
   def mergeAndCommit(git: Git, into: String, branch: String, message: String = null): Unit = {
     val repository = git.getRepository


### PR DESCRIPTION
# Introduce **new** rendering approach

This PR introduce `EnhancedRenderer` and some extended classes.

## Changes

### All files rendered by `EnhancedRenderer`.

- It makes more simple logic for blob/diff view.
- Previous `Renderer` assumes used for render *Markup*. So, image/video/audio renderer is tricky.

### correct handling image files

Previously, GitBucket detects image files by MIME-type. But, some `image/xxx` files can't render by browser. for example tiff file can't render by `img` tag.

`EnhancedRenderer` provides `ImageRenderer` trait. It represents "file can render by img tag".

### Image file is not limited to binary

For example, SVG file is text but it can rendered by img tag. So this PR introduce `TextImageRenderer`. It extends `TextRenderer` and `ImageRenderer`. For `TextImageRenderer` repository viewer and diff viewer render both image and source text .

![image](https://user-images.githubusercontent.com/6997928/39613099-e4fc15a8-4f9f-11e8-8c59-5ea88eaca86e.png)

![image](https://user-images.githubusercontent.com/6997928/39613109-f626d142-4f9f-11e8-986b-31d2b5fd0a8f.png)


### Allow read file as string or binary for `EnhancedRenderer`

`EnhancedRenderer` can read file as binary. So, it can render with format converter (for example, tiff to png).

It enables direct serving image file with data-URI. It reduce number of connections.

![20180503-132639](https://user-images.githubusercontent.com/6997928/39613137-371a0be2-4fa0-11e8-84fc-7f4c16ccd606.png)


### Diffs rendered by `EnhancedRenderer`.

If plugin has new renderer which extends `ImageRenderer`, automatically rendered with Image Diff tool.

or, If renderer extends `DiffRenderer`, diffs are rendered with custom diff rendering.

for example: JSON diff by [benjamine/JsonDiffPatch](https://github.com/benjamine/JsonDiffPatch)

![image](https://user-images.githubusercontent.com/6997928/39614069-acee711c-4fa7-11e8-8ebe-b658b268ad2d.png)


## Compatibility

The `RendererWrapper` wraps old-style `Renderer` to new-style `EnhancedRenderer`. So, no changes required for old-style Renderer plugins.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
