### PR TITLE
Close classLoader when Plugin doesn't add

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
@@ -331,6 +331,7 @@ object PluginRegistry {
         instance.getPlugins().find(_.pluginId == pluginId) match {
           case Some(x) => {
             logger.warn(s"Plugin ${pluginId} is duplicated. ${x.pluginJar.getName} is available.")
+            classLoader.close()
           }
           case None => {
             // Migration
@@ -370,7 +371,9 @@ object PluginRegistry {
           }
         }
       } catch {
-        case e: Throwable => logger.error(s"Error during plugin initialization: ${pluginJar.getName}", e)
+        case e: Throwable =>
+          logger.error(s"Error during plugin initialization: ${pluginJar.getName}", e)
+          classLoader.close()
       }
     }
 


### PR DESCRIPTION
On Windows and if there is two or more versions of same plugin, plugin reload feature doesn't work. This PR fix this issue. 

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
