### PR TITLE
Added mime-type mapping for SVG files

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -89,5 +89,10 @@
     <param-value>PATH_TO_DATADIR</param-value>
   </context-param>
   -->
+  
+  <mime-mapping>
+    <extension>svg</extension>
+    <mime-type>image/svg+xml</mime-type>
+  </mime-mapping>
 
 </web-app>


### PR DESCRIPTION
I added a mime-type mapping for SVG files because when serving gitbucket from Wildfly, SVG files like the logo "gitbucket.svg" are being sent with "Content-Type: text/html", causing the image not to be displayed in the browser.
Adding this mapping to web.xml fixes that behavior for deployments on Wildfly and possibly other application servers.

### Before submitting a pull-request to GitBucket I have first:

- [done] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [done] rebased my branch over master
- [not applicable] verified that project is compiling
- [not applicable] verified that tests are passing
- [not applicable] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [not applicable] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
