### PR TITLE
Commit updateLastLoginDate before processing filter

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
@@ -7,6 +7,7 @@ import gitbucket.core.model.Account
 import gitbucket.core.service.SystemSettingsService.SystemSettings
 import gitbucket.core.service.{AccessTokenService, AccountService, SystemSettingsService}
 import gitbucket.core.util.{AuthUtil, Keys}
+import gitbucket.core.model.Profile.profile.blockingApi._
 
 class ApiAuthenticationFilter extends Filter with AccessTokenService with AccountService with SystemSettingsService {
 
@@ -33,7 +34,9 @@ class ApiAuthenticationFilter extends Filter with AccessTokenService with Accoun
       } match {
       case Some(Right(account)) =>
         request.setAttribute(Keys.Session.LoginAccount, account)
-        updateLastLoginDate(account.userName)
+        Database() withTransaction { implicit session =>
+          updateLastLoginDate(account.userName)
+        }
         chain.doFilter(req, res)
       case None => chain.doFilter(req, res)
       case Some(Left(_)) => {


### PR DESCRIPTION
In some situation, #2267 update table lock causes problem. This PR fix such problem.

<details>
```
2019-03-18 10:50:22.885:WARN:oejs.HttpChannel:qtp127618319-15: /api/v3/users/root/repos
javax.servlet.ServletException: org.h2.jdbc.JdbcSQLException: 繝�繝ｼ繝悶Ν  縺ｮ繝ｭ繝�繧ｯ隧ｦ陦後′繧ｿ繧､繝�繧｢繧ｦ繝医＠縺ｾ縺励◆|Timeout trying to lock table ; SQL statement:|update "ACCOUNT" set "LAST_LOGIN_DATE" = ? where "ACCOUNT"."USER_NAME" = ? [50200-197]
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.Server.handle(Server.java:530)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:347)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:256)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:279)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:124)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:247)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:140)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:382)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:708)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:626)
        at java.lang.Thread.run(Thread.java:748)
Caused by:
org.h2.jdbc.JdbcSQLException: 繝�繝ｼ繝悶Ν  縺ｮ繝ｭ繝�繧ｯ隧ｦ陦後′繧ｿ繧､繝�繧｢繧ｦ繝医＠縺ｾ縺励◆|Timeout trying to lock table ; SQL statement:|update "ACCOUNT" set "LAST_LOGIN_DATE" = ? where "ACCOUNT"."USER_NAME" = ? [50200-197]
        at org.h2.message.DbException.getJdbcSQLException(DbException.java:357)
        at org.h2.message.DbException.get(DbException.java:168)
        at org.h2.command.Command.filterConcurrentUpdate(Command.java:316)
        at org.h2.command.Command.executeUpdate(Command.java:268)
        at org.h2.jdbc.JdbcPreparedStatement.executeUpdateInternal(JdbcPreparedStatement.java:199)
        at org.h2.jdbc.JdbcPreparedStatement.executeUpdate(JdbcPreparedStatement.java:153)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.$anonfun$run$10(JdbcActionComponent.scala:324)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.$anonfun$run$10$adapted(JdbcActionComponent.scala:320)
        at slick.jdbc.JdbcBackend$SessionDef.withPreparedStatement(JdbcBackend.scala:371)
        at slick.jdbc.JdbcBackend$SessionDef.withPreparedStatement$(JdbcBackend.scala:366)
        at slick.jdbc.JdbcBackend$BaseSession.withPreparedStatement(JdbcBackend.scala:433)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.run(JdbcActionComponent.scala:320)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.run(JdbcActionComponent.scala:319)
        at slick.jdbc.JdbcActionComponent$SimpleJdbcProfileAction.run(JdbcActionComponent.scala:29)
        at slick.jdbc.JdbcActionComponent$SimpleJdbcProfileAction.run(JdbcActionComponent.scala:26)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingUpdateInvoker.update(BlockingProfile.scala:111)
        at gitbucket.core.service.AccountService.updateLastLoginDate(AccountService.scala:241)
        at gitbucket.core.service.AccountService.updateLastLoginDate$(AccountService.scala:240)
        at gitbucket.core.servlet.ApiAuthenticationFilter.updateLastLoginDate(ApiAuthenticationFilter.scala:11)
        at gitbucket.core.servlet.ApiAuthenticationFilter.doFilter(ApiAuthenticationFilter.scala:36)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
        at gitbucket.core.servlet.TransactionFilter.$anonfun$doFilter$1(TransactionFilter.scala:39)
        at gitbucket.core.servlet.TransactionFilter.$anonfun$doFilter$1$adapted(TransactionFilter.scala:30)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.$anonfun$withTransaction$2(BlockingProfile.scala:207)
        at slick.JdbcProfileBlockingSession$BlockingSession.withTransaction(TransactionalJdbcBackend.scala:26)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.$anonfun$withTransaction$1(BlockingProfile.scala:207)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.withSession(BlockingProfile.scala:200)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.withTransaction(BlockingProfile.scala:207)
        at gitbucket.core.servlet.TransactionFilter.doFilter(TransactionFilter.scala:30)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1629)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:533)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:548)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:190)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:188)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1253)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:168)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:166)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1155)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:219)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.Server.handle(Server.java:530)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:347)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:256)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:279)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:124)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:247)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:140)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:382)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:708)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:626)
        at java.lang.Thread.run(Thread.java:748)
Caused by:
org.h2.jdbc.JdbcSQLException: 繝�繝ｼ繝悶Ν "ACCOUNT" 縺ｫ荳ｦ陦後＠縺ｦ譖ｴ譁ｰ縺瑚｡後ｏ繧後∪縺励◆: 蛻･縺ｮ繝医Λ繝ｳ繧ｶ繧ｯ繧ｷ繝ｧ繝ｳ縺後�∝酔縺倩｡後↓譖ｴ譁ｰ縺句炎髯､繧定｡後＞縺ｾ縺励◆|Concurrent update in table "ACCOUNT": another transaction has updated or deleted the same row [90131-197]
        at org.h2.message.DbException.getJdbcSQLException(DbException.java:357)
        at org.h2.message.DbException.get(DbException.java:168)
        at org.h2.mvstore.db.MVTable.convertException(MVTable.java:922)
        at org.h2.mvstore.db.MVSecondaryIndex.remove(MVSecondaryIndex.java:252)
        at org.h2.mvstore.db.MVTable.removeRow(MVTable.java:706)
        at org.h2.table.Table.updateRows(Table.java:490)
        at org.h2.command.dml.Update.update(Update.java:177)
        at org.h2.command.CommandContainer.update(CommandContainer.java:102)
        at org.h2.command.Command.executeUpdate(Command.java:261)
        at org.h2.jdbc.JdbcPreparedStatement.executeUpdateInternal(JdbcPreparedStatement.java:199)
        at org.h2.jdbc.JdbcPreparedStatement.executeUpdate(JdbcPreparedStatement.java:153)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.$anonfun$run$10(JdbcActionComponent.scala:324)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.$anonfun$run$10$adapted(JdbcActionComponent.scala:320)
        at slick.jdbc.JdbcBackend$SessionDef.withPreparedStatement(JdbcBackend.scala:371)
        at slick.jdbc.JdbcBackend$SessionDef.withPreparedStatement$(JdbcBackend.scala:366)
        at slick.jdbc.JdbcBackend$BaseSession.withPreparedStatement(JdbcBackend.scala:433)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.run(JdbcActionComponent.scala:320)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.run(JdbcActionComponent.scala:319)
        at slick.jdbc.JdbcActionComponent$SimpleJdbcProfileAction.run(JdbcActionComponent.scala:29)
        at slick.jdbc.JdbcActionComponent$SimpleJdbcProfileAction.run(JdbcActionComponent.scala:26)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingUpdateInvoker.update(BlockingProfile.scala:111)
        at gitbucket.core.service.AccountService.updateLastLoginDate(AccountService.scala:241)
        at gitbucket.core.service.AccountService.updateLastLoginDate$(AccountService.scala:240)
        at gitbucket.core.servlet.ApiAuthenticationFilter.updateLastLoginDate(ApiAuthenticationFilter.scala:11)
        at gitbucket.core.servlet.ApiAuthenticationFilter.doFilter(ApiAuthenticationFilter.scala:36)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
        at gitbucket.core.servlet.TransactionFilter.$anonfun$doFilter$1(TransactionFilter.scala:39)
        at gitbucket.core.servlet.TransactionFilter.$anonfun$doFilter$1$adapted(TransactionFilter.scala:30)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.$anonfun$withTransaction$2(BlockingProfile.scala:207)
        at slick.JdbcProfileBlockingSession$BlockingSession.withTransaction(TransactionalJdbcBackend.scala:26)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.$anonfun$withTransaction$1(BlockingProfile.scala:207)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.withSession(BlockingProfile.scala:200)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.withTransaction(BlockingProfile.scala:207)
        at gitbucket.core.servlet.TransactionFilter.doFilter(TransactionFilter.scala:30)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1629)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:533)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:548)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:190)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:188)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1253)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:168)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:166)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1155)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:219)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.Server.handle(Server.java:530)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:347)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:256)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:279)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:124)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:247)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:140)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:382)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:708)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:626)
        at java.lang.Thread.run(Thread.java:748)
Caused by:
java.lang.IllegalStateException: Entry is locked [1.4.197/101]
        at org.h2.mvstore.DataUtils.newIllegalStateException(DataUtils.java:870)
        at org.h2.mvstore.db.TransactionStore$TransactionMap.set(TransactionStore.java:1067)
        at org.h2.mvstore.db.TransactionStore$TransactionMap.remove(TransactionStore.java:1026)
        at org.h2.mvstore.db.MVSecondaryIndex.remove(MVSecondaryIndex.java:246)
        at org.h2.mvstore.db.MVTable.removeRow(MVTable.java:706)
        at org.h2.table.Table.updateRows(Table.java:490)
        at org.h2.command.dml.Update.update(Update.java:177)
        at org.h2.command.CommandContainer.update(CommandContainer.java:102)
        at org.h2.command.Command.executeUpdate(Command.java:261)
        at org.h2.jdbc.JdbcPreparedStatement.executeUpdateInternal(JdbcPreparedStatement.java:199)
        at org.h2.jdbc.JdbcPreparedStatement.executeUpdate(JdbcPreparedStatement.java:153)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.$anonfun$run$10(JdbcActionComponent.scala:324)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.$anonfun$run$10$adapted(JdbcActionComponent.scala:320)
        at slick.jdbc.JdbcBackend$SessionDef.withPreparedStatement(JdbcBackend.scala:371)
        at slick.jdbc.JdbcBackend$SessionDef.withPreparedStatement$(JdbcBackend.scala:366)
        at slick.jdbc.JdbcBackend$BaseSession.withPreparedStatement(JdbcBackend.scala:433)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.run(JdbcActionComponent.scala:320)
        at slick.jdbc.JdbcActionComponent$UpdateActionExtensionMethodsImpl$$anon$8.run(JdbcActionComponent.scala:319)
        at slick.jdbc.JdbcActionComponent$SimpleJdbcProfileAction.run(JdbcActionComponent.scala:29)
        at slick.jdbc.JdbcActionComponent$SimpleJdbcProfileAction.run(JdbcActionComponent.scala:26)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingUpdateInvoker.update(BlockingProfile.scala:111)
        at gitbucket.core.service.AccountService.updateLastLoginDate(AccountService.scala:241)
        at gitbucket.core.service.AccountService.updateLastLoginDate$(AccountService.scala:240)
        at gitbucket.core.servlet.ApiAuthenticationFilter.updateLastLoginDate(ApiAuthenticationFilter.scala:11)
        at gitbucket.core.servlet.ApiAuthenticationFilter.doFilter(ApiAuthenticationFilter.scala:36)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
        at gitbucket.core.servlet.TransactionFilter.$anonfun$doFilter$1(TransactionFilter.scala:39)
        at gitbucket.core.servlet.TransactionFilter.$anonfun$doFilter$1$adapted(TransactionFilter.scala:30)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.$anonfun$withTransaction$2(BlockingProfile.scala:207)
        at slick.JdbcProfileBlockingSession$BlockingSession.withTransaction(TransactionalJdbcBackend.scala:26)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.$anonfun$withTransaction$1(BlockingProfile.scala:207)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.withSession(BlockingProfile.scala:200)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.withTransaction(BlockingProfile.scala:207)
        at gitbucket.core.servlet.TransactionFilter.doFilter(TransactionFilter.scala:30)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1629)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:533)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:548)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:190)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:188)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1253)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:168)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:166)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1155)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:219)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.Server.handle(Server.java:530)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:347)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:256)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:279)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:124)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:247)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:140)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:382)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:708)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:626)
        at java.lang.Thread.run(Thread.java:748)
```
</details>

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
