### PR TITLE
Add "Repositories" tab to the dashboard

### DIFF
--- a/src/main/scala/gitbucket/core/controller/DashboardController.scala
+++ b/src/main/scala/gitbucket/core/controller/DashboardController.scala
@@ -21,6 +21,16 @@ class DashboardController
 trait DashboardControllerBase extends ControllerBase {
   self: IssuesService with PullRequestService with RepositoryService with AccountService with UsersAuthenticator =>
 
+  get("/dashboard/repos")(usersOnly {
+    val userName = context.loginAccount.get.userName
+
+    html.repos(
+      getGroupNames(userName),
+      Nil,
+      getUserRepositories(userName, withoutPhysicalInfo = true)
+    )
+  })
+
   get("/dashboard/issues")(usersOnly {
     searchIssues("created_by")
   })

--- a/src/main/scala/gitbucket/core/controller/DashboardController.scala
+++ b/src/main/scala/gitbucket/core/controller/DashboardController.scala
@@ -26,7 +26,7 @@ trait DashboardControllerBase extends ControllerBase {
 
     html.repos(
       getGroupNames(userName),
-      Nil,
+      getVisibleRepositories(None, withoutPhysicalInfo = true),
       getUserRepositories(userName, withoutPhysicalInfo = true)
     )
   })
@@ -93,8 +93,7 @@ trait DashboardControllerBase extends ControllerBase {
       },
       filter,
       getGroupNames(userName),
-      Nil,
-      getUserRepositories(userName, withoutPhysicalInfo = true)
+      getVisibleRepositories(None, withoutPhysicalInfo = true)
     )
   }
 
@@ -119,8 +118,7 @@ trait DashboardControllerBase extends ControllerBase {
       },
       filter,
       getGroupNames(userName),
-      Nil,
-      getUserRepositories(userName, withoutPhysicalInfo = true)
+      getVisibleRepositories(None, withoutPhysicalInfo = true)
     )
   }
 

--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -64,8 +64,7 @@ trait IndexControllerBase extends ControllerBase {
         val visibleOwnerSet: Set[String] = Set(account.userName) ++ getGroupsByUserName(account.userName)
         gitbucket.core.html.index(
           getRecentActivitiesByOwners(visibleOwnerSet),
-          Nil,
-          getUserRepositories(account.userName, withoutPhysicalInfo = true),
+          getVisibleRepositories(None, withoutPhysicalInfo = true),
           showBannerToCreatePersonalAccessToken = hasAccountFederation(account.userName) && !hasAccessToken(
             account.userName
           )
@@ -75,7 +74,6 @@ trait IndexControllerBase extends ControllerBase {
         gitbucket.core.html.index(
           getRecentActivities(),
           getVisibleRepositories(None, withoutPhysicalInfo = true),
-          Nil,
           showBannerToCreatePersonalAccessToken = false
         )
       }
@@ -273,18 +271,7 @@ trait IndexControllerBase extends ControllerBase {
     val repositories = visibleRepositories.filter { repository =>
       repository.name.toLowerCase.indexOf(query) >= 0 || repository.owner.toLowerCase.indexOf(query) >= 0
     }
-    context.loginAccount
-      .map { account =>
-        gitbucket.core.search.html.repositories(
-          query,
-          repositories,
-          Nil,
-          getUserRepositories(account.userName, withoutPhysicalInfo = true)
-        )
-      }
-      .getOrElse {
-        gitbucket.core.search.html.repositories(query, repositories, visibleRepositories, Nil)
-      }
+    gitbucket.core.search.html.repositories(query, repositories, visibleRepositories)
   }
 
 }

--- a/src/main/twirl/gitbucket/core/dashboard/issues.scala.html
+++ b/src/main/twirl/gitbucket/core/dashboard/issues.scala.html
@@ -5,10 +5,9 @@
   condition: gitbucket.core.service.IssuesService.IssueSearchCondition,
   filter: String,
   groups: List[String],
-  recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
-  userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
+  recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
 @gitbucket.core.html.main("Issues"){
-  @gitbucket.core.dashboard.html.sidebar(recentRepositories, userRepositories){
+  @gitbucket.core.dashboard.html.sidebar(recentRepositories){
     @gitbucket.core.dashboard.html.tab("issues")
     <div class="container">
       @gitbucket.core.dashboard.html.issuesnavi("issues", filter, openCount, closedCount, condition)

--- a/src/main/twirl/gitbucket/core/dashboard/pulls.scala.html
+++ b/src/main/twirl/gitbucket/core/dashboard/pulls.scala.html
@@ -5,10 +5,9 @@
   condition: gitbucket.core.service.IssuesService.IssueSearchCondition,
   filter: String,
   groups: List[String],
-  recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
-  userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
+  recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
 @gitbucket.core.html.main("Pull requests"){
-  @gitbucket.core.dashboard.html.sidebar(recentRepositories, userRepositories){
+  @gitbucket.core.dashboard.html.sidebar(recentRepositories){
     @gitbucket.core.dashboard.html.tab("pulls")
     <div class="container">
       @gitbucket.core.dashboard.html.issuesnavi("pulls", filter, openCount, closedCount, condition)

--- a/src/main/twirl/gitbucket/core/dashboard/repos.scala.html
+++ b/src/main/twirl/gitbucket/core/dashboard/repos.scala.html
@@ -1,0 +1,37 @@
+@(groups: List[String],
+  recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
+  userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
+@import gitbucket.core.view.helpers
+@gitbucket.core.html.main("Repositories"){
+  @gitbucket.core.dashboard.html.sidebar(recentRepositories, userRepositories){
+    @gitbucket.core.dashboard.html.tab("repos")
+    <div class="container">
+      @if(userRepositories.isEmpty){
+        No repositories
+      } else {
+        @userRepositories.map { repository =>
+          <div class="block">
+            <div class="repository-icon">
+              @gitbucket.core.helper.html.repositoryicon(repository, true)
+            </div>
+            <div class="repository-content">
+              <div class="block-header">
+                <a href="@helpers.url(repository)">@repository.owner/@repository.name</a>
+                @if(repository.repository.isPrivate){
+                  <i class="octicon octicon-lock"></i>
+                }
+              </div>
+              @if(repository.repository.originUserName.isDefined){
+                <div class="small muted">forked from <a href="@context.path/@repository.repository.parentUserName/@repository.repository.parentRepositoryName">@repository.repository.parentUserName/@repository.repository.parentRepositoryName</a></div>
+              }
+              @if(repository.repository.description.isDefined){
+                <div>@repository.repository.description</div>
+              }
+              <div><span class="muted small">Updated @gitbucket.core.helper.html.datetimeago(repository.repository.lastActivityDate)</span></div>
+            </div>
+          </div>
+        }
+      }
+    </div>
+  }
+}

--- a/src/main/twirl/gitbucket/core/dashboard/repos.scala.html
+++ b/src/main/twirl/gitbucket/core/dashboard/repos.scala.html
@@ -3,7 +3,7 @@
   userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main("Repositories"){
-  @gitbucket.core.dashboard.html.sidebar(recentRepositories, userRepositories){
+  @gitbucket.core.dashboard.html.sidebar(recentRepositories){
     @gitbucket.core.dashboard.html.tab("repos")
     <div class="container">
       @if(userRepositories.isEmpty){

--- a/src/main/twirl/gitbucket/core/dashboard/repos.scala.html
+++ b/src/main/twirl/gitbucket/core/dashboard/repos.scala.html
@@ -6,11 +6,23 @@
   @gitbucket.core.dashboard.html.sidebar(recentRepositories){
     @gitbucket.core.dashboard.html.tab("repos")
     <div class="container">
+      <div class="btn-group" id="owner-dropdown">
+        <button id="test" class="dropdown-toggle btn btn-default" data-toggle="dropdown" aria-expanded="false">
+          <span class="strong">All</span>
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+          <li><a href="javascript:void(0);" data-name=""><i class="octicon octicon-check"></i><span>All</span></a></li>
+          @userRepositories.map(_.owner).distinct.map { userName =>
+            <li><a href="javascript:void(0);" data-name="@userName"><i class="octicon"></i><span>@helpers.avatar(userName, 20) @userName</span></a></li>
+          }
+        </ul>
+      </div>
       @if(userRepositories.isEmpty){
         No repositories
       } else {
         @userRepositories.map { repository =>
-          <div class="block">
+          <div class="block" data-owner="@repository.owner">
             <div class="repository-icon">
               @gitbucket.core.helper.html.repositoryicon(repository, true)
             </div>
@@ -35,3 +47,25 @@
     </div>
   }
 }
+<script>
+$('#owner-dropdown a').click(function(){
+  var userName = $(this).data('name');
+
+  $('#owner-dropdown i').attr('class', 'octicon');
+  $(this).find('i').attr('class', 'octicon octicon-check');
+
+  $('#owner-dropdown span.strong').html($(this).find('span').html());
+
+  $('div.block').each(function(i, e){
+    if(userName == ''){
+      $(e).show();
+    } else {
+      if($(e).data('owner') == userName){
+        $(e).show();
+      } else {
+        $(e).hide();
+      }
+    }
+  });
+});
+</script>

--- a/src/main/twirl/gitbucket/core/dashboard/sidebar.scala.html
+++ b/src/main/twirl/gitbucket/core/dashboard/sidebar.scala.html
@@ -1,29 +1,8 @@
-@(recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
-  userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(body: Html)(implicit context: gitbucket.core.controller.Context)
+@(recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(body: Html)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 <div class="main-sidebar">
   <div class="sidebar">
   <ul class="nav sidebar-menu">
-  @if(context.loginAccount.isDefined){
-    <li class="header">
-      <span class="label label-primary pull-right">@userRepositories.size</span>
-      Your repositories
-    </li>
-    @if(userRepositories.isEmpty){
-      <li>No repositories</li>
-    } else {
-      <li><form class="sidebar-form"><input type="text" id="filter-box" class="form-control input-sm" placeholder="Find repository"/></form></li>
-      @userRepositories.zipWithIndex.map { case (repository, i) =>
-        <li class="repo-link menu-item-hover">
-          @if(repository.owner == context.loginAccount.get.userName){
-            <a href="@helpers.url(repository)">@gitbucket.core.helper.html.repositoryicon(repository, false) <span class="strong">@repository.name</span></a>
-          } else {
-          <a href="@helpers.url(repository)">@gitbucket.core.helper.html.repositoryicon(repository, false) <span>@repository.owner/<span class="strong">@repository.name</span></span></a>
-          }
-        </li>
-      }
-    }
-  } else {
     <li class="header">Recent updated repositories</li>
     @if(recentRepositories.isEmpty){
       <li>No repositories</li>
@@ -35,7 +14,6 @@
         </li>
       }
     }
-  }
   </ul>
   </div>
 </div>

--- a/src/main/twirl/gitbucket/core/dashboard/tab.scala.html
+++ b/src/main/twirl/gitbucket/core/dashboard/tab.scala.html
@@ -2,6 +2,7 @@
 <ul class="nav nav-tabs" style="margin-bottom: 20px;">
   <li @if(active == ""){ class="active"}><a href="@context.path/">News feed</a></li>
   @if(context.loginAccount.isDefined){
+    <li @if(active == "repos" ){ class="active"}><a href="@context.path/dashboard/repos">Repositories</a></li>
     <li @if(active == "pulls" ){ class="active"}><a href="@context.path/dashboard/pulls">Pull requests</a></li>
     <li @if(active == "issues"){ class="active"}><a href="@context.path/dashboard/issues">Issues</a></li>
     @gitbucket.core.plugin.PluginRegistry().getDashboardTabs.map { tab =>

--- a/src/main/twirl/gitbucket/core/index.scala.html
+++ b/src/main/twirl/gitbucket/core/index.scala.html
@@ -1,10 +1,9 @@
 @(activities: List[gitbucket.core.model.Activity],
   recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
-  userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
   showBannerToCreatePersonalAccessToken: Boolean)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main("GitBucket"){
-  @gitbucket.core.dashboard.html.sidebar(recentRepositories, userRepositories){
+  @gitbucket.core.dashboard.html.sidebar(recentRepositories){
     @context.settings.information.map { information =>
       <div class="alert alert-info" style="background-color: white; color: #555; border-color: #4183c4; font-size: small; line-height: 120%;">
         <button type="button" class="close" data-dismiss="alert">&times;</button>

--- a/src/main/twirl/gitbucket/core/search/repositories.scala.html
+++ b/src/main/twirl/gitbucket/core/search/repositories.scala.html
@@ -1,10 +1,9 @@
 @(query: String,
   repositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
-  recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo],
-  userRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
+  recentRepositories: List[gitbucket.core.service.RepositoryService.RepositoryInfo])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main("GitBucket"){
-  @gitbucket.core.dashboard.html.sidebar(recentRepositories, userRepositories){
+  @gitbucket.core.dashboard.html.sidebar(recentRepositories){
     <form action="@context.path/search" method="GET" class="form-inline">
       <input type="text" name="query" value="@query" class="form-control" style="width: 250px; margin-bottom: 0px;"/>
       <input type="submit" value="Search" class="btn btn-default"/>


### PR DESCRIPTION
![dashboard-repo-list](https://user-images.githubusercontent.com/1094760/41616781-cc4bba0e-7439-11e8-91e9-36ca354ea507.png)

- Add "Repositories" tab to the dashboard which lists all visible repositories for logged-in user
- Repositories can be filtered by their owner using a dropdown which located at the top of the list
- Instead, the sidebar is fixed to the list of recent updated repositories even if logged-in