### PR TITLE
Fix archiving for slashed branches

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -834,52 +834,37 @@ trait RepositoryViewerControllerBase extends ControllerBase {
   /**
    * Download repository contents as a zip archive as compatible URL.
    */
-  get("/:owner/:repository/archive/:branch.zip")(referrersOnly { repository =>
+  get("/:owner/:repository/archive/*/:branch.zip")(referrersOnly { repository =>
     val branch = params("branch")
-    archiveRepository(branch, branch + ".zip", repository, "")
+    val path = multiParams("splat").head
+    archiveRepository(branch, branch + ".zip", repository, path)
   })
 
   /**
    * Download repository contents as a tar.gz archive as compatible URL.
    */
-  get("/:owner/:repository/archive/:branch.tar.gz")(referrersOnly { repository =>
+  get("/:owner/:repository/archive/*/:branch.tar.gz")(referrersOnly { repository =>
     val branch = params("branch")
-    archiveRepository(branch, branch + ".tar.gz", repository, "")
+    val path = multiParams("splat").head
+    archiveRepository(branch, branch + ".tar.gz", repository, path)
   })
 
   /**
    * Download repository contents as a tar.bz2 archive as compatible URL.
    */
-  get("/:owner/:repository/archive/:branch.tar.bz2")(referrersOnly { repository =>
+  get("/:owner/:repository/archive/*/:branch.tar.bz2")(referrersOnly { repository =>
     val branch = params("branch")
-    archiveRepository(branch, branch + ".tar.bz2", repository, "")
+    val path = multiParams("splat").head
+    archiveRepository(branch, branch + ".tar.bz2", repository, path)
   })
 
   /**
    * Download repository contents as a tar.xz archive as compatible URL.
    */
-  get("/:owner/:repository/archive/:branch.tar.xz")(referrersOnly { repository =>
+  get("/:owner/:repository/archive/*/:branch.tar.xz")(referrersOnly { repository =>
     val branch = params("branch")
-    archiveRepository(branch, branch + ".tar.xz", repository, "")
-  })
-
-  /**
-   * Download all repository contents as an archive.
-   */
-  get("/:owner/:repository/archive/:branch/:name")(referrersOnly { repository =>
-    val branch = params("branch")
-    val name = params("name")
-    archiveRepository(branch, name, repository, "")
-  })
-
-  /**
-   * Download repositories subtree contents as an archive.
-   */
-  get("/:owner/:repository/archive/:branch/*/:name")(referrersOnly { repository =>
-    val branch = params("branch")
-    val name = params("name")
     val path = multiParams("splat").head
-    archiveRepository(branch, name, repository, path)
+    archiveRepository(branch, branch + ".tar.xz", repository, path)
   })
 
   get("/:owner/:repository/network/members")(referrersOnly { repository =>

--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -33,7 +33,7 @@
     <div class="head" style="height: 24px;">
       <div class="pull-right">
         <div class="btn-group">
-          <a href="@{helpers.url(repository)}/archive/@{helpers.encodeRefName(branch)}@if(pathList.length > 0){/@pathList.mkString("/")}/@{helpers.encodeRefName(branch)}.zip" class="btn btn-sm btn-default pc"><i class="octicon octicon-cloud-download"></i> Download ZIP</a>
+          <a href="@{helpers.url(repository)}/archive/@if(pathList.length > 0){@pathList.map(helpers.urlEncode).mkString("/")}/@{helpers.urlEncode(branch)}.zip" class="btn btn-sm btn-default pc"><i class="octicon octicon-cloud-download"></i> Download ZIP</a>
           <a href="@helpers.url(repository)/find/@helpers.encodeRefName(branch)" class="btn btn-sm btn-default" data-hotkey="t"><i class="octicon octicon-search"></i></a>
           <a href="@helpers.url(repository)/commits/@helpers.encodeRefName((branch :: pathList).mkString("/"))" class="btn btn-sm btn-default"><i class="octicon octicon-history"></i> @if(commitCount > 10000){10000+} else {@commitCount} @helpers.plural(commitCount, "commit")</a>
         </div>


### PR DESCRIPTION
This pull request fixes archiving for branches which contain `/` in their name by url encoding a branch name in following URL form:

- `baseUrl`/archive/`branch`.zip

When archiving sub directories, URL form is:

- `baseUrl`/archive/`path`/`branch`.zip

See also #2048 and #2102 