### PR TITLE
Ignore maven (and npm) paths for public repos

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PreProcessController.scala
+++ b/src/main/scala/gitbucket/core/controller/PreProcessController.scala
@@ -30,6 +30,7 @@ trait PreProcessControllerBase extends ControllerBase {
    */
   get(!context.settings.allowAnonymousAccess, context.loginAccount.isEmpty) {
     if (!context.currentPath.startsWith("/assets") && !context.currentPath.startsWith("/signin") &&
+        !context.currentPath.startsWith("/maven") && !context.currentPath.startsWith("/npm") &&
         !context.currentPath.startsWith("/register") && !context.currentPath.endsWith("/info/refs")) {
       Unauthorized()
     } else {


### PR DESCRIPTION
Fixes https://github.com/takezoe/gitbucket-maven-repository-plugin/issues/10
since the resopnsible code is not in the plug-in itself.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
