### PR TITLE
Create comment on changing issue title

### DIFF
--- a/doc/comment_action.md
+++ b/doc/comment_action.md
@@ -6,22 +6,26 @@ The details are saved at `ISSUE_COMMENT` table.
 To determine if it was any operation, you see the `ACTION` column.
 And in the case of some actions, `CONTENT` column value contains additional information.
 
-|ACTION          |CONTENT               |
-|----------------|----------------------|
-|comment         |comment               |
-|close_comment   |comment               |
-|reopen_comment  |comment               |
-|close           |"Close"               |
-|reopen          |"Reopen"              |
-|commit          |comment commitId      |
-|merge           |comment               |
-|delete_branch   |branchName            |
-|refer           |issueId:title         |
-|add_label       |labelName             |
-|delete_label    |labelName             |
-|change_priority |oldPriority:priority  |
-|change_milestone|oldMilestone:milestone|
-|assign          |oldAssigned:assigned  |
+|ACTION          |CONTENT                   |
+|----------------|--------------------------|
+|comment         |comment                   |
+|close_comment   |comment                   |
+|reopen_comment  |comment                   |
+|close           |"Close"                   |
+|reopen          |"Reopen"                  |
+|commit          |comment commitId          |
+|merge           |comment                   |
+|delete_branch   |branchName                |
+|refer           |issueId:title             |
+|add_label       |labelName                 |
+|delete_label    |labelName                 |
+|change_priority |oldPriority:priority      |
+|change_milestone|oldMilestone:milestone    |
+|assign          |oldAssigned:assigned      |
+|change_title    |oldTitle(CRLF)title \[1\] |
+
+\[1\]: (CRLF) is "\r\n"
+
 
 ### comment
 
@@ -79,3 +83,7 @@ This value is saved when users have changed the milestone.
 ### assign
 
 This value is saved when users have assign issue/PR to user or remove the assign.
+
+### change_title
+
+This value is saved when users have changed the title.

--- a/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
@@ -228,6 +228,17 @@
           </div>
         </div>
       }
+      case "change_title" => {
+        <div class="discussion-item discussion-item-pencil">
+          <div class="discussion-item-header">
+            <span class="discussion-item-icon"><i class="octicon octicon-pencil"></i></span>
+            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.user(comment.commentedUserName, styleClass="username strong")
+            change title from <code>@comment.content.split("\r\n")(0)</code> to <code>@comment.content.split("\r\n")(1)</code>
+            @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
+          </div>
+        </div>
+      }
       case _ => {
         @showFormattedComment(comment)
       }


### PR DESCRIPTION
I will suggest to create a comment that notify changing issue title.
And I've improved to update issue data when title was changed as actually.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
