### PR TITLE
Use SecureRandom to generate access tokens.

### DIFF
--- a/src/main/scala/gitbucket/core/service/AccessTokenService.scala
+++ b/src/main/scala/gitbucket/core/service/AccessTokenService.scala
@@ -5,13 +5,13 @@ import gitbucket.core.model.Profile.profile.blockingApi._
 import gitbucket.core.model.{AccessToken, Account}
 import gitbucket.core.util.StringUtil
 
-import scala.util.Random
+import java.security.SecureRandom
 
 trait AccessTokenService {
 
   def makeAccessTokenString: String = {
     val bytes = new Array[Byte](20)
-    Random.nextBytes(bytes)
+    AccessTokenService.secureRandom.nextBytes(bytes)
     bytes.map("%02x".format(_)).mkString
   }
 
@@ -55,4 +55,6 @@ trait AccessTokenService {
 
 }
 
-object AccessTokenService extends AccessTokenService
+object AccessTokenService extends AccessTokenService {
+  private val secureRandom = new SecureRandom()
+}


### PR DESCRIPTION
scala.util.Random uses java.util.Random which only provides 64 bits of randomness.

### Before submitting a pull-request to GitBucket I have first:

- [v] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [v] rebased my branch over master
- [v] verified that project is compiling
- [v] verified that tests are passing
- [v] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [N/A] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
