### PR TITLE
Embedding filename to file icon tag

### DIFF
--- a/src/main/twirl/gitbucket/core/releases/list.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/list.scala.html
@@ -46,7 +46,7 @@
                   @release.map { case (release, assets) =>
                     @assets.map { asset =>
                       <li>
-                        <a href="@helpers.url(repository)/releases/@helpers.urlEncode(release.tag)/assets/@asset.fileName"><i class="octicon octicon-file" data-filename="@asset.label"></i>@asset.label</a>
+                        <a href="@helpers.url(repository)/releases/@helpers.urlEncode(release.tag)/assets/@helpers.urlEncode(asset.fileName)"><i class="octicon octicon-file" data-filename="@asset.label"></i>@asset.label</a>
                         <span class="label label-default">@helpers.readableSize(Some(asset.size))</span>
                       </li>
                     }

--- a/src/main/twirl/gitbucket/core/releases/list.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/list.scala.html
@@ -46,7 +46,7 @@
                   @release.map { case (release, assets) =>
                     @assets.map { asset =>
                       <li>
-                        <i class="octicon octicon-file"></i><a href="@helpers.url(repository)/releases/@helpers.urlEncode(release.tag)/assets/@asset.fileName">@asset.label</a>
+                        <a href="@helpers.url(repository)/releases/@helpers.urlEncode(release.tag)/assets/@asset.fileName"><i class="octicon octicon-file" data-filename="@asset.label"></i>@asset.label</a>
                         <span class="label label-default">@helpers.readableSize(Some(asset.size))</span>
                       </li>
                     }

--- a/src/main/twirl/gitbucket/core/releases/release.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/release.scala.html
@@ -44,7 +44,7 @@
           <ul style="list-style: none; padding-left: 8px;" id="attachedFiles">
             @assets.map{ asset =>
               <li>
-                <a href="@helpers.url(repository)/releases/@release.tag/assets/@asset.fileName"><i class="octicon octicon-file" data-filename="@asset.label"></i>@asset.label</a>
+                <a href="@helpers.url(repository)/releases/@release.tag/assets/@asset.fileName"><i class="octicon octicon-file" data-filename="@helpers.urlEncode(asset.label)"></i>@asset.label</a>
                 <span class="label label-default">@helpers.readableSize(Some(asset.size))</span>
               </li>
             }

--- a/src/main/twirl/gitbucket/core/releases/release.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/release.scala.html
@@ -44,7 +44,7 @@
           <ul style="list-style: none; padding-left: 8px;" id="attachedFiles">
             @assets.map{ asset =>
               <li>
-                <i class="octicon octicon-file"></i><a href="@helpers.url(repository)/releases/@release.tag/assets/@asset.fileName">@asset.label</a>
+                <a href="@helpers.url(repository)/releases/@release.tag/assets/@asset.fileName"><i class="octicon octicon-file" data-filename="@asset.label"></i>@asset.label</a>
                 <span class="label label-default">@helpers.readableSize(Some(asset.size))</span>
               </li>
             }

--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -149,7 +149,7 @@
                 <i class="octicon octicon-file-directory"></i>
               }
             } else {
-              <i class="octicon octicon-file-text" data-filename="@file.name"></i>
+              <i class="octicon octicon-file-text" data-filename="@helpers.urlEncode(file.name)"></i>
             }
           </td>
           <td class="ellipsis-cell" style="width: 20%; min-width: 160px;">

--- a/src/main/twirl/gitbucket/core/repo/files.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/files.scala.html
@@ -149,7 +149,7 @@
                 <i class="octicon octicon-file-directory"></i>
               }
             } else {
-              <i class="octicon octicon-file-text"></i>
+              <i class="octicon octicon-file-text" data-filename="@file.name"></i>
             }
           </td>
           <td class="ellipsis-cell" style="width: 20%; min-width: 160px;">


### PR DESCRIPTION
This PR is alternative implementation to #1981. I made [gitbucket-fileicon-plugin](https://github.com/kounoike/gitbucket-fileicon-plugin). It can run with this PR.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
