### PR TITLE
Implement Draft Pull Request Feature #2319

### DIFF
--- a/src/main/resources/update/gitbucket-core_4.32.xml
+++ b/src/main/resources/update/gitbucket-core_4.32.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeSet>
+  <addColumn tableName="PULL_REQUEST">
+    <column name="IS_DRAFT" type="boolean" nullable="false" defaultValueBoolean="false" />
+  </addColumn>
+</changeSet>

--- a/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
+++ b/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
@@ -63,5 +63,6 @@ object GitBucketCoreModule
       new Version("4.30.1"),
       new Version("4.31.0", new LiquibaseMigration("update/gitbucket-core_4.31.xml")),
       new Version("4.31.1"),
-      new Version("4.31.2")
+      new Version("4.31.2"),
+      new Version("4.32.0", new LiquibaseMigration("update/gitbucket-core_4.32.xml"))
     )

--- a/src/main/scala/gitbucket/core/controller/api/ApiPullRequestControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiPullRequestControllerBase.scala
@@ -114,6 +114,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
                       requestBranch = reqBranch,
                       commitIdFrom = commitIdFrom.getName,
                       commitIdTo = commitIdTo.getName,
+                      isDraft = false,
                       loginAccount = context.loginAccount.get
                     )
                     getApiPullRequest(repository, issueId).map(JsonFormat(_))
@@ -141,6 +142,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
                       requestBranch = reqBranch,
                       commitIdFrom = commitIdFrom.getName,
                       commitIdTo = commitIdTo.getName,
+                      isDraft = false,
                       loginAccount = context.loginAccount.get
                     )
                     getApiPullRequest(repository, createPullReqAlt.issue).map(JsonFormat(_))

--- a/src/main/scala/gitbucket/core/model/PullRequest.scala
+++ b/src/main/scala/gitbucket/core/model/PullRequest.scala
@@ -12,6 +12,7 @@ trait PullRequestComponent extends TemplateComponent { self: Profile =>
     val requestBranch = column[String]("REQUEST_BRANCH")
     val commitIdFrom = column[String]("COMMIT_ID_FROM")
     val commitIdTo = column[String]("COMMIT_ID_TO")
+    val isDraft = column[Boolean]("IS_DRAFT")
     def * =
       (
         userName,
@@ -22,7 +23,8 @@ trait PullRequestComponent extends TemplateComponent { self: Profile =>
         requestRepositoryName,
         requestBranch,
         commitIdFrom,
-        commitIdTo
+        commitIdTo,
+        isDraft
       ) <> (PullRequest.tupled, PullRequest.unapply)
 
     def byPrimaryKey(userName: String, repositoryName: String, issueId: Int) =
@@ -41,5 +43,6 @@ case class PullRequest(
   requestRepositoryName: String,
   requestBranch: String,
   commitIdFrom: String,
-  commitIdTo: String
+  commitIdTo: String,
+  isDraft: Boolean
 )

--- a/src/main/twirl/gitbucket/core/pulls/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/compare.scala.html
@@ -79,6 +79,7 @@
                 completionContext  = "issues",
                 style              = "height: 200px;"
               )
+              <div class="text-right">
               <input type="hidden" name="targetUserName" value="@originRepository.owner"/>
               <input type="hidden" name="targetBranch" value="@originId"/>
               <input type="hidden" name="requestUserName" value="@forkedRepository.owner"/>
@@ -86,8 +87,20 @@
               <input type="hidden" name="requestBranch" value="@forkedId"/>
               <input type="hidden" name="commitIdFrom" value="@sourceId"/>
               <input type="hidden" name="commitIdTo" value="@commitId"/>
-              <div class="align-right">
-                <input type="submit" class="btn btn-success" value="Create pull request"/>
+               <input type="hidden" id="is-draft" name="isDraft" value=false />
+
+<!--                <input type="submit" class="btn btn-success" value="Create pull request"/>-->
+<!--                formaction="@context.path/@originRepository.owner/@originRepository.name/pulls/new"-->
+                <div class="btn-group dropup">
+                <input type="submit" class="btn btn-success" tabindex="2" value="Create pull request" id="submit-button" validate="true" formaction="@context.path/@originRepository.owner/@originRepository.name/pulls/new"/>
+                <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                  <li><a id="pull-request">Create pull request</a></li>
+                  <li><a id="draft-request">Create draft request</a></li>
+                </ul>
+                </div>
               </div>
             </div>
             <div class="col-md-3">
@@ -159,6 +172,21 @@
   }
 }
 <script>
