### PR TITLE
Change to avatar image link from avatar image

### DIFF
--- a/src/main/twirl/gitbucket/core/account/members.scala.html
+++ b/src/main/twirl/gitbucket/core/account/members.scala.html
@@ -7,7 +7,7 @@
     @members.map { member =>
       <div class="block">
         <div class="block-header">
-          @helpers.avatar(member.userName, 20) <a href="@helpers.url(member.userName)">@member.userName</a>
+          @helpers.avatarLink(member.userName, 20) <a href="@helpers.url(member.userName)">@member.userName</a>
           @if(member.isManager){ (Manager) }
         </div>
       </div>

--- a/src/main/twirl/gitbucket/core/admin/userlist.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/userlist.scala.html
@@ -26,7 +26,7 @@
               }
             </div>
             <div class="strong">
-              @helpers.avatar(account.userName, 20)
+              @helpers.avatarLink(account.userName, 20)
               <a href="@helpers.url(account.userName)">@account.userName</a>
               @if(account.isGroupAccount){
                 (Group)
@@ -39,7 +39,7 @@
               }
               @if(account.isGroupAccount){
                 @members(account.userName).map { userName =>
-                  @helpers.avatar(userName, 20, tooltip = true)
+                  @helpers.avatarLink(userName, 20, tooltip = true)
                 }
               }
             </div>

--- a/src/main/twirl/gitbucket/core/helper/activities.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/activities.scala.html
@@ -67,7 +67,7 @@
   <div>
     <div class="muted small">@gitbucket.core.helper.html.datetimeago(activity.activityDate)</div>
     <div class="strong">
-      @helpers.avatar(activity.activityUserName, 16)
+      @helpers.avatarLink(activity.activityUserName, 16)
       @helpers.activityMessage(activity.message)
     </div>
     @activity.additionalInfo.map { additionalInfo =>
@@ -83,7 +83,7 @@
   <div>
     <div class="muted small">@gitbucket.core.helper.html.datetimeago(activity.activityDate)</div>
     <div class="strong">
-      @helpers.avatar(activity.activityUserName, 16)
+      @helpers.avatarLink(activity.activityUserName, 16)
       @helpers.activityMessage(activity.message)
     </div>
     @additionalInfo
@@ -97,7 +97,7 @@
   <div>
     <span class="muted small">@gitbucket.core.helper.html.datetimeago(activity.activityDate)</span>
     <div>
-      @helpers.avatar(activity.activityUserName, 16)
+      @helpers.avatarLink(activity.activityUserName, 16)
       @helpers.activityMessage(activity.message)
     </div>
   </div>

--- a/src/main/twirl/gitbucket/core/helper/commitcomment.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/commitcomment.scala.html
@@ -10,7 +10,7 @@
   <div class="commit-comment-@comment.commentId">
     <div class="markdown-body">
       <div>
-        @helpers.avatar(comment.commentedUserName, 20)
+        @helpers.avatarLink(comment.commentedUserName, 20)
         @helpers.user(comment.commentedUserName, styleClass="username strong")
         <span class="muted">@gitbucket.core.helper.html.datetimeago(comment.registeredDate)</span>
         <span class="pull-right">

--- a/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
@@ -9,7 +9,7 @@
 @showFormattedComment(comment: gitbucket.core.model.IssueComment)={
 <div class="panel panel-default issue-comment-box" id="comment-@comment.commentId">
   <div class="panel-heading">
-    @helpers.avatar(comment.commentedUserName, 20)
+    @helpers.avatarLink(comment.commentedUserName, 20)
     @helpers.user(comment.commentedUserName, styleClass="username strong")
     <span class="muted">
       @if(comment.action == "comment"){
@@ -45,7 +45,7 @@
 @if(issue.isDefined){
   <div class="panel panel-default issue-comment-box">
     <div class="panel-heading">
-      @helpers.avatar(issue.get.openedUserName, 20)
+      @helpers.avatarLink(issue.get.openedUserName, 20)
       @helpers.user(issue.get.openedUserName, styleClass="username strong")
       <span class="muted">commented @gitbucket.core.helper.html.datetimeago(issue.get.registeredDate)</span>
       <span class="pull-right">
@@ -81,7 +81,7 @@
           <div class="discussion-item discussion-item-commit">
             <div class="discussion-item-header">
               <span class="discussion-item-icon"><i class="octicon octicon-bookmark"></i></span>
-              @helpers.avatar(comment.commentedUserName, 16)
+              @helpers.avatarLink(comment.commentedUserName, 16)
               @helpers.user(comment.commentedUserName, styleClass="username strong")
               added a commit that referenced this @issueOrPullRequest()
               @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -104,7 +104,7 @@
         <div class="discussion-item discussion-item-refer">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-bookmark"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             referenced the @issueOrPullRequest()
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -121,7 +121,7 @@
         <div class="discussion-item discussion-item-merge">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-git-merge"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             merged commit
             <code>@pullreq.map(_.commitIdTo.substring(0, 7))</code> into
@@ -141,7 +141,7 @@
         <div class="discussion-item discussion-item-close">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-circle-slash"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             closed this @issueOrPullRequest()
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -155,7 +155,7 @@
         <div class="discussion-item discussion-item-reopen">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-primitive-dot"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             reopened the @issueOrPullRequest()
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -166,7 +166,7 @@
         <div class="discussion-item discussion-item-delete_branch">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-git-branch"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             deleted the <code>@pullreq.map(_.requestBranch)</code> branch
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -177,7 +177,7 @@
         <div class="discussion-item discussion-item-add-label">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-tag"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             add the <code>@comment.content</code> label
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -188,7 +188,7 @@
         <div class="discussion-item discussion-item-delete-label">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-tag"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             removed the <code>@comment.content</code> label
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -199,7 +199,7 @@
         <div class="discussion-item discussion-item-change-priority">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-flame"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             change priority from <code>@comment.content.split(":")(0)</code> to <code>@comment.content.split(":")(1)</code>
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -210,7 +210,7 @@
         <div class="discussion-item discussion-item-change-milestone">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-milestone"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             change milestone from <code>@comment.content.split(":")(0)</code> to <code>@comment.content.split(":")(1)</code>
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -221,7 +221,7 @@
         <div class="discussion-item discussion-item-assign">
           <div class="discussion-item-header">
             <span class="discussion-item-icon"><i class="octicon octicon-person"></i></span>
-            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.avatarLink(comment.commentedUserName, 16)
             @helpers.user(comment.commentedUserName, styleClass="username strong")
             change assignee from <code>@comment.content.split(":")(0)</code> to <code>@comment.content.split(":")(1)</code>
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
@@ -239,7 +239,7 @@
   case comment: gitbucket.core.model.CommitComment => {
     <div class="panel panel-default commit-comment-box commit-comment-@comment.commentId">
       <div class="panel-heading">
-        @helpers.avatar(comment.commentedUserName, 20)
+        @helpers.avatarLink(comment.commentedUserName, 20)
         @helpers.user(comment.commentedUserName, styleClass="username strong")
         <span class="muted">
           commented

--- a/src/main/twirl/gitbucket/core/issues/issueinfo.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/issueinfo.scala.html
@@ -139,7 +139,7 @@
 </div>
 <span id="label-assigned">
   @issue.flatMap(_.assignedUserName).map { userName =>
-    @helpers.avatar(userName, 20) @helpers.user(userName, styleClass="username strong small")
+    @helpers.avatarLink(userName, 20) @helpers.user(userName, styleClass="username strong small")
   }.getOrElse{
     <span class="muted small">No one</span>
   }

--- a/src/main/twirl/gitbucket/core/pulls/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/compare.scala.html
@@ -142,7 +142,7 @@
             <tr>
               <td style="width: 20%;">
                 <i class="octicon octicon-git-commit"></i>
-                @helpers.avatar(commit, 20)
+                @helpers.avatarLink(commit, 20)
                 @helpers.user(commit.authorName, commit.authorEmailAddress, "username strong")
               </td>
               <td><span class="monospace">@commit.shortMessage</span></td>

--- a/src/main/twirl/gitbucket/core/releases/list.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/list.scala.html
@@ -22,7 +22,7 @@
                 @release.map { case (release, assets) =>
                   <h3><a href="@helpers.url(repository)/releases/@release.tag">@release.name</a></h3>
                   <p class="muted">
-                    @helpers.avatar(release.author, 20) @helpers.user(release.author, styleClass="username") released this @gitbucket.core.helper.html.datetimeago(release.registeredDate)
+                    @helpers.avatarLink(release.author, 20) @helpers.user(release.author, styleClass="username") released this @gitbucket.core.helper.html.datetimeago(release.registeredDate)
                   </p>
                   @helpers.markdown(
                     markdown           = release.content getOrElse "No description provided.",

--- a/src/main/twirl/gitbucket/core/releases/release.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/release.scala.html
@@ -29,7 +29,7 @@
             }
           </h3>
           <p class="muted">
-           @helpers.avatar(release.author, 20) @helpers.user(release.author, styleClass="username") released this @gitbucket.core.helper.html.datetimeago(release.registeredDate)
+           @helpers.avatarLink(release.author, 20) @helpers.user(release.author, styleClass="username") released this @gitbucket.core.helper.html.datetimeago(release.registeredDate)
           </p>
           @helpers.markdown(
             markdown           = release.content getOrElse "No description provided.",

--- a/src/main/twirl/gitbucket/core/repo/blob.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/blob.scala.html
@@ -50,7 +50,7 @@
       }
     </div>
     <div class="box-header">
-      @helpers.avatar(latestCommit, 28)
+      @helpers.avatarLink(latestCommit, 28)
       @helpers.user(latestCommit.authorName, latestCommit.authorEmailAddress, "username strong")
       <span class="muted">@gitbucket.core.helper.html.datetimeago(latestCommit.commitTime)</span>
       <span class="label label-default">@helpers.readableSize(content.size)</span>

--- a/src/main/twirl/gitbucket/core/repo/commit.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commit.scala.html
@@ -69,7 +69,7 @@
 
           <div class="author-info">
             <div class="author">
-              @helpers.avatar(commit, 20)
+              @helpers.avatarLink(commit, 20)
               <span>@helpers.user(commit.authorName, commit.authorEmailAddress, "username strong")</span>
               <span class="muted">authored @gitbucket.core.helper.html.datetimeago(commit.authorTime)</span>
             </div>

--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -116,7 +116,7 @@
             </div>
             <div class="author-info">
               <div class="author">
-                @helpers.avatar(latestCommit, 20)
+                @helpers.avatarLink(latestCommit, 20)
                 <span>@helpers.user(latestCommit.authorName, latestCommit.authorEmailAddress, "username strong")</span>
                 <span class="muted"> authored @gitbucket.core.helper.html.datetimeago(latestCommit.authorTime)</span>
               </div>

--- a/src/main/twirl/gitbucket/core/repo/forked.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/forked.scala.html
@@ -24,7 +24,7 @@
     }
     <div class="block">
       @if(originRepository.isDefined){
-        @helpers.avatar(originRepository.get.owner, 20)
+        @helpers.avatarLink(originRepository.get.owner, 20)
         <span@if(repository.owner == originRepository.get.owner){ class="highlight"}>
           <a href="@helpers.url(originRepository.get.owner)">@originRepository.get.owner</a> / <a href="@context.path/@originRepository.get.owner/@originRepository.get.name">@originRepository.get.name</a>
         </span>
@@ -38,7 +38,7 @@
     </div>
     @members.map { case (owner, name) =>
       <div class="block">
-        @helpers.avatar(owner, 20)
+        @helpers.avatarLink(owner, 20)
         <span@if(repository.owner == owner){ class="highlight"}>
           <a href="@helpers.url(owner)">@owner</a> / <a href="@context.path/@owner/@name">@name</a>
         </span>

--- a/src/main/twirl/gitbucket/core/wiki/history.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/history.scala.html
@@ -37,7 +37,7 @@
       @commits.map { commit =>
         <tr>
           <td style="width: 32px; text-align: center ;"><input type="checkbox" name="commitId" value="@commit.id"></td>
-          <td style="width: 200px;">@helpers.avatar(commit, 20)&nbsp;@helpers.user(commit.authorName, commit.authorEmailAddress)</td>
+          <td style="width: 200px;">@helpers.avatarLink(commit, 20)&nbsp;@helpers.user(commit.authorName, commit.authorEmailAddress)</td>
           <td>
             <span class="muted">@gitbucket.core.helper.html.datetimeago(commit.authorTime):</span>&nbsp;@commit.shortMessage
           </td>


### PR DESCRIPTION
I will suggest to add a link on avatar image at possible places.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
