### PR TITLE
Display disabled checkbox in markdown files

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/Renderer.scala
+++ b/src/main/scala/gitbucket/core/plugin/Renderer.scala
@@ -29,7 +29,9 @@ object MarkdownRenderer extends Renderer {
         enableWikiLink = enableWikiLink,
         enableRefsLink = enableRefsLink,
         enableAnchor = enableAnchor,
-        enableLineBreaks = false
+        enableLineBreaks = false,
+        enableTaskList = true,
+        hasWritePermission = false
       )(context)
     )
   }


### PR DESCRIPTION
Currently, GitBucket can display checkbox in Markdown, but it works for only issues and pull requests. This pull request makes possible to display disabled checkbox for Markdown files in Git repositories. 

<img width="730" alt="disabled checkbox" src="https://user-images.githubusercontent.com/1094760/49273720-46473900-f4b9-11e8-89f1-9813d9e16f83.png">

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
