### PR TITLE
Apply default priority to pull request

### DIFF
--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -464,6 +464,7 @@ trait PullRequestsControllerBase extends ControllerBase {
             getAssignableUserNames(originRepository.owner, originRepository.name),
             getMilestones(originRepository.owner, originRepository.name),
             getPriorities(originRepository.owner, originRepository.name),
+            getDefaultPriority(originRepository.owner, originRepository.name),
             getLabels(originRepository.owner, originRepository.name)
           )
         }

--- a/src/main/twirl/gitbucket/core/pulls/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/compare.scala.html
@@ -15,6 +15,7 @@
   collaborators: List[String],
   milestones: List[gitbucket.core.model.Milestone],
   priorities: List[gitbucket.core.model.Priority],
+  defaultPriority: Option[gitbucket.core.model.Priority],
   labels: List[gitbucket.core.model.Label])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main(s"Pull requests - ${repository.owner}/${repository.name}", Some(repository)){
@@ -82,7 +83,7 @@
               </div>
             </div>
             <div class="col-md-3">
-              @gitbucket.core.issues.html.issueinfo(None, Nil, Nil, collaborators, milestones.map((_, 0, 0)), priorities, None, labels, hasOriginWritePermission, repository)
+              @gitbucket.core.issues.html.issueinfo(None, Nil, Nil, collaborators, milestones.map((_, 0, 0)), priorities, defaultPriority, labels, hasOriginWritePermission, repository)
             </div>
           </div>
         </form>


### PR DESCRIPTION
While the default priority is appiled to only creating an issue for now, it can be applied to creating a pull request as well.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
