### PR TITLE
docs: update issue & pull request template task lists

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 ### Before submitting an issue to GitBucket I have first:
 
-- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
-- [] searched for similar already existing issue
-- [] read the documentation and [wiki](https://github.com/gitbucket/gitbucket/wiki) 
+- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
+- [ ] searched for similar already existing issue
+- [ ] read the documentation and [wiki](https://github.com/gitbucket/gitbucket/wiki)
 
 *(if you have performed all the above, remove the paragraph and continue describing the issue with template below)*
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 ### Before submitting a pull-request to GitBucket I have first:
 
-- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
-- [] rebased my branch over master
-- [] verified that project is compiling
-- [] verified that tests are passing
-- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
-- [] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
+- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
+- [ ] rebased my branch over master
+- [ ] verified that project is compiling
+- [ ] verified that tests are passing
+- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
+- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

### Motivation
---

Current ISSUE_TEMPLATE & PULL_REQUEST_TEMPLATE is not following [GitHub task list](https://help.github.com/en/articles/about-task-lists#creating-task-lists) and it's not displayed checkbox correctly.

* https://help.github.com/en/articles/about-task-lists#creating-task-lists

### Before
---

![issue-check-list-befor](https://user-images.githubusercontent.com/11273093/59701182-f8650900-922f-11e9-991b-b5a8c124d04c.png)

### After
---

![issue-check-list-after](https://user-images.githubusercontent.com/11273093/59701192-fef38080-922f-11e9-9f41-642cb85ce94a.png)
