### PR TITLE
Fix bug that fails to export bigint fields in RELEASE_ASSET

### DIFF
--- a/src/main/scala/gitbucket/core/util/JDBCUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JDBCUtil.scala
@@ -142,7 +142,7 @@ object JDBCUtil {
                     columnType match {
                       case Types.BOOLEAN | Types.BIT                                   => rs.getBoolean(columnName)
                       case Types.VARCHAR | Types.CLOB | Types.CHAR | Types.LONGVARCHAR => rs.getString(columnName)
-                      case Types.INTEGER                                               => rs.getInt(columnName)
+                      case Types.INTEGER | Types.BIGINT                                => rs.getInt(columnName)
                       case Types.TIMESTAMP                                             => rs.getTimestamp(columnName)
                     }
                   }


### PR DESCRIPTION
If there are attached files on release page, an error occurs when exporting RELEASE_ASSET.

```
Internal Server Error
scala.MatchError: -5 (of class java.lang.Integer)
```

I fixed to accept bigint columns.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
