### PR TITLE
Find all text when collect diff data

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commentform.scala.html
@@ -155,7 +155,7 @@
           'oldLine': oldTh.attr('line-number'),
           'newLine': newTh.attr('line-number'),
           'type': tr.has('td.insert').length > 0 ? 'insert' : tr.has('td.delete').length > 0 ? 'delete' : 'equal',
-          'text': tr.find('td>span').text()
+          'text': tr.find('td span').text()
         })
 
         tr = tr.prev('tr:has(th.line-num)');


### PR DESCRIPTION
I've fixed #2050 .
This issue occur when `<ins>` or `<del>` exists as nested tag under `<td>`.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
