### PR TITLE
Bump sbt-scalatra plugin to 1.0.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 addSbtPlugin("com.geirsson"     % "sbt-scalafmt" % "1.5.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl"    % "1.3.15")
 addSbtPlugin("com.eed3si9n"     % "sbt-assembly" % "0.14.8")
-addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.1")
+addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.3")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "1.1.2")
 addSbtCoursier
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")


### PR DESCRIPTION
To solve a problem which is reported in #2179, upgrade sbt-scalatra to the latest version to upgrade jetty which is used in xsbt-web-plugin.