### PR TITLE
Implement creation of group via api

### DIFF
--- a/src/main/scala/gitbucket/core/api/CreateAGroup.scala
+++ b/src/main/scala/gitbucket/core/api/CreateAGroup.scala
@@ -1,0 +1,8 @@
+package gitbucket.core.api
+
+case class CreateAGroup(
+  login: String,
+  admin: String,
+  profile_name: Option[String],
+  url: Option[String]
+)

--- a/src/main/scala/gitbucket/core/controller/api/ApiOrganizationControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiOrganizationControllerBase.scala
@@ -1,12 +1,12 @@
 package gitbucket.core.controller.api
-import gitbucket.core.api.{ApiGroup, ApiRepository, ApiUser, JsonFormat}
+import gitbucket.core.api.{ApiGroup, CreateAGroup, ApiRepository, ApiUser, JsonFormat}
 import gitbucket.core.controller.ControllerBase
 import gitbucket.core.service.{AccountService, RepositoryService}
 import gitbucket.core.util.Implicits._
-import gitbucket.core.util.UsersAuthenticator
+import gitbucket.core.util.{AdminAuthenticator, UsersAuthenticator}
 
 trait ApiOrganizationControllerBase extends ControllerBase {
-  self: RepositoryService with AccountService with UsersAuthenticator =>
+  self: RepositoryService with AccountService with AdminAuthenticator with UsersAuthenticator =>
 
   /*
    * i. List your organizations
@@ -51,6 +51,19 @@ trait ApiOrganizationControllerBase extends ControllerBase {
    * ghe: i. Create an organization
    * https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#create-an-organization
    */
+  post("/api/v3/admin/organizations")(adminOnly {
+    for {
+      data <- extractFromJsonBody[CreateAGroup]
+    } yield {
+      val group = createGroup(
+        data.login,
+        data.profile_name,
+        data.url
+      )
+      updateGroupMembers(data.login, List(data.admin -> true))
+      JsonFormat(ApiGroup(group))
+    }
+  })
 
   /*
    * ghe: ii. Rename an organization

--- a/src/main/scala/gitbucket/core/service/AccountService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountService.scala
@@ -240,8 +240,8 @@ trait AccountService {
   def updateLastLoginDate(userName: String)(implicit s: Session): Unit =
     Accounts.filter(_.userName === userName.bind).map(_.lastLoginDate).update(currentDate)
 
-  def createGroup(groupName: String, description: Option[String], url: Option[String])(implicit s: Session): Unit =
-    Accounts insert Account(
+  def createGroup(groupName: String, description: Option[String], url: Option[String])(implicit s: Session): Account = {
+    val group = Account(
       userName = groupName,
       password = "",
       fullName = groupName,
@@ -256,6 +256,9 @@ trait AccountService {
       isRemoved = false,
       description = description
     )
+    Accounts insert group
+    group
+  }
 
   def updateGroup(groupName: String, description: Option[String], url: Option[String], removed: Boolean)(
     implicit s: Session


### PR DESCRIPTION
This PR implements group creation via api: [https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#create-an-organization](https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#create-an-organization)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
