### PR TITLE
Count multiple comments on the same line

### DIFF
--- a/src/main/twirl/gitbucket/core/pulls/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/menu.scala.html
@@ -122,5 +122,8 @@
 </script>
 
 @countConversation(comments: Seq[Comment]) = @{
-  comments.count(c => c.isInstanceOf[CommitComments] || c.asInstanceOf[IssueComment].action.endsWith("comment"))
+  comments.collect {
+    case c: CommitComments => c.comments.size
+    case c: IssueComment if c.action.endsWith("comment") => 1
+  }.sum
 }


### PR DESCRIPTION
See #2015

Sorry, consideration was not enough on #2015.
I've changed to count multiple comments on the same line. 


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
