### PR TITLE
BugFix for the file remove page

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -427,8 +427,10 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       commit = form.commit
     )
 
+    println(form.path)
+
     redirect(
-      s"/${repository.owner}/${repository.name}/tree/${form.branch}${if (form.path.length == 0) "" else form.path}"
+      s"/${repository.owner}/${repository.name}/tree/${form.branch}${if (form.path.length == 0) "" else "/" + form.path}"
     )
   })
 

--- a/src/main/twirl/gitbucket/core/helper/diff.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/diff.scala.html
@@ -103,8 +103,8 @@
         } else {
           @if(diff.newContent != None || diff.oldContent != None){
             <div id="diffText-@i" class="diffText"></div>
-            <textarea id="newText-@i" style="display: none;" data-file-name="@diff.oldPath" data-val='@diff.newContent.getOrElse("")'></textarea>
-            <textarea id="oldText-@i" style="display: none;" data-file-name="@diff.newPath" data-val='@diff.oldContent.getOrElse("")'></textarea>
+            <input type="hidden" id="newText-@i" data-file-name="@diff.oldPath" value="@diff.newContent">
+            <input type="hidden" id="oldText-@i" data-file-name="@diff.newPath" value="@diff.oldContent">
           } else {
             @if(diff.newIsImage || diff.oldIsImage){
               <div class="diff-image-render diff2up">

--- a/src/main/twirl/gitbucket/core/repo/delete.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/delete.scala.html
@@ -32,8 +32,8 @@
         <tr>
           <td>
             <div id="diffText"></div>
-            <textarea id="newText" style="display: none;" data-file-name="@fileName"></textarea>
-            <textarea id="oldText" style="display: none;" data-file-name="@fileName">@content.content</textarea>
+            <input type="hidden" id="newText" data-file-name="@fileName" value="">
+            <input type="hidden" id="oldText" data-file-name="@fileName" value="@content.content">
           </td>
         </tr>
       </table>
@@ -46,7 +46,7 @@
             <input type="text" name="message" class="form-control"/>
           </div>
           <div style="text-align: right;">
-            <a href="@helpers.url(repository)/blob/@helpers.encodeRefName((branch :: pathList).mkString("/"))" class="btn btn-default">Cancel</a>
+            <a href="@helpers.url(repository)/blob/@helpers.encodeRefName((branch :: pathList ::: List(fileName)).mkString("/"))" class="btn btn-default">Cancel</a>
             <input type="submit" id="commitButton" class="btn btn-success" value="Commit changes"/>
           </div>
         </div>

--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -78,9 +78,9 @@ function displayErrors(data, elem){
 function diffUsingJS(oldTextId, newTextId, outputId, viewType, ignoreSpace) {
   var old = $('#'+oldTextId), head = $('#' + newTextId);
   var render = new JsDiffRender({
-    oldText: old.attr('data-val'),
+    oldText: old.val(),
     oldTextName: old.attr('data-file-name'),
-    newText: head.attr('data-val'),
+    newText: head.val(),
     newTextName: head.attr('data-file-name'),
     ignoreSpace: ignoreSpace,
     contextSize: 4


### PR DESCRIPTION
Fix following bugs of the file remove page of the repository viewer:

- Cancel button didn’t work
- Redirection after remove didn’t work
- Diff wasn’t displayed at the remove confirmation page
