### PR TITLE
Pubkey vs. Private Key clarity

### DIFF
--- a/src/main/twirl/gitbucket/core/account/ssh.scala.html
+++ b/src/main/twirl/gitbucket/core/account/ssh.scala.html
@@ -1,9 +1,9 @@
 @(account: gitbucket.core.model.Account, sshKeys: List[gitbucket.core.model.SshKey])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.ssh.SshUtil
-@gitbucket.core.html.main("SSH Keys"){
+@gitbucket.core.html.main("Public SSH Keys"){
   @gitbucket.core.account.html.menu("ssh", context.loginAccount.get.userName, false){
     <div class="panel panel-default">
-      <div class="panel-heading strong">SSH Keys</div>
+      <div class="panel-heading strong">Public SSH Keys</div>
       <div class="panel-body">
         @if(sshKeys.isEmpty){
           No keys
@@ -19,7 +19,7 @@
     </div>
     <form method="POST" action="@context.path/@account.userName/_ssh" validate="true" autocomplete="off">
       <div class="panel panel-default">
-        <div class="panel-heading strong">Add a SSH Key</div>
+        <div class="panel-heading strong">Add an SSH public key</div>
         <div class="panel-body">
           <fieldset class="form-group">
             <label for="title" class="strong">Title</label>


### PR DESCRIPTION
It should be clearer to they user that they're adding a public key for access to a git repo and not adding private keys unnecessarily.

### Before submitting a pull-request to GitBucket I have first:

- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [] rebased my branch over master
- [] verified that project is compiling
- [] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
