### PR TITLE
Remove repeat plugin name

### DIFF
--- a/src/main/twirl/gitbucket/core/admin/plugins.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/plugins.scala.html
@@ -41,10 +41,6 @@
               <span class="col-md-10">@plugin.pluginVersion</span>
             </div>
             <div class="row">
-              <label class="col-md-2">Name</label>
-              <span class="col-md-10">@plugin.pluginName</span>
-            </div>
-            <div class="row">
               <label class="col-md-2">Description</label>
               <span class="col-md-10 muted">@plugin.description</span>
             </div>


### PR DESCRIPTION
As the name is already in the panel header, don't repeat it

### Before submitting a pull-request to GitBucket I have first:

- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [] rebased my branch over master
- [] verified that project is compiling
- [] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
