### PR TITLE
Jgit 5.1.1 - updated to the recent version of jgit and fixed deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val Name = "gitbucket"
 val GitBucketVersion = "4.28.0"
 val ScalatraVersion = "2.6.3"
 val JettyVersion = "9.4.11.v20180605"
-val JgitVersion = "5.0.1.201806211838-r"
+val JgitVersion = "5.1.1.201809181055-r"
 
 lazy val root = (project in file("."))
   .enablePlugins(SbtTwirl, ScalatraPlugin)

--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -256,9 +256,9 @@ trait ApiControllerBase extends ControllerBase {
       } else {
         val refs = git
           .getRepository()
-          .getAllRefs()
+          .getRefDatabase()
+          .getRefsByPrefix("refs/")
           .asScala
-          .collect { case (str, ref) if str.startsWith("refs/" + revstr) => ref }
 
         JsonFormat(refs.map { ref =>
           val sha = ref.getObjectId().name()

--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -740,15 +740,17 @@ object JGitUtil {
   def getBranchesOfCommit(git: Git, commitId: String): List[String] =
     using(new RevWalk(git.getRepository)) { revWalk =>
       defining(revWalk.parseCommit(git.getRepository.resolve(commitId + "^0"))) { commit =>
-        git.getRepository.getAllRefs.entrySet.asScala
+        git.getRepository.getRefDatabase
+          .getRefsByPrefix(Constants.R_HEADS)
+          .asScala
           .filter { e =>
-            (e.getKey.startsWith(Constants.R_HEADS) && revWalk.isMergedInto(
+            (revWalk.isMergedInto(
               commit,
-              revWalk.parseCommit(e.getValue.getObjectId)
+              revWalk.parseCommit(e.getObjectId)
             ))
           }
           .map { e =>
-            e.getValue.getName.substring(org.eclipse.jgit.lib.Constants.R_HEADS.length)
+            e.getName.substring(Constants.R_HEADS.length)
           }
           .toList
           .sorted
@@ -781,15 +783,17 @@ object JGitUtil {
   def getTagsOfCommit(git: Git, commitId: String): List[String] =
     using(new RevWalk(git.getRepository)) { revWalk =>
       defining(revWalk.parseCommit(git.getRepository.resolve(commitId + "^0"))) { commit =>
-        git.getRepository.getAllRefs.entrySet.asScala
+        git.getRepository.getRefDatabase
+          .getRefsByPrefix(Constants.R_TAGS)
+          .asScala
           .filter { e =>
-            (e.getKey.startsWith(Constants.R_TAGS) && revWalk.isMergedInto(
+            (revWalk.isMergedInto(
               commit,
-              revWalk.parseCommit(e.getValue.getObjectId)
+              revWalk.parseCommit(e.getObjectId)
             ))
           }
           .map { e =>
-            e.getValue.getName.substring(org.eclipse.jgit.lib.Constants.R_TAGS.length)
+            e.getName.substring(Constants.R_TAGS.length)
           }
           .toList
           .sorted


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*

I checked #2134 against this new version. The warning doesn't show up within the logs.
I had to do some changes due to deprecation warnings. Please review them carefully,
I'm not sure if I modified the scala part correctly (I'm no scala developer).