### PR TITLE
Add fail pattern at access token test

### DIFF
--- a/src/test/scala/gitbucket/core/service/AccessTokenServiceSpec.scala
+++ b/src/test/scala/gitbucket/core/service/AccessTokenServiceSpec.scala
@@ -3,7 +3,6 @@ package gitbucket.core.service
 import gitbucket.core.model._
 import org.scalatest.FunSuite
 import gitbucket.core.model.Profile._
-import gitbucket.core.model.Profile.profile._
 import gitbucket.core.model.Profile.profile.blockingApi._
 
 class AccessTokenServiceSpec extends FunSuite with ServiceSpecBase {

--- a/src/test/scala/gitbucket/core/service/AccessTokenServiceSpec.scala
+++ b/src/test/scala/gitbucket/core/service/AccessTokenServiceSpec.scala
@@ -53,6 +53,7 @@ class AccessTokenServiceSpec extends FunSuite with ServiceSpecBase {
       val (id, token) = AccessTokenService.generateAccessToken("root", "note")
       assert(AccessTokenService.getAccountByAccessToken(token) match {
         case Some(user) => user.userName == "root"
+        case _          => fail()
       })
     }
   }
@@ -88,6 +89,7 @@ class AccessTokenServiceSpec extends FunSuite with ServiceSpecBase {
 
       assert(AccessTokenService.getAccountByAccessToken(token) match {
         case Some(user) => user.userName == "user3"
+        case _          => fail()
       })
     }
   }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
