### PR TITLE
Proxy support for plugin installation

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
@@ -255,7 +255,7 @@ object PluginRegistry {
         })
         .foreach(_.delete())
 
-      withHttpClient(settings.proxy) { httpClient =>
+      withHttpClient(settings.pluginProxy) { httpClient =>
         val httpGet = new HttpGet(url.toString)
         try {
           val response = httpClient.execute(httpGet)

--- a/src/main/scala/gitbucket/core/plugin/PluginRepository.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRepository.scala
@@ -1,7 +1,12 @@
 package gitbucket.core.plugin
 
+import java.net.{InetSocketAddress, PasswordAuthentication}
+import java.net.{Proxy => JProxy}
+
+import gitbucket.core.controller.Context
 import org.json4s._
 import org.apache.commons.io.IOUtils
+import java.net.Authenticator
 
 object PluginRepository {
   implicit val formats = DefaultFormats
@@ -10,9 +15,27 @@ object PluginRepository {
     org.json4s.jackson.JsonMethods.parse(json).extract[Seq[PluginMetadata]]
   }
 
-  def getPlugins(): Seq[PluginMetadata] = {
+  def getPlugins()(implicit context: Context): Seq[PluginMetadata] = {
     val url = new java.net.URL("https://plugins.gitbucket-community.org/releases/plugins.json")
-    val str = IOUtils.toString(url, "UTF-8")
+
+    val in = context.settings.proxy match {
+      case Some(proxy) =>
+        (proxy.user, proxy.password) match {
+          case (Some(user), Some(password)) =>
+            Authenticator.setDefault(new Authenticator() {
+              override def getPasswordAuthentication = new PasswordAuthentication(user, password.toCharArray)
+            })
+          case _ =>
+            Authenticator.setDefault(null)
+        }
+
+        url
+          .openConnection(new JProxy(JProxy.Type.HTTP, new InetSocketAddress(proxy.host, proxy.port)))
+          .getInputStream
+      case None => url.openStream()
+    }
+
+    val str = IOUtils.toString(in, "UTF-8")
     parsePluginJson(str)
   }
 

--- a/src/main/scala/gitbucket/core/plugin/PluginRepository.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRepository.scala
@@ -21,7 +21,7 @@ object PluginRepository {
     try {
       val url = new java.net.URL("https://plugins.gitbucket-community.org/releases/plugins.json")
 
-      withHttpClient(context.settings.proxy) { httpClient =>
+      withHttpClient(context.settings.pluginProxy) { httpClient =>
         val httpGet = new HttpGet(url.toString)
         try {
           val response = httpClient.execute(httpGet)

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -70,14 +70,14 @@ trait SystemSettingsService {
       props.setProperty(SkinName, settings.skinName.toString)
       props.setProperty(ShowMailAddress, settings.showMailAddress.toString)
       props.setProperty(PluginNetworkInstall, settings.pluginNetworkInstall.toString)
-      settings.proxy.foreach { proxy =>
-        props.setProperty(ProxyHost, proxy.host)
-        props.setProperty(ProxyPort, proxy.port.toString)
+      settings.pluginProxy.foreach { proxy =>
+        props.setProperty(PluginProxyHost, proxy.host)
+        props.setProperty(PluginProxyPort, proxy.port.toString)
         proxy.user.foreach { user =>
-          props.setProperty(ProxyUser, user)
+          props.setProperty(PluginProxyUser, user)
         }
         proxy.password.foreach { password =>
-          props.setProperty(ProxyPassword, password)
+          props.setProperty(PluginProxyPassword, password)
         }
       }
 
@@ -158,13 +158,13 @@ trait SystemSettingsService {
         getValue(props, SkinName, "skin-blue"),
         getValue(props, ShowMailAddress, false),
         getValue(props, PluginNetworkInstall, false),
-        if (getValue(props, ProxyHost, "").nonEmpty) {
+        if (getValue(props, PluginProxyHost, "").nonEmpty) {
           Some(
             Proxy(
-              getValue(props, ProxyHost, ""),
-              getValue(props, ProxyPort, 8080),
-              getOptionValue(props, ProxyUser, None),
-              getOptionValue(props, ProxyPassword, None)
+              getValue(props, PluginProxyHost, ""),
+              getValue(props, PluginProxyPort, 8080),
+              getOptionValue(props, PluginProxyUser, None),
+              getOptionValue(props, PluginProxyPassword, None)
             )
           )
         } else None
@@ -198,7 +198,7 @@ object SystemSettingsService {
     skinName: String,
     showMailAddress: Boolean,
     pluginNetworkInstall: Boolean,
-    proxy: Option[Proxy]
+    pluginProxy: Option[Proxy]
   ) {
 
     def baseUrl(request: HttpServletRequest): String =
@@ -322,10 +322,10 @@ object SystemSettingsService {
   private val SkinName = "skinName"
   private val ShowMailAddress = "showMailAddress"
   private val PluginNetworkInstall = "plugin.networkInstall"
-  private val ProxyHost = "proxy.host"
-  private val ProxyPort = "proxy.port"
-  private val ProxyUser = "proxy.user"
-  private val ProxyPassword = "proxy.password"
+  private val PluginProxyHost = "plugin.proxy.host"
+  private val PluginProxyPort = "plugin.proxy.port"
+  private val PluginProxyUser = "plugin.proxy.user"
+  private val PluginProxyPassword = "plugin.proxy.password"
 
   private def getValue[A: ClassTag](props: java.util.Properties, key: String, default: A): A = {
     getSystemProperty(key).getOrElse(getEnvironmentVariable(key).getOrElse {

--- a/src/main/scala/gitbucket/core/util/HttpClientUtil.scala
+++ b/src/main/scala/gitbucket/core/util/HttpClientUtil.scala
@@ -1,0 +1,34 @@
+package gitbucket.core.util
+
+import gitbucket.core.service.SystemSettingsService
+import org.apache.http.HttpHost
+import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
+import org.apache.http.impl.client.{BasicCredentialsProvider, CloseableHttpClient, HttpClientBuilder}
+
+object HttpClientUtil {
+
+  def withHttpClient[T](proxy: Option[SystemSettingsService.Proxy])(f: CloseableHttpClient => T): T = {
+    val builder = HttpClientBuilder.create.useSystemProperties
+
+    proxy.foreach { proxy =>
+      for (user <- proxy.user; password <- proxy.password) {
+        builder.setProxy(new HttpHost(proxy.host, proxy.port))
+        val credential = new BasicCredentialsProvider()
+        credential.setCredentials(
+          new AuthScope(proxy.host, proxy.port),
+          new UsernamePasswordCredentials(user, password)
+        )
+        builder.setDefaultCredentialsProvider(credential)
+      }
+    }
+
+    val httpClient = builder.build()
+
+    try {
+      f(httpClient)
+    } finally {
+      httpClient.close()
+    }
+  }
+
+}

--- a/src/main/scala/gitbucket/core/util/HttpClientUtil.scala
+++ b/src/main/scala/gitbucket/core/util/HttpClientUtil.scala
@@ -11,8 +11,9 @@ object HttpClientUtil {
     val builder = HttpClientBuilder.create.useSystemProperties
 
     proxy.foreach { proxy =>
+      builder.setProxy(new HttpHost(proxy.host, proxy.port))
+
       for (user <- proxy.user; password <- proxy.password) {
-        builder.setProxy(new HttpHost(proxy.host, proxy.port))
         val credential = new BasicCredentialsProvider()
         credential.setCredentials(
           new AuthScope(proxy.host, proxy.port),

--- a/src/main/twirl/gitbucket/core/admin/plugins.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/plugins.scala.html
@@ -3,8 +3,6 @@
   @gitbucket.core.admin.html.menu("plugins") {
     @gitbucket.core.helper.html.information(info)
     <form action="@context.path/admin/plugins/_reload" method="POST" class="pull-right">
-      <input type="checkbox" name="pluginNetworkInstall" id="pluginNetworkInstall" value="true" @if(context.settings.pluginNetworkInstall){checked}>
-      <label for="pluginNetworkInstall">Install plugin from <a href="https://plugins.gitbucket-community.org" target="_blank">plugins.gitbucket-community.org</a></label>
       <input type="submit" value="Reload plugins" class="btn btn-default">
     </form>
     <h1 class="system-settings-title">Plugins</h1>

--- a/src/main/twirl/gitbucket/core/admin/settings.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings.scala.html
@@ -8,6 +8,7 @@
       <ul class="nav nav-tabs fill-width" id="pullreq-tab">
         <li><a href="#system">System settings</a></li>
         <li><a href="#authentication">Authentication</a></li>
+        <li><a href="#plugins">Plugins</a></li>
       </ul>
       <div class="tab-content fill-width" style="padding-top: 20px;">
         <div class="tab-pane" id="system">
@@ -15,6 +16,9 @@
         </div>
         <div class="tab-pane" id="authentication">
           @settings_authentication(info)
+        </div>
+        <div class="tab-pane" id="plugins">
+          @settings_plugins(info)
         </div>
       </div>
       <hr>
@@ -30,6 +34,9 @@ $(function(){
   if(location.hash == '#authentication'){
     $('li:has(a[href="#authentication"])').addClass('active');
     $('div#authentication').addClass('active');
+  } else if(location.hash == '#plugins'){
+    $('li:has(a[href="#plugins"])').addClass('active');
+    $('div#plugins').addClass('active');
   } else {
     $('li:has(a[href="#system"])').addClass('active');
     $('div#system').addClass('active');

--- a/src/main/twirl/gitbucket/core/admin/settings_plugins.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_plugins.scala.html
@@ -9,7 +9,7 @@
 <hr>
 <fieldset>
   <label class="checkbox">
-    <input type="checkbox" id="useProxy" name="useProxy"@if(context.settings.proxy.isDefined){ checked} />
+    <input type="checkbox" id="useProxy" name="useProxy"@if(context.settings.pluginProxy.isDefined){ checked} />
     Use proxy
   </label>
 </fieldset>
@@ -17,28 +17,28 @@
   <div class="form-group">
     <label class="control-label col-md-2" for="proxyHost">Proxy host</label>
     <div class="col-md-10">
-      <input type="text" id="proxyHost" name="proxy.host" class="form-control" value="@context.settings.proxy.map(_.host)"/>
+      <input type="text" id="proxyHost" name="proxy.host" class="form-control" value="@context.settings.pluginProxy.map(_.host)"/>
       <span id="error-proxy_host" class="error"></span>
     </div>
   </div>
   <div class="form-group">
     <label class="control-label col-md-2" for="proxyPort">Proxy port</label>
     <div class="col-md-10">
-      <input type="text" id="proxyPort" name="proxy.port" class="form-control input-mini" value="@context.settings.proxy.map(_.port)"/>
+      <input type="text" id="proxyPort" name="proxy.port" class="form-control input-mini" value="@context.settings.pluginProxy.map(_.port)"/>
       <span id="error-proxy_port" class="error"></span>
     </div>
   </div>
   <div class="form-group">
     <label class="control-label col-md-2" for="proxyUser">Proxy user</label>
     <div class="col-md-10">
-      <input type="text" id="proxyUser" name="proxy.user" class="form-control" value="@context.settings.proxy.map(_.user)"/>
+      <input type="text" id="proxyUser" name="proxy.user" class="form-control" value="@context.settings.pluginProxy.map(_.user)"/>
       <span id="error-proxy_user" class="error"></span>
     </div>
   </div>
   <div class="form-group">
     <label class="control-label col-md-2" for="proxyPassword">Proxy password</label>
     <div class="col-md-10">
-      <input type="text" id="proxyPassword" name="proxy.password" class="form-control" value="@context.settings.proxy.map(_.password)"/>
+      <input type="text" id="proxyPassword" name="proxy.password" class="form-control" value="@context.settings.pluginProxy.map(_.password)"/>
       <span id="error-proxy_password" class="error"></span>
     </div>
   </div>

--- a/src/main/twirl/gitbucket/core/admin/settings_plugins.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_plugins.scala.html
@@ -1,0 +1,52 @@
+@(info: Option[Any])(implicit context: gitbucket.core.controller.Context)
+<label class="strong">Plugin repositories</label>
+<fieldset>
+  <label class="checkbox">
+    <input type="checkbox" id="pluginNetworkInstall" name="pluginNetworkInstall"@if(context.settings.pluginNetworkInstall){ checked} />
+    <a href="https://plugins.gitbucket-community.org" target="_blank">plugins.gitbucket-community.org</a>
+  </label>
+</fieldset>
+<hr>
+<fieldset>
+  <label class="checkbox">
+    <input type="checkbox" id="useProxy" name="useProxy"@if(context.settings.proxy.isDefined){ checked} />
+    Use proxy
+  </label>
+</fieldset>
+<div class="proxy">
+  <div class="form-group">
+    <label class="control-label col-md-2" for="proxyHost">Proxy host</label>
+    <div class="col-md-10">
+      <input type="text" id="proxyHost" name="proxy.host" class="form-control" value="@context.settings.proxy.map(_.host)"/>
+      <span id="error-proxy_host" class="error"></span>
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="control-label col-md-2" for="proxyPort">Proxy port</label>
+    <div class="col-md-10">
+      <input type="text" id="proxyPort" name="proxy.port" class="form-control input-mini" value="@context.settings.proxy.map(_.port)"/>
+      <span id="error-proxy_port" class="error"></span>
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="control-label col-md-2" for="proxyUser">Proxy user</label>
+    <div class="col-md-10">
+      <input type="text" id="proxyUser" name="proxy.user" class="form-control" value="@context.settings.proxy.map(_.user)"/>
+      <span id="error-proxy_user" class="error"></span>
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="control-label col-md-2" for="proxyPassword">Proxy password</label>
+    <div class="col-md-10">
+      <input type="text" id="proxyPassword" name="proxy.password" class="form-control" value="@context.settings.proxy.map(_.password)"/>
+      <span id="error-proxy_password" class="error"></span>
+    </div>
+  </div>
+</div>
+<script>
+$(function(){
+  $('#useProxy').change(function(){
+    $('.proxy input').prop('disabled', !$(this).prop('checked'));
+  }).change();
+});
+</script>

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -138,7 +138,8 @@ class AvatarImageProviderSpec extends FunSpec with MockitoSugar {
       oidc = None,
       skinName = "skin-blue",
       showMailAddress = false,
-      pluginNetworkInstall = false
+      pluginNetworkInstall = false,
+      proxy = None
     )
 
   /**

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -139,7 +139,7 @@ class AvatarImageProviderSpec extends FunSpec with MockitoSugar {
       skinName = "skin-blue",
       showMailAddress = false,
       pluginNetworkInstall = false,
-      proxy = None
+      pluginProxy = None
     )
 
   /**


### PR DESCRIPTION
This pull request adds proxy support for plugin installation from the central repository. Also supports proxy authentication, however I'm not sure whether replacing a global authenticator is a good solution in this case.

Closes #2103