### PR TITLE
fix extra email bug in account registration

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -577,7 +577,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
         form.url
       )
       updateImage(form.userName, form.fileId, false)
-      updateAccountExtraMailAddresses(form.userName, form.extraMailAddresses)
+      updateAccountExtraMailAddresses(form.userName, form.extraMailAddresses.filter(_ != ""))
       redirect("/signin")
     } else NotFound()
   }


### PR DESCRIPTION
This PR fixes bug in account registration.

In current version,  a `ACCOUNT_EXTRA_MAIL_ADDRESS` record with empty string as mail address inserted at account registration. If exists such record, users can't register new accounts and can't modify account informations.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