+
+$(function(){
+  $('#draft-request').click(function(){
+    $("#is-draft").val(true);
+    $('#submit-button').attr('value', 'Create draft request')
+    $('#action').val('create draft request');
+  });
+  $('#pull-request').click(function(){
+  $("#is-draft").val(false);
+    $('#submit-button').attr('value', 'Create pull request')
+    $('#action').val('create pull request');
+  });
+});
+
+
 $(function(){
   function updateSelector(e){
     e.parents('ul').find('i').attr('class', 'octicon');

--- a/src/main/twirl/gitbucket/core/pulls/compare.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/compare.scala.html
@@ -177,12 +177,10 @@ $(function(){
   $('#draft-request').click(function(){
     $("#is-draft").val(true);
     $('#submit-button').attr('value', 'Create draft request')
-    $('#action').val('create draft request');
   });
   $('#pull-request').click(function(){
   $("#is-draft").val(false);
     $('#submit-button').attr('value', 'Create pull request')
-    $('#action').val('create pull request');
   });
 });
 

--- a/src/main/twirl/gitbucket/core/pulls/conversation.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/conversation.scala.html
@@ -1,4 +1,4 @@
-@(issue: gitbucket.core.model.Issue,
+ @(issue: gitbucket.core.model.Issue,
   pullreq: gitbucket.core.model.PullRequest,
   commits: Seq[gitbucket.core.util.JGitUtil.CommitInfo],
   comments: Seq[gitbucket.core.model.Comment],

--- a/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
@@ -77,15 +77,37 @@
           } else {
             <div class="merge-indicator merge-indicator-success"><span class="octicon octicon-check"></span></div>
             @if(status.hasMergePermission){
-              <span class="strong">Merging can be performed automatically.</span>
-              <div class="small">
-                Merging can be performed automatically.
-              </div>
+              @if(!pullreq.isDraft){
+                  <span class="strong">Merging can be performed automatically.</span>
+                  <div class="small">
+                  Merging can be performed automatically.
+                 </div>
+               } else {
+                   <form method="POST" action="@context.path/@originRepository.owner/@originRepository.name/pull/@issue.issueId/update_draft" validate="true">
+                   <span class="strong">This pull request is still a work in progress.</span>
+                   <div class="small">
+                   Draft pull requests cannot be merged.
+                   </div>
+                   <div class="pull-right">
+                     <input type="button" class="btn btn-default" value="Ready for review" id="ready-for-review" validate="true" formaction="@context.path/@originRepository.owner/@originRepository.name/pull/@issue.issueId/update_draft"/>
+                   </div>`
+                   </form>
+                  }
             } else {
-              <span class="strong">This branch has no conflicts with the base branch.</span>
-              <div class="small">
-                Only those with write access to this repository can merge pull requests.
-              </div>
+                 @if(pullreq.isDraft){
+                   <span class="strong">This pull request is still a work in progress.</span>
+                   <div class="small">
+                    Draft pull requests cannot be merged.
+                   </div>
+                 <div class="pull-right">
+                 <input type="button" class="btn btn-default" value="Ready for review" id="ready-for-review" validate="true" formaction="@context.path/@originRepository.owner/@originRepository.name/pull/@issue.issueId/update_draft"/>
+                 </div>`
+              } else {
+                    <span class="strong">This branch has no conflicts with the base branch.</span>
+                    <div class="small">
+                      Only those with write access to this repository can merge pull requests.
+                    </div>
+              }
             }
           }
         }
@@ -93,7 +115,7 @@
       </div>
       @if(status.hasMergePermission){
         <div style="padding:15px; border-top:solid 1px #e5e5e5; background:#fafafa">
-          <input type="button" class="btn @if(!status.hasProblem){btn-success} else {btn-default}" id="merge-pull-request-button" value="Merge pull request"@if(!status.canMerge){ disabled="true"}/>
+          <input type="button" class="btn @if(!status.hasProblem){btn-success} else {btn-default}" id="merge-pull-request-button" value="Merge pull request"@if(!status.canMerge || pullreq.isDraft){ disabled="true"}/>
           &nbsp;&nbsp;You can also merge branches on the <a href="#" class="show-command-line">command line</a>.
           <div id="command-line" style="display: none;margin-top: 15px;">
             <hr />
@@ -191,6 +213,7 @@
             <input type="button" class="btn btn-default" value="Cancel" id="cancel-merge-pull-request"/>
             <input type="submit" class="btn btn-success" value="Confirm merge"/>
             <input type="hidden" name="strategy" value="@originRepository.repository.options.defaultMergeOption"/>
+            <input type="hidden" name="isDraft" value="@pullreq.isDraft" />
           </div>
         </div>
       </form>
@@ -199,6 +222,15 @@
 </div>
 
 <script>
+
+$(function(){
+  $('#ready-for-review').click(function(){
+    $.post('@helpers.url(originRepository)/pull/@issue.issueId/update_draft', function(data, status){
+      location.reload();
+    })
+  });
+});
+
 $(function(){
   $('.show-command-line').click(function(){
     $('#command-line').toggle();

--- a/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
@@ -76,39 +76,28 @@
             </div>
           } else {
             <div class="merge-indicator merge-indicator-success"><span class="octicon octicon-check"></span></div>
+
+        @if(pullreq.isDraft){
+          <span class="strong">This pull request is still a work in progress.</span>
+        <div class="pull-right">
+          <input type="button" class="btn btn-default" value="Ready for review" id="ready-for-review" />
+        </div>
+          <div class="small">
+            Draft pull requests cannot be merged.
+          </div>
+        } else {
             @if(status.hasMergePermission){
-              @if(!pullreq.isDraft){
                   <span class="strong">Merging can be performed automatically.</span>
                   <div class="small">
                   Merging can be performed automatically.
                  </div>
-               } else {
-                   <form method="POST" action="@context.path/@originRepository.owner/@originRepository.name/pull/@issue.issueId/update_draft" validate="true">
-                   <span class="strong">This pull request is still a work in progress.</span>
-                   <div class="small">
-                   Draft pull requests cannot be merged.
-                   </div>
-                   <div class="pull-right">
-                     <input type="button" class="btn btn-default" value="Ready for review" id="ready-for-review" validate="true" formaction="@context.path/@originRepository.owner/@originRepository.name/pull/@issue.issueId/update_draft"/>
-                   </div>`
-                   </form>
-                  }
             } else {
-                 @if(pullreq.isDraft){
-                   <span class="strong">This pull request is still a work in progress.</span>
-                   <div class="small">
-                    Draft pull requests cannot be merged.
-                   </div>
-                 <div class="pull-right">
-                 <input type="button" class="btn btn-default" value="Ready for review" id="ready-for-review" validate="true" formaction="@context.path/@originRepository.owner/@originRepository.name/pull/@issue.issueId/update_draft"/>
-                 </div>`
-              } else {
                     <span class="strong">This branch has no conflicts with the base branch.</span>
                     <div class="small">
                       Only those with write access to this repository can merge pull requests.
                     </div>
-              }
             }
+           }
           }
         }
       }

--- a/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
+++ b/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
@@ -139,7 +139,8 @@ object ApiSpecModels {
     requestRepositoryName = repo1Name.name,
     requestBranch = "new-topic",
     commitIdFrom = sha1,
-    commitIdTo = sha1
+    commitIdTo = sha1,
+    isDraft = true
   )
 
   val commitComment = CommitComment(

--- a/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
+++ b/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
@@ -138,6 +138,7 @@ trait ServiceSpecBase extends MockitoSugar {
       requestBranch = requestBranch,
       commitIdFrom = baesBranch,
       commitIdTo = requestBranch,
+      isDraft = false,
       loginAccount = loginAccount.get
     )
     dummyService.getPullRequest(baseUserName, baseRepositoryName, issueId).get


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

This PR is related to issue #2319 

This PR enables users to either create a Pull request or a Draft Request. If a draft request is being created, it cannot be merged until it as marked as ```Ready for Review```. So a WIP code can be raised as a PR, so that early review is possible for peer developers.

![image](https://user-images.githubusercontent.com/13068144/60335881-840f3000-99bc-11e9-981f-97aad325fae1.png)


![image](https://user-images.githubusercontent.com/13068144/60335914-97ba9680-99bc-11e9-8dfe-ff472955bd0a.png)


![image](https://user-images.githubusercontent.com/13068144/60335948-ad2fc080-99bc-11e9-86b7-e1d27c620853.png)