### PR TITLE
Change the input type of "Proxy Password" from "text" to "password".

### DIFF
--- a/src/main/twirl/gitbucket/core/admin/settings_plugins.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_plugins.scala.html
@@ -38,7 +38,7 @@
   <div class="form-group">
     <label class="control-label col-md-2" for="proxyPassword">Proxy password</label>
     <div class="col-md-10">
-      <input type="text" id="proxyPassword" name="proxy.password" class="form-control" value="@context.settings.pluginProxy.map(_.password)"/>
+      <input type="password" id="proxyPassword" name="proxy.password" class="form-control" value="@context.settings.pluginProxy.map(_.password)"/>
       <span id="error-proxy_password" class="error"></span>
     </div>
   </div>


### PR DESCRIPTION
Since the password field of proxy authentication is plain text, it was able to confirm after entering.
Because it is sensitive information, I changed the input type to password.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
