### PR TITLE
Counting conversations on pull request screen

### DIFF
--- a/src/main/twirl/gitbucket/core/pulls/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/menu.scala.html
@@ -8,6 +8,8 @@
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
   flash: Map[String, String] = Map.empty)(body: => Html)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
+@import gitbucket.core.model.Comment
+@import gitbucket.core.model.CommitComments
 @import gitbucket.core.model.IssueComment
 @gitbucket.core.html.main(s"${issue.title} - Pull request #${issue.issueId} - ${repository.owner}/${repository.name}", Some(repository)) {
   @gitbucket.core.html.menu("pulls", repository) {
@@ -69,7 +71,7 @@
       }
       </div>
       <ul class="nav nav-tabs fill-width" id="pullreq-tab">
-        <li @if(active=="conversation"){class="active"}><a href="@helpers.url(repository)/pull/@issue.issueId">Conversation <span class="badge">@comments.size</span></a></li>
+        <li @if(active=="conversation"){class="active"}><a href="@helpers.url(repository)/pull/@issue.issueId">Conversation <span class="badge">@countConversation(comments)</span></a></li>
         <li @if(active=="commits"){class="active"}><a href="@helpers.url(repository)/pull/@issue.issueId/commits">Commits <span class="badge">@commits.size</span></a></li>
         <li @if(active=="files"){class="active"}><a href="@helpers.url(repository)/pull/@issue.issueId/files">Files Changed <span class="badge">@changedFileSize</span></a></li>
       </ul>
@@ -118,3 +120,7 @@
     });
   });
 </script>
+
+@countConversation(comments: Seq[Comment]) = @{
+  comments.count(c => c.isInstanceOf[CommitComments] || c.asInstanceOf[IssueComment].action.endsWith("comment"))
+}


### PR DESCRIPTION
In current implementation, conversation count become all comment size. In other words, it includes action comments(e.g. `add label`, `remove label`, and so on...).
I will expect to display only comments for commit comment and pull request comment. (I think action of PR does not need on conversation count)

### Related Issues

* #2003

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
