### PR TITLE
Add ETag feature for cache plugin-assets

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
@@ -409,6 +409,13 @@ object PluginRegistry {
     }
   }
 
+  def getPluginInfoFromClassLoader(classLoader: ClassLoader): Option[PluginInfo] = {
+    instance
+      .getPlugins()
+      .find { info =>
+        info.classLoader.equals(classLoader)
+      }
+  }
 }
 
 case class Link(

--- a/src/main/scala/gitbucket/core/servlet/PluginAssetsServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/PluginAssetsServlet.scala
@@ -31,7 +31,6 @@ class PluginAssetsServlet extends HttpServlet {
                     val bytes = IOUtils.toByteArray(in)
                     resp.setContentLength(bytes.length)
                     resp.setContentType(FileUtil.getMimeType(path, bytes))
-                    //resp.setDateHeader("Last-Modified", lastModified)
                     resp.setHeader("ETag", etag)
                     resp.getOutputStream.write(bytes)
                   } finally {

--- a/src/main/scala/gitbucket/core/servlet/PluginAssetsServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/PluginAssetsServlet.scala
@@ -1,7 +1,6 @@
 package gitbucket.core.servlet
 
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
-
 import gitbucket.core.plugin.PluginRegistry
 import gitbucket.core.util.FileUtil
 import org.apache.commons.io.IOUtils
@@ -17,24 +16,33 @@ class PluginAssetsServlet extends HttpServlet {
 
     assetsMappings
       .find { case (prefix, _, _) => path.startsWith("/plugin-assets" + prefix) }
-      .flatMap {
+      .foreach {
         case (prefix, resourcePath, classLoader) =>
-          val resourceName = path.substring(("/plugin-assets" + prefix).length)
-          Option(classLoader.getResourceAsStream(resourcePath.stripPrefix("/") + resourceName))
-      }
-      .map { in =>
-        try {
-          val bytes = IOUtils.toByteArray(in)
-          resp.setContentLength(bytes.length)
-          resp.setContentType(FileUtil.getMimeType(path, bytes))
-          resp.setHeader("Cache-Control", "max-age=3600")
-          resp.getOutputStream.write(bytes)
-        } finally {
-          in.close()
-        }
-      }
-      .getOrElse {
-        resp.setStatus(404)
+          val ifNoneMatch = req.getHeader("If-None-Match")
+          PluginRegistry.getPluginInfoFromClassLoader(classLoader).map { info =>
+            val etag = s""""${info.pluginJar.lastModified}"""" // ETag must wrapped with double quote
+            if (ifNoneMatch == etag) {
+              resp.setStatus(304)
+            } else {
+              val resourceName = path.substring(("/plugin-assets" + prefix).length)
+              Option(classLoader.getResourceAsStream(resourcePath.stripPrefix("/") + resourceName))
+                .map { in =>
+                  try {
+                    val bytes = IOUtils.toByteArray(in)
+                    resp.setContentLength(bytes.length)
+                    resp.setContentType(FileUtil.getMimeType(path, bytes))
+                    //resp.setDateHeader("Last-Modified", lastModified)
+                    resp.setHeader("ETag", etag)
+                    resp.getOutputStream.write(bytes)
+                  } finally {
+                    in.close()
+                  }
+                }
+                .getOrElse {
+                  resp.setStatus(404)
+                }
+            }
+          }
       }
   }
 


### PR DESCRIPTION
In #1491, I added Cache-Control header for cache plugin-assets. But, it is over-cached for plugin-developers. It requires reload when plugin updated.

I replaced cache control with ETag header which generated by plugin jar's modified time.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
