### PR TITLE
Disabled a checkbox of tasklist on preview

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/preview.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/preview.scala.html
@@ -57,6 +57,7 @@ $(function(){
       enableTaskList   : @enableTaskList
     }, function(data){
       $('#preview-area@uid').html(data);
+      $('#preview-area@uid input').prop('disabled', true);
       prettyPrint();
     });
   });


### PR DESCRIPTION
I've improved that display a checkbox of tasklist as disabled status on preview area.
In current, it can be changed checked status on preview area.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
