### PR TITLE
Stop using JGit's RepositoryCache

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/GitAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitAuthenticationFilter.scala
@@ -106,6 +106,7 @@ class GitAuthenticationFilter extends Filter with RepositoryService with Account
                   if (isUpdating) {
                     if (hasDeveloperRole(repository.owner, repository.name, Some(account))) {
                       request.setAttribute(Keys.Request.UserName, account.userName)
+                      request.setAttribute(Keys.Request.RepositoryLockKey, s"${repository.owner}/${repository.name}")
                       true
                     } else false
                   } else if (repository.repository.isPrivate) {

--- a/src/main/scala/gitbucket/core/util/Keys.scala
+++ b/src/main/scala/gitbucket/core/util/Keys.scala
@@ -87,6 +87,11 @@ object Keys {
     val UserName = "USER_NAME"
 
     /**
+     * Request key for the Lock key which is used during Git repository write access.
+     */
+    val RepositoryLockKey = "REPOSITORY_LOCK_KEY"
+
+    /**
      * Generate request key for the request cache.
      */
     def Cache(key: String) = s"cache.${key}"


### PR DESCRIPTION
In JGit, [FileResolver](https://github.com/eclipse/jgit/blob/562976f417f21f3f2852ba9e91e12c292c39fa02/org.eclipse.jgit/src/org/eclipse/jgit/transport/resolver/FileResolver.java#L116) uses `RepositoryCache`. And cached `FileRepository` keeps the pack file open which I pointed out [here](https://github.com/gitbucket/gitbucket/issues/544#issuecomment-357951858).

This PR closes #544 by stop using `FileResolver` and improve exclusion control between `GitServlet` and WebUI/REST API.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
