### PR TITLE
use PBKDF2 for password

### DIFF
--- a/src/main/resources/update/gitbucket-core_4.25.xml
+++ b/src/main/resources/update/gitbucket-core_4.25.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeSet>
+  <modifyDataType columnName="PASSWORD" newDataType="varchar(200)" tableName="ACCOUNT"/>
+</changeSet>

--- a/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
+++ b/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
@@ -53,5 +53,6 @@ object GitBucketCoreModule
       new Version("4.23.0", new LiquibaseMigration("update/gitbucket-core_4.23.xml")),
       new Version("4.23.1"),
       new Version("4.24.0", new LiquibaseMigration("update/gitbucket-core_4.24.xml")),
-      new Version("4.24.1")
+      new Version("4.24.1"),
+      new Version("4.25.0", new LiquibaseMigration("update/gitbucket-core_4.25.xml"))
     )

--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -322,7 +322,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
       account =>
         updateAccount(
           account.copy(
-            password = form.password.map(sha1).getOrElse(account.password),
+            password = form.password.map(pbkdf2_sha256).getOrElse(account.password),
             fullName = form.fullName,
             mailAddress = form.mailAddress,
             description = form.description,
@@ -563,7 +563,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
     if (context.settings.allowAccountRegistration) {
       createAccount(
         form.userName,
-        sha1(form.password),
+        pbkdf2_sha256(form.password),
         form.fullName,
         form.mailAddress,
         false,

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -417,7 +417,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
   post("/admin/users/_newuser", newUserForm)(adminOnly { form =>
     createAccount(
       form.userName,
-      sha1(form.password),
+      pbkdf2_sha256(form.password),
       form.fullName,
       form.mailAddress,
       form.isAdmin,
@@ -457,7 +457,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
 
           updateAccount(
             account.copy(
-              password = form.password.map(sha1).getOrElse(account.password),
+              password = form.password.map(pbkdf2_sha256).getOrElse(account.password),
               fullName = form.fullName,
               mailAddress = form.mailAddress,
               isAdmin = form.isAdmin,

--- a/src/main/scala/gitbucket/core/service/AccountService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountService.scala
@@ -38,7 +38,7 @@ trait AccountService {
       case account if !account.isGroupAccount =>
         account.password match {
           case pbkdf2re(iter, salt, hash) if (pbkdf2_sha256(iter.toInt, salt, password) == hash) => Some(account)
-          case p: String if p == sha1(password) =>
+          case p if p == sha1(password) =>
             updateAccount(account.copy(password = pbkdf2_sha256(password)))
             Some(account)
           case _ => None

--- a/src/main/scala/gitbucket/core/service/AccountService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountService.scala
@@ -33,7 +33,16 @@ trait AccountService {
    * Authenticate by internal database.
    */
   private def defaultAuthentication(userName: String, password: String)(implicit s: Session) = {
+    val pbkdf2re = """^\$pbkdf2-sha256\$(\d+)\$([0-9a-zA-Z+/=]+)\$([0-9a-zA-Z+/=]+)$""".r
     getAccountByUserName(userName).collect {
+      case account if !account.isGroupAccount =>
+        account.password match {
+          case pbkdf2re(iter, salt, hash) if (pbkdf2_sha256(iter.toInt, salt, password) == hash) => Some(account)
+          case p: String if p == sha1(password) =>
+            updateAccount(account.copy(password = pbkdf2_sha256(password)))
+            Some(account)
+          case _ => None
+        }
       case account if (!account.isGroupAccount && account.password == sha1(password)) => Some(account)
     } getOrElse None
   }


### PR DESCRIPTION
This PR improves password hashing discussed in #118. Newly created account or changed password are stored with PBKDF2 with SHA256. Old style password is also checked by `defaultAuthentication`. And it automatically update to PBKDF2.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
