### PR TITLE
fix: issue save button disabled if after edited issue title once

### DIFF
--- a/src/main/twirl/gitbucket/core/issues/issue.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/issue.scala.html
@@ -79,9 +79,9 @@ $(function(){
     }).done(function(data){
       $('#show-title').empty().text(data.title);
       $('#cancel').click();
-      $(this).removeAttr('disabled');
+      $('#update').removeAttr('disabled');
     }).fail(function(req){
-      $(this).removeAttr('disabled');
+      $('#update').removeAttr('disabled');
       $('#error-edit-title').text($.parseJSON(req.responseText).title);
     });
     return false;


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

### Motivation

Issue save button disabled if after edit issue title once. Please see the following.

![gitbucket-issue-edit](https://user-images.githubusercontent.com/11273093/59699641-e766c880-922c-11e9-8549-cf6dcc0db6eb.gif)

### After fix

After fix. Issue button is enabled if after edit issue title. Please see the following.

![gitbucket-after-fix](https://user-images.githubusercontent.com/11273093/59699654-ec2b7c80-922c-11e9-9e65-0b1b7d94f6ba.gif)

Thanks :)