### PR TITLE
Support line comment on split mode

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/diff.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/diff.scala.html
@@ -335,7 +335,11 @@ $(function(){
         .append(renderStatBar(add, del).attr('title', (add + del) + " lines changed").tooltip());
 
     @if(hasWritePermission) {
-      diffText.find('.body').each(function(){ $('<b class="add-comment">+</b>').prependTo(this); });
+      diffText.find('.body').filter(function(i, e) {
+        return $(e).has('span').length > 0;
+      }).each(function(){
+        $('<b class="add-comment">+</b>').prependTo(this);
+      });
     }
     @if(showLineNotes){
       var fileName = table.attr('filename');

--- a/src/main/twirl/gitbucket/core/repo/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commentform.scala.html
@@ -140,6 +140,14 @@
     }
 
     function getDiffData(tr){
+      if(window.viewType === 0) {
+        return getDiffDataOnSplitMode(tr);
+      } else {
+        return getDiffDataOnUnifiedMode(tr);
+      }
+    }
+
+    function getDiffDataOnUnifiedMode(tr) {
       var result = [];
       var count = 0;
 
@@ -147,19 +155,72 @@
         var oldTh = tr.find('th.oldline');
         var newTh = tr.find('th.newline');
 
-        if(!oldTh.attr('line-number') && !newTh.attr('line-number')){
+        var oldLineNumber = oldTh.attr('line-number');
+        var newLineNumber = newTh.attr('line-number');
+
+        if(!oldLineNumber && !newLineNumber){
           break;
         }
 
         result.unshift({
-          'oldLine': oldTh.attr('line-number'),
-          'newLine': newTh.attr('line-number'),
+          'oldLine': oldLineNumber,
+          'newLine': newLineNumber,
           'type': tr.has('td.insert').length > 0 ? 'insert' : tr.has('td.delete').length > 0 ? 'delete' : 'equal',
           'text': tr.find('td span').text()
-        })
+        });
 
         tr = tr.prev('tr:has(th.line-num)');
         count++;
+      }
+
+      return result;
+    }
+
+    function getDiffDataOnSplitMode(tr) {
+      var result = [];
+      var count = 0;
+
+      while(tr && count < 4){
+        var oldTh = tr.find('th.oldline');
+        var newTh = tr.find('th.newline');
+
+        var oldLineNumber = oldTh.attr('line-number');
+        var newLineNumber = newTh.attr('line-number');
+
+        if(!oldLineNumber && !newLineNumber){
+          break;
+        }
+
+        var oldTd = oldTh.next();
+        var newTd = newTh.next();
+
+        if (oldTd.hasClass('equal') && newTd.hasClass('equal')) {
+          result.unshift({
+            'oldLine': oldLineNumber,
+            'newLine': newLineNumber,
+            'type': 'equal',
+            'text': newTd.find('span').text()
+          });
+          count++;
+        } else {
+          if(newLineNumber) {
+            result.unshift({
+              'newLine': newLineNumber,
+              'type': 'insert',
+              'text': newTd.find('span').text()
+            });
+            count++;
+          }
+          if(oldLineNumber) {
+            result.unshift({
+              'oldLine': oldLineNumber,
+              'type': 'delete',
+              'text': oldTd.find('span').text()
+            });
+            count++;
+          }
+        }
+        tr = tr.prev('tr:has(th.line-num)');
       }
 
       return result;


### PR DESCRIPTION
In current implementation, the line comment does not get diff data correctly on split mode. I've fixed as getting diff data correctly on split mode.
And I've improved the condition for adding "the comment add button"(`<b class="add-comment">+</b>`) on diff screen.

**Note:**
This PR includes changes of #2050/#2051 .

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
