### PR TITLE
Display the confirmation dialog

### DIFF
--- a/src/main/twirl/gitbucket/core/settings/danger.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/danger.scala.html
@@ -50,5 +50,15 @@ $(function(){
   $('#delete-form').submit(function(){
     return confirm('Once you delete a repository, there is no going back.\nAre you sure?');
   });
+  $('#transfer-form').submit(function(){
+    if($('#transfer-form').data('validated') === true){
+      return confirm('Transfer to the repository owner you entered.\nAre you sure?');
+    } else {
+      return true;
+    }
+  });
+  $('#gc-form').submit(function(){
+    return confirm('The garbage collection may take a long time.\nDo you want to execute it?');
+  });
 });
 </script>


### PR DESCRIPTION
When executing [Transfer Ownership] and [Garbage collection], display a confirmation dialog like [Delete repository]

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
