### PR TITLE
Add avatar to username completion

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -10,6 +10,7 @@ import gitbucket.core.service._
 import gitbucket.core.util.Implicits._
 import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util._
+import gitbucket.core.view.helpers._
 import org.scalatra.Ok
 import org.scalatra.forms._
 
@@ -206,7 +207,8 @@ trait IndexControllerBase extends ControllerBase {
             }
             .map { t =>
               Map(
-                "label" -> s"<b>@${StringUtil.escapeHtml(t.userName)}</b> ${StringUtil.escapeHtml(t.fullName)}",
+                "label" -> s"${avatar(t.userName, 16)}<b>@${StringUtil.escapeHtml(t.userName)}</b> ${StringUtil
+                  .escapeHtml(t.fullName)}",
                 "value" -> t.userName
               )
             }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

This PR adds avatar to username completion as:

![20190209-101426](https://user-images.githubusercontent.com/6997928/52515034-5cf8d180-2c5a-11e9-8db1-3928c857809f.png)
![20190209-101546](https://user-images.githubusercontent.com/6997928/52515036-5f5b2b80-2c5a-11e9-9005-ba089343048d.png)
