### PR TITLE
Drop JRebel configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val ScalatraVersion = "2.6.1"
 val JettyVersion = "9.4.7.v20170914"
 
 lazy val root = (project in file("."))
-  .enablePlugins(SbtTwirl, ScalatraPlugin, JRebelPlugin)
+  .enablePlugins(SbtTwirl, ScalatraPlugin)
   .settings(
     )
 
@@ -94,21 +94,6 @@ assemblyMergeStrategy in assembly := {
       case _                      => MergeStrategy.discard
     }
   case x => MergeStrategy.first
-}
-
-// JRebel
-//Seq(jrebelSettings: _*)
-
-//jrebel.webLinks += (target in webappPrepare).value
-//jrebel.enabled := System.getenv().get("JREBEL") != null
-javaOptions in Jetty ++= Option(System.getenv().get("JREBEL")).toSeq.flatMap { path =>
-  if (path.endsWith(".jar")) {
-    // Legacy JRebel agent
-    Seq("-noverify", "-XX:+UseConcMarkSweepGC", "-XX:+CMSClassUnloadingEnabled", s"-javaagent:${path}")
-  } else {
-    // New JRebel agent
-    Seq(s"-agentpath:${path}")
-  }
 }
 
 // Exclude a war file from published artifacts

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,6 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 addSbtPlugin("com.geirsson"     % "sbt-scalafmt" % "1.5.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl"    % "1.3.13")
 addSbtPlugin("com.eed3si9n"     % "sbt-assembly" % "0.14.5")
-//addSbtPlugin("com.earldouglas"      % "xsbt-web-plugin"   % "4.0.0")
-//addSbtPlugin("fi.gekkio.sbtplugins" % "sbt-jrebel-plugin" % "0.10.0")
 addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.1")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "1.1.0")
 addSbtCoursier


### PR DESCRIPTION
Because myJRebel will be terminated at July, 5, 2018. We will became to not able to use it without purchasing for the license.