### PR TITLE
Add new extension point: anonymousAccessiblePaths

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PreProcessController.scala
+++ b/src/main/scala/gitbucket/core/controller/PreProcessController.scala
@@ -1,5 +1,6 @@
 package gitbucket.core.controller
 
+import gitbucket.core.plugin.PluginRegistry
 import org.scalatra.MovedPermanently
 
 class PreProcessController extends PreProcessControllerBase
@@ -30,7 +31,10 @@ trait PreProcessControllerBase extends ControllerBase {
    */
   get(!context.settings.allowAnonymousAccess, context.loginAccount.isEmpty) {
     if (!context.currentPath.startsWith("/assets") && !context.currentPath.startsWith("/signin") &&
-        !context.currentPath.startsWith("/register") && !context.currentPath.endsWith("/info/refs")) {
+        !context.currentPath.startsWith("/register") && !context.currentPath.endsWith("/info/refs") &&
+        !PluginRegistry().getAnonymousAccessiblePaths().exists { path =>
+          context.currentPath.startsWith(path)
+        }) {
       Unauthorized()
     } else {
       pass()

--- a/src/main/scala/gitbucket/core/plugin/Plugin.scala
+++ b/src/main/scala/gitbucket/core/plugin/Plugin.scala
@@ -48,6 +48,20 @@ abstract class Plugin {
   ): Seq[(String, ControllerBase)] = Nil
 
   /**
+   * Override to declare this plug-in provides anonymous accessible paths.
+   */
+  val anonymousAccessiblePaths: Seq[String] = Nil
+
+  /**
+   * Override to declare this plug-in provides anonymous accessible paths.
+   */
+  def anonymousAccessiblePaths(
+    registry: PluginRegistry,
+    context: ServletContext,
+    settings: SystemSettings
+  ): Seq[String] = Nil
+
+  /**
    * Override to declare this plug-in provides JavaScript.
    */
   val javaScripts: Seq[(String, String)] = Nil

--- a/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
@@ -1,6 +1,6 @@
 package gitbucket.core.plugin
 
-import java.io.{File, FilenameFilter, InputStream}
+import java.io.{File, FilenameFilter}
 import java.net.URLClassLoader
 import java.nio.file.{Files, Paths, StandardWatchEventKinds}
 import java.util.Base64
@@ -15,7 +15,6 @@ import gitbucket.core.service.ProtectedBranchService.ProtectedBranchReceiveHook
 import gitbucket.core.service.RepositoryService.RepositoryInfo
 import gitbucket.core.service.SystemSettingsService
 import gitbucket.core.service.SystemSettingsService.SystemSettings
-import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.DatabaseConfig
 import gitbucket.core.util.Directory._
 import gitbucket.core.util.HttpClientUtil._
@@ -35,6 +34,7 @@ class PluginRegistry {
   private val plugins = new ConcurrentLinkedQueue[PluginInfo]
   private val javaScripts = new ConcurrentLinkedQueue[(String, String)]
   private val controllers = new ConcurrentLinkedQueue[(ControllerBase, String)]
+  private val anonymousAccessiblePaths = new ConcurrentLinkedQueue[String]
   private val images = new ConcurrentHashMap[String, String]
   private val renderers = new ConcurrentHashMap[String, Renderer]
   renderers.put("md", MarkdownRenderer)
@@ -75,6 +75,10 @@ class PluginRegistry {
   def addController(path: String, controller: ControllerBase): Unit = controllers.add((controller, path))
 
   def getControllers(): Seq[(ControllerBase, String)] = controllers.asScala.toSeq
+
+  def addAnonymousAccessiblePath(path: String): Unit = anonymousAccessiblePaths.add(path)
+
+  def getAnonymousAccessiblePaths(): Seq[String] = anonymousAccessiblePaths.asScala.toSeq
 
   def addJavaScript(path: String, script: String): Unit =
     javaScripts.add((path, script)) //javaScripts += ((path, script))


### PR DESCRIPTION
This is an alternative to #2197 and the original issue is https://github.com/takezoe/gitbucket-maven-repository-plugin/issues/10.

This pull request allows plugins to add paths which are accessible by anonymous users even if anonymous access is prohibited in GitBucket configuration.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
