### PR TITLE
Allow login form to accept username in case-insensitive manner

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -88,7 +88,7 @@ trait IndexControllerBase extends ControllerBase {
   }
 
   post("/signin", signinForm) { form =>
-    authenticate(context.settings, form.userName, form.password) match {
+    authenticate(context.settings, form.userName.toLowerCase, form.password) match {
       case Some(account) =>
         flash.get(Keys.Flash.Redirect) match {
           case Some(redirectUrl: String) => signin(account, redirectUrl + form.hash.getOrElse(""))


### PR DESCRIPTION
## Issue that this PR is trying to solve

Currently the username while login is case-sensitive. For example, using "ROOT" to login will fail while "root" will do.
<img width="358" alt="screen shot 2018-12-04 at 9 06 13 pm" src="https://user-images.githubusercontent.com/11539188/49443910-9e0ed880-f808-11e8-920c-5215b1206f66.png">

However, creating new user with ID "ROOT" will fail, which means the username should be case-insensitive.
<img width="524" alt="screen shot 2018-12-04 at 9 08 19 pm" src="https://user-images.githubusercontent.com/11539188/49443963-c565a580-f808-11e8-9440-0a1471315148.png">

## Benefit brought by this PR

**This PR makes the login form accept username with case-insensitive manner. Say my ID is `test`, then entering `test` or `TEST` or `Test` in login form should all be valid.**

**This is also how most applications handles case of ID (including GitHub).**

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
