### PR TITLE
add openjdk 8 & 11 in the travis-ci build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: true
 jdk: 
   - oraclejdk8
   - oraclejdk11
+  - openjdk8
+  - openjdk11
 script:
   - sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck test
 before_script:


### PR DESCRIPTION
as discussed on gitter, introduce opendjdk in travis build to ensure compatibility with openjdk