### PR TITLE
Keep showing a fold comment when tasklist is not complete

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/commitcomments.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/commitcomments.scala.html
@@ -19,3 +19,14 @@
     </div>
   </div>
 </div>
+
+@if(!latestCommitId.contains(comments.comments.head.commitId)) {
+  <script>
+    $(function(){
+      var foldComments = $('.fold-comments-@comments.comments.head.commentId');
+      if(foldComments.find('input:checkbox:not(:checked)').length > 0){
+        foldComments.show();
+      }
+    });
+  </script>
+}


### PR DESCRIPTION
I want to keep showing a fold comment when exists a un-completed task on commit comment. 
WDYT?

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
