### PR TITLE
Fix release activity link generation

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ReleasesController.scala
+++ b/src/main/scala/gitbucket/core/controller/ReleasesController.scala
@@ -121,7 +121,7 @@ trait ReleaseControllerBase extends ControllerBase {
         createReleaseAsset(repository.owner, repository.name, tagName, fileId, fileName, size, loginAccount)
     }
 
-    recordReleaseActivity(repository.owner, repository.name, loginAccount.userName, form.name)
+    recordReleaseActivity(repository.owner, repository.name, loginAccount.userName, form.name, tagName)
 
     redirect(s"/${repository.owner}/${repository.name}/releases/${tagName}")
   })

--- a/src/main/scala/gitbucket/core/service/ActivityService.scala
+++ b/src/main/scala/gitbucket/core/service/ActivityService.scala
@@ -352,15 +352,19 @@ trait ActivityService {
       currentDate
     )
 
-  def recordReleaseActivity(userName: String, repositoryName: String, activityUserName: String, name: String)(
-    implicit s: Session
-  ): Unit =
+  def recordReleaseActivity(
+    userName: String,
+    repositoryName: String,
+    activityUserName: String,
+    releaseName: String,
+    tagName: String
+  )(implicit s: Session): Unit =
     Activities insert Activity(
       userName,
       repositoryName,
       activityUserName,
       "release",
-      s"[user:${activityUserName}] released [release:${userName}/${repositoryName}/${name}] at [repo:${userName}/${repositoryName}]",
+      s"[user:${activityUserName}] released [release:${userName}/${repositoryName}/${tagName}:${releaseName}] at [repo:${userName}/${repositoryName}]",
       None,
       currentDate
     )

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -235,10 +235,10 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
               .group(2)}@${m.group(3).substring(0, 7)}</a>"""
         )
         .replaceAll(
-          "\\[release:([^\\s]+?)/([^\\s]+?)/([^\\s]+?)\\]",
+          "\\[release:([^\\s]+?)/([^\\s]+?)/([^\\s]+?):(.+)\\]",
           (m: Match) =>
             s"""<a href="${context.path}/${m.group(1)}/${m.group(2)}/releases/${encodeRefName(m.group(3))}">${m
-              .group(3)}</a>"""
+              .group(4)}</a>"""
         )
     )
 


### PR DESCRIPTION
This PR fixes inappropriate activity link generation when you create a release whose name isn't the same as tag name.
 
![link-generation-error](https://user-images.githubusercontent.com/17608272/52215427-5a535080-28d7-11e9-8743-0a0bcf93fc18.PNG)