### PR TITLE
Wrong file size issue when cloning and pulling contents via git-lfs.

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/GitLfsTransferServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitLfsTransferServlet.scala
@@ -28,7 +28,7 @@ class GitLfsTransferServlet extends HttpServlet {
       if (file.exists()) {
         res.setStatus(HttpStatus.SC_OK)
         res.setContentType("application/octet-stream")
-        res.setContentLength(file.length.toInt)
+        res.setHeader("Content-Length", file.length.toString)
         using(new FileInputStream(file), res.getOutputStream) { (in, out) =>
           IOUtils.copy(in, out)
           out.flush()


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
----
I already explained the route cause which is caused by failing clone and/or pull large git-lfsed files via git-lfs, on gitter.im.
Also, I fixed it. However, I'm not familiar with scala and deep git command. ex. rebase and so on.
Sorry for inconvenience.