### PR TITLE
Release the disable status on line comment adding button when validation error occurred

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commentform.scala.html
@@ -122,7 +122,7 @@
         //   $('#comment-list').children('.inline-comment').hide();
         // }
       }).fail(function(req) {
-        $('.btn-inline-comment').removeAttr('disabled');
+        $(e.target).removeAttr('disabled');
         $('#error-content', $form).html($.parseJSON(req.responseText).content);
       });
     });


### PR DESCRIPTION
In this current implementation, cannot click the line comment adding button after  validation error occurred.

![image](https://user-images.githubusercontent.com/5616270/40810875-23956140-656a-11e8-9a39-14157f081e45.png)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
