### PR TITLE
fix logo vertical align

### DIFF
--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -142,6 +142,7 @@ div.content-wrapper {
   width: 24px;
   height: 24px;
   display: inline;
+  vertical-align: text-bottom;
 }
 
 /* ======================================================================== */


### PR DESCRIPTION
before:

![20190302-213800](https://user-images.githubusercontent.com/6997928/53681988-84602d00-3d34-11e9-8f51-ac7f098d4c0d.png)

after:

![20190302-214214](https://user-images.githubusercontent.com/6997928/53681989-87f3b400-3d34-11e9-874a-2b3ee4649c36.png)


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
