### PR TITLE
Focus to textarea at add and edit a comment

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -628,7 +628,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       newLineNumber,
       issueId,
       hasWritePermission = hasDeveloperRole(repository.owner, repository.name, context.loginAccount),
-      repository = repository
+      repository = repository,
+      focus = true
     )
   })
 

--- a/src/main/twirl/gitbucket/core/helper/preview.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/preview.scala.html
@@ -10,12 +10,13 @@
   styleClass: String = "",
   placeholder: String = "Leave a comment",
   elastic: Boolean = false,
+  focus: Boolean = false,
   tabIndex: Int = -2,
   uid: Long = new java.util.Date().getTime())(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 <div class="tabbable">
   <ul class="nav nav-tabs fill-width" style="margin-bottom: 10px;">
-    <li class="active"><a href="#tab@uid" data-toggle="tab">Write</a></li>
+    <li class="active"><a href="#tab@uid" data-toggle="tab" id="write@uid">Write</a></li>
     <li><a href="#tab@(uid + 1)" data-toggle="tab" id="preview@uid">Preview</a></li>
   </ul>
   <div class="tab-content">
@@ -46,6 +47,13 @@ $(function(){
     $('#content@uid').elastic();
     $('#content@uid').trigger('blur');
   }
+  @if(focus){
+    $('#content@uid').trigger('focus');
+  }
+
+  $('#write@uid').on('shown.bs.tab', function(){
+    $('#content@uid').trigger('focus');
+  });
 
   $('#preview@uid').click(function(){
     $('#preview-area@uid').html('<img src="@helpers.assets("/common/images/indicator.gif")"> Previewing...');

--- a/src/main/twirl/gitbucket/core/issues/editcomment.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/editcomment.scala.html
@@ -12,6 +12,7 @@
   completionContext  = "issues",
   style              = "",
   elastic            = true,
+  focus              = true,
   tabIndex           = 1
 )
 <div class="pull-right">

--- a/src/main/twirl/gitbucket/core/issues/editissue.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/editissue.scala.html
@@ -11,6 +11,7 @@
   completionContext  = "issues",
   style              = "",
   elastic            = true,
+  focus              = true,
   tabIndex           = 1
 )
 <div class="pull-right">

--- a/src/main/twirl/gitbucket/core/repo/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commentform.scala.html
@@ -5,6 +5,7 @@
   issueId: Option[Int] = None,
   hasWritePermission: Boolean,
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
+  focus: Boolean = false,
   uid: Long = new java.util.Date().getTime())(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @if(context.loginAccount.isDefined){
@@ -23,6 +24,7 @@
           completionContext  = "issues",
           style              = "height: 100px; max-height: 150px;",
           elastic            = true,
+          focus              = focus,
           uid                = uid
         )
       </div>

--- a/src/main/twirl/gitbucket/core/repo/editcomment.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editcomment.scala.html
@@ -12,6 +12,7 @@
   completionContext  = "issues",
   style              = "",
   elastic            = true,
+  focus              = true,
   tabIndex           = 1
 )
 <div class="text-right">


### PR DESCRIPTION
In current implementation, cannot focus to textarea at follows operations:

* Add a line comment on diff screen
* Reply a commit comment on diff screen
* Edit a description on issue and pull-request screen
* Edit a comment on issue and pull-request screen
* Edit a commit comment on diff screen
* Move to edit-area from preview-area

I propose focusing to the textarea by automatically because there is troublesome to focus by manually.


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
