### PR TITLE
Fix database export failure

### DIFF
--- a/src/main/scala/gitbucket/core/util/JDBCUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JDBCUtil.scala
@@ -143,6 +143,7 @@ object JDBCUtil {
                       case Types.BOOLEAN | Types.BIT                                   => rs.getBoolean(columnName)
                       case Types.VARCHAR | Types.CLOB | Types.CHAR | Types.LONGVARCHAR => rs.getString(columnName)
                       case Types.INTEGER                                               => rs.getInt(columnName)
+                      case Types.BIGINT                                                => rs.getLong(columnName)
                       case Types.TIMESTAMP                                             => rs.getTimestamp(columnName)
                     }
                   }


### PR DESCRIPTION
This PR fixes database export error when exporting table that contains bigint column.

Column `SIZE` in table `RELEASE_ASSET` is defined as bigint and export failure if `RELEASE_ASSET` contains records.

fix #2120