### PR TITLE
Updates for GitBucket 4.30.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 All changes to the project will be documented in this file.
 
 ## 4.30.0 - xx Dec 2018
-- Automatic ChangeLog generation for the Releases
-- A lot of GitHub compatible Web APIs
-- Show checkboxes in Markdown files in Git repository
-- New extension point for plugins: anonymousAccessiblePaths
-- Group support in Gist plugin
-- Allow to redirect to the Release from the activity timeline
+- Automatic ChangeLog Summary generation for new Releases
+- Allot of GitBucket Web API updates to increase compatibility with the GitHub API.
+- Display of checkboxes in Markdown files in Git repositories
+- A new extension point for plugins: anonymousAccessiblePaths
+- Group support in the Gist Plugin
+- Allow redirection to the Release Page from the Activity Timeline Page
 
 ## 4.29.0 - 29 Sep 2018
 - Official Docker image has been available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to the project will be documented in this file.
 
 ## 4.30.0 - xx Dec 2018
 - Automatic ChangeLog Summary generation for new Releases
-- Allot of GitBucket Web API updates to increase compatibility with the GitHub API.
+- A lot of GitBucket Web API updates to increase compatibility with the GitHub API.
 - Display of checkboxes in Markdown files in Git repositories
 - A new extension point for plugins: anonymousAccessiblePaths
 - Group support in the Gist Plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## 4.30.0 - xx Dec 2018
+- Automatic ChangeLog generation for the Releases
+- A lot of GitHub compatible Web APIs
+- Show checkboxes in Markdown files in Git repository
+- New extension point for plugins: anonymousAccessiblePaths
+- Group support in Gist plugin
+- Allow to redirect to the Release from the activity timeline
+
 ## 4.29.0 - 29 Sep 2018
 - Official Docker image has been available
 - Enhance file edit and delete buttons of the repository viewer

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ What's New in 4.30.x
 -------------
 ### 4.30.0 - xx Dec 2018
 - Automatic ChangeLog Summary generation for new Releases
-- Allot of GitBucket Web API updates to increase compatibility with the GitHub API.
+- A lot of GitBucket Web API updates to increase compatibility with the GitHub API.
 - Display of checkboxes in Markdown files in Git repositories
 - A new extension point for plugins: anonymousAccessiblePaths
 - Group support in the Gist Plugin

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Support
 What's New in 4.30.x
 -------------
 ### 4.30.0 - xx Dec 2018
-- Automatic ChangeLog generation for the Releases
-- A lot of GitHub compatible Web APIs
-- Show checkboxes in Markdown files in Git repository
-- New extension point for plugins: anonymousAccessiblePaths
-- Group support in Gist plugin
-- Allow to redirect to the Release from the activity timeline
+- Automatic ChangeLog Summary generation for new Releases
+- Allot of GitBucket Web API updates to increase compatibility with the GitHub API.
+- Display of checkboxes in Markdown files in Git repositories
+- A new extension point for plugins: anonymousAccessiblePaths
+- Group support in the Gist Plugin
+- Allow redirection to the Release Page from the Activity Timeline Page
 
 See the [change log](CHANGELOG.md) for all of the updates.

--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ Support
 - If you can't find same question and report, send it to [gitter room](https://gitter.im/gitbucket/gitbucket) before raising an issue.
 - The highest priority of GitBucket is the ease of installation and API compatibility with GitHub, so your feature request might be rejected if they go against those principles.
 
-What's New in 4.29.x
+What's New in 4.30.x
 -------------
-### 4.29.0 - 29 Sep 2018
-- Official Docker image has been available
-- Enhance file edit and delete buttons of the repository viewer
-- Fix Patch button to generate patches for all files in the commit
-- Display confirmation dialog for Transfer Ownership and Garbage collection
-- Fix wrong url encoding in "Compare & pull request"
+### 4.30.0 - xx Dec 2018
+- Automatic ChangeLog generation for the Releases
+- A lot of GitHub compatible Web APIs
+- Show checkboxes in Markdown files in Git repository
+- New extension point for plugins: anonymousAccessiblePaths
+- Group support in Gist plugin
+- Allow to redirect to the Release from the activity timeline
 
 See the [change log](CHANGELOG.md) for all of the updates.

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.pgp.PgpKeys._
 
 val Organization = "io.github.gitbucket"
 val Name = "gitbucket"
-val GitBucketVersion = "4.30.0-SNAPSHOT"
+val GitBucketVersion = "4.30.0"
 val ScalatraVersion = "2.6.3"
 val JettyVersion = "9.4.14.v20181114"
 val JgitVersion = "5.1.3.201810200350-r"

--- a/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
+++ b/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
@@ -58,5 +58,6 @@ object GitBucketCoreModule
       new Version("4.26.0"),
       new Version("4.27.0", new LiquibaseMigration("update/gitbucket-core_4.27.xml")),
       new Version("4.28.0"),
-      new Version("4.29.0")
+      new Version("4.29.0"),
+      new Version("4.30.0")
     )


### PR DESCRIPTION
GitBucket 4.30.0 will be released by the end of 2018.

We have to create `4.30.0` tag shortly because we have to fix some plugins which are affected by breaking changes in GitBucket 4.30.0 before release.

Closed issues and pull requests:
https://github.com/gitbucket/gitbucket/milestone/84?closed=1