### PR TITLE
Move buttons into commentform area

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commentform.scala.html
@@ -25,13 +25,13 @@
           elastic            = true,
           uid                = uid
         )
+        @if(fileName.isDefined){
+          <div class="pull-right">
+            <input type="button" class="btn btn-default" value="Cancel"/>
+            <input type="submit" id="btn-inline-comment-@uid" class="btn btn-success" formaction="@helpers.url(repository)/commit/@commitId/comment/new" value="Comment"/>
+          </div>
+        }
       </div>
-      @if(fileName.isDefined){
-        <div class="pull-right" style="margin-top: 10px;">
-          <input type="button" class="btn btn-default" value="Cancel"/>
-          <input type="submit" id="btn-inline-comment-@uid" class="btn btn-success" formaction="@helpers.url(repository)/commit/@commitId/comment/new" value="Comment"/>
-        </div>
-      }
     </div>
     @if(!fileName.isDefined){
       <div class="pull-right">


### PR DESCRIPTION
I will propose to move buttons(cancel, comment) into commentform area.

Current:

![image](https://user-images.githubusercontent.com/5616270/40793974-d83ce8c0-6538-11e8-8349-278ddb4455ca.png)

After:

![image](https://user-images.githubusercontent.com/5616270/40794541-7a91c64e-653a-11e8-9545-49b828083ff4.png)


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
