### PR TITLE
Add notification hooks

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -482,21 +482,19 @@ trait PullRequestsControllerBase extends ControllerBase {
                         loginAccount.userName,
                         owner,
                         name
-                      ).foreach {
-                        issueId =>
-                          getIssue(owner, name, issueId.toString).map { issue =>
-                            callIssuesWebHook("closed", repository, issue, baseUrl, loginAccount)
-                            PluginRegistry().getIssueHooks
-                              .foreach(_.closedByCommitComment(issue, repository, issueContent, loginAccount))
-                          }
+                      ).foreach { issueId =>
+                        getIssue(owner, name, issueId.toString).map { issue =>
+                          callIssuesWebHook("closed", repository, issue, baseUrl, loginAccount)
+                          PluginRegistry().getIssueHooks
+                            .foreach(_.closedByCommitComment(issue, repository, issueContent, loginAccount))
+                        }
                       }
-                      closeIssuesFromMessage(form.message, loginAccount.userName, owner, name).foreach {
-                        issueId =>
-                          getIssue(owner, name, issueId.toString).map { issue =>
-                            callIssuesWebHook("closed", repository, issue, baseUrl, loginAccount)
-                            PluginRegistry().getIssueHooks
-                              .foreach(_.closedByCommitComment(issue, repository, issueContent, loginAccount))
-                          }
+                      closeIssuesFromMessage(form.message, loginAccount.userName, owner, name).foreach { issueId =>
+                        getIssue(owner, name, issueId.toString).map { issue =>
+                          callIssuesWebHook("closed", repository, issue, baseUrl, loginAccount)
+                          PluginRegistry().getIssueHooks
+                            .foreach(_.closedByCommitComment(issue, repository, issueContent, loginAccount))
+                        }
                       }
                     }
 

--- a/src/main/scala/gitbucket/core/plugin/IssueHook.scala
+++ b/src/main/scala/gitbucket/core/plugin/IssueHook.scala
@@ -1,7 +1,7 @@
 package gitbucket.core.plugin
 
 import gitbucket.core.controller.Context
-import gitbucket.core.model.Issue
+import gitbucket.core.model.{Account, Issue}
 import gitbucket.core.service.RepositoryService.RepositoryInfo
 import gitbucket.core.model.Profile._
 import profile.api._
@@ -15,6 +15,19 @@ trait IssueHook {
   ): Unit = ()
   def closed(issue: Issue, repository: RepositoryInfo)(implicit session: Session, context: Context): Unit = ()
   def reopened(issue: Issue, repository: RepositoryInfo)(implicit session: Session, context: Context): Unit = ()
+  def assigned(
+    issue: Issue,
+    repository: RepositoryInfo,
+    assigner: Option[String],
+    assigned: Option[String],
+    oldAssigned: Option[String]
+  )(
+    implicit session: Session,
+    context: Context
+  ): Unit = ()
+  def closedByCommitComment(issue: Issue, repository: RepositoryInfo, message: String, pusher: Account)(
+    implicit session: Session
+  ): Unit = ()
 
 }
 

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -6,20 +6,21 @@ import gitbucket.core.util.Implicits._
 import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.controller.Context
 import gitbucket.core.model.{
+  Account,
+  CommitState,
   Issue,
-  PullRequest,
   IssueComment,
   IssueLabel,
   Label,
-  Account,
+  PullRequest,
   Repository,
-  CommitState,
   Role
 }
 import gitbucket.core.model.Profile._
 import gitbucket.core.model.Profile.profile._
 import gitbucket.core.model.Profile.profile.blockingApi._
 import gitbucket.core.model.Profile.dateColumnType
+import gitbucket.core.plugin.PluginRegistry
 
 trait IssuesService {
   self: AccountService with RepositoryService with LabelsService with PrioritiesService with MilestonesService =>
@@ -511,19 +512,23 @@ trait IssuesService {
     assignedUserName: Option[String],
     insertComment: Boolean = false
   )(implicit context: Context, s: Session): Int = {
+    val oldAssigned = getIssue(owner, repository, s"${issueId}").get.assignedUserName
+    val assigned = assignedUserName
+    val assigner = context.loginAccount.map(_.userName)
     if (insertComment) {
-      val oldAssigned = getIssue(owner, repository, s"${issueId}").get.assignedUserName.getOrElse("Not assigned")
-      val assigned = assignedUserName.getOrElse("Not assigned")
       IssueComments insert IssueComment(
         userName = owner,
         repositoryName = repository,
         issueId = issueId,
         action = "assign",
-        commentedUserName = context.loginAccount.map(_.userName).getOrElse("Unknown user"),
-        content = s"${oldAssigned}:${assigned}",
+        commentedUserName = assigner.getOrElse("Unknown user"),
+        content = s"""${oldAssigned.getOrElse("Not assigned")}:${assigned.getOrElse("Not assigned")}""",
         registeredDate = currentDate,
         updatedDate = currentDate
       )
+    }
+    for (issue <- getIssue(owner, repository, issueId.toString); repo <- getRepository(owner, repository)) {
+      PluginRegistry().getIssueHooks.foreach(_.assigned(issue, repo, assigner, assigned, oldAssigned))
     }
     Issues
       .filter(_.byPrimaryKey(owner, repository, issueId))

--- a/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
@@ -300,6 +300,8 @@ class CommitLogHook(owner: String, repository: String, pusher: String, baseUrl: 
                       closeIssuesFromMessage(commit.fullMessage, pusher, owner, repository).foreach { issueId =>
                         getIssue(owner, repository, issueId.toString).map { issue =>
                           callIssuesWebHook("closed", repositoryInfo, issue, baseUrl, pusherAccount)
+                          PluginRegistry().getIssueHooks
+                            .foreach(_.closedByCommitComment(issue, repositoryInfo, commit.fullMessage, pusherAccount))
                         }
                       }
                     }


### PR DESCRIPTION
This PR adds two hooks for notification.

1. `assigned` for close #450
2. `closedByCommitComment` for close #1985 


## Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
