### PR TITLE
Fix JSON diff issue.

### DIFF
--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -78,10 +78,10 @@ function displayErrors(data, elem){
 function diffUsingJS(oldTextId, newTextId, outputId, viewType, ignoreSpace) {
   var old = $('#'+oldTextId), head = $('#'+newTextId);
   var render = new JsDiffRender({
-    oldText: old.data('val'),
-    oldTextName: old.data('file-name'),
-    newText: head.data('val'),
-    newTextName: head.data('file-name'),
+    oldText: old.attr('data-val'),
+    oldTextName: old.attr('data-file-name'),
+    newText: head.attr('data-val'),
+    newTextName: head.attr('data-file-name'),
     ignoreSpace: ignoreSpace,
     contextSize: 4
   });


### PR DESCRIPTION
This PR fix Problem: JSON file's diff doesn't appear in the commit page.

In #1871, `data-val` contains contents for diff. But it read by `$().data("val")`. But `.data()` parses contents. For example: content is a JSON file.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
