### PR TITLE
Download bundled plugins from GitHub to obsolete Plugin Farm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,8 +165,8 @@ executableKey := {
   plugins.foreach { plugin =>
     plugin.trim.split(":") match {
       case Array(pluginId, pluginVersion) =>
-        val url = "https://plugins.gitbucket-community.org/releases/" +
-          s"gitbucket-${pluginId}-plugin/gitbucket-${pluginId}-plugin-gitbucket_${version.value}-${pluginVersion}.jar"
+        val url = "https://github.com/" +
+          s"gitbucket/gitbucket-${pluginId}-plugin/releases/download/${pluginVersion}/gitbucket-${pluginId}-plugin-${pluginVersion}.jar"
         log info s"Download: ${url}"
         IO transfer (new java.net.URL(url).openStream, pluginsDir / url.substring(url.lastIndexOf("/") + 1))
       case _ => ()

--- a/src/main/resources/bundle-plugins.txt
+++ b/src/main/resources/bundle-plugins.txt
@@ -1,1 +1,4 @@
-notifications:1.7.1
+notifications:1.8.0
+gist:4.18.0
+emoji:4.6.0
+pages:1.8.0

--- a/src/main/scala/gitbucket/core/servlet/InitializeListener.scala
+++ b/src/main/scala/gitbucket/core/servlet/InitializeListener.scala
@@ -88,7 +88,7 @@ class InitializeListener extends ServletContextListener with SystemSettingsServi
       }
 
       // Install bundled plugins
-      extractBundledPlugins(gitbucketVersion)
+      extractBundledPlugins()
 
       // Load plugins
       logger.info("Initialize plugins")
@@ -138,7 +138,7 @@ class InitializeListener extends ServletContextListener with SystemSettingsServi
     }
   }
 
-  private def extractBundledPlugins(gitbucketVersion: String): Unit = {
+  private def extractBundledPlugins(): Unit = {
     logger.info("Extract bundled plugins...")
     val cl = Thread.currentThread.getContextClassLoader
     try {
@@ -150,7 +150,7 @@ class InitializeListener extends ServletContextListener with SystemSettingsServi
           plugins.asScala.foreach { plugin =>
             plugin.trim.split(":") match {
               case Array(pluginId, pluginVersion) =>
-                val fileName = s"gitbucket-${pluginId}-plugin-gitbucket_${gitbucketVersion}-${pluginVersion}.jar"
+                val fileName = s"gitbucket-${pluginId}-plugin-${pluginVersion}.jar"
                 val in = cl.getResourceAsStream("plugins/" + fileName)
                 if (in != null) {
                   val file = new File(PluginHome, fileName)


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
