### PR TITLE
Map url's ending with .git to GitRepositoryServlet

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -45,6 +45,12 @@
     <servlet-name>GitRepositoryServlet</servlet-name>
     <url-pattern>/git/*</url-pattern>
   </servlet-mapping>
+  
+  <servlet-mapping>
+    <servlet-name>GitRepositoryServlet</servlet-name>
+    <url-pattern>*.git</url-pattern>
+  </servlet-mapping>
+
 
   <servlet>
     <servlet-name>GitLfsTransferServlet</servlet-name>


### PR DESCRIPTION
Allows Github-like interaction with gitbucket, removing the need for /git sufix

### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct


Allows Github-like interaction with gitbucket, removing the need for /git sufix
