### PR TITLE
Rollback h2 from 1.4.197 to 1.4.196

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
   "org.apache.tika"                 % "tika-core"                    % "1.19.1",
   "com.github.takezoe"              %% "blocking-slick-32"           % "0.0.11",
   "com.novell.ldap"                 % "jldap"                        % "2009-10-07",
-  "com.h2database"                  % "h2"                           % "1.4.197",
+  "com.h2database"                  % "h2"                           % "1.4.196",
   "org.mariadb.jdbc"                % "mariadb-java-client"          % "2.3.0",
   "org.postgresql"                  % "postgresql"                   % "42.2.5",
   "ch.qos.logback"                  % "logback-classic"              % "1.2.3",


### PR DESCRIPTION
h2 was upgraded to 1.4.197 in https://github.com/gitbucket/gitbucket/pull/2174, but it causes following exception in `sbt ~jetty:start` in my local environment:
```
java.lang.RuntimeException: Error scanning entry META-INF/versions/9/org/h2/util/Bits.class from jar file:///Users/takezoe/IdeaProjects/gitbucket/target/webapp/WEB-INF/lib/h2-1.4.197.jar
	at org.eclipse.jetty.annotations.AnnotationParser.parseJar(AnnotationParser.java:891)
	at org.eclipse.jetty.annotations.AnnotationParser.parse(AnnotationParser.java:837)
	at org.eclipse.jetty.annotations.AnnotationConfiguration$ParserTask.call(AnnotationConfiguration.java:159)
	at org.eclipse.jetty.annotations.AnnotationConfiguration$1.run(AnnotationConfiguration.java:462)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:673)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:591)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by:
java.lang.IllegalArgumentException
	at org.objectweb.asm.ClassReader.<init>(Unknown Source)
	at org.objectweb.asm.ClassReader.<init>(Unknown Source)
	at org.objectweb.asm.ClassReader.<init>(Unknown Source)
	at org.eclipse.jetty.annotations.AnnotationParser.scanClass(AnnotationParser.java:959)
	at org.eclipse.jetty.annotations.AnnotationParser.parseJarEntry(AnnotationParser.java:940)
	at org.eclipse.jetty.annotations.AnnotationParser.parseJar(AnnotationParser.java:887)
	at org.eclipse.jetty.annotations.AnnotationParser.parse(AnnotationParser.java:837)
	at org.eclipse.jetty.annotations.AnnotationConfiguration$ParserTask.call(AnnotationConfiguration.java:159)
	at org.eclipse.jetty.annotations.AnnotationConfiguration$1.run(AnnotationConfiguration.java:462)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:673)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:591)
	at java.base/java.lang.Thread.run(Thread.java:834)
```