### PR TITLE
Add --upload_timeout bootstrap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You can specify following options:
 - `--gitbucket.home=[DATA_DIR]`
 - `--temp_dir=[TEMP_DIR]`
 - `--max_file_size=[MAX_FILE_SIZE]`
+- `--upload_timeout=[MAX_UPLOAD_TIMEOUT]`
 
 `TEMP_DIR` is used as the [temporary directory for the jetty application context](https://www.eclipse.org/jetty/documentation/9.3.x/ref-temporary-directories.html). This is the directory into which the `gitbucket.war` file is unpacked, the source files are compiled, etc. If given this parameter **must** match the path of an existing directory or the application will quit reporting an error; if not given the path used will be a `tmp` directory inside the gitbucket home.
 

--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -42,6 +42,9 @@ public class JettyLauncher {
                         case "--max_file_size":
                             System.setProperty("gitbucket.maxFileSize", dim[1]);
                             break;
+                        case "--upload_timeout":
+                            System.setProperty("gitbucket.UploadTimeout", dim[1]);
+                            break;
                         case "--gitbucket.home":
                             System.setProperty("gitbucket.home", dim[1]);
                             break;

--- a/src/main/scala/gitbucket/core/controller/FileUploadController.scala
+++ b/src/main/scala/gitbucket/core/controller/FileUploadController.scala
@@ -31,7 +31,6 @@ class FileUploadController
     with ReleaseService {
 
   configureMultipartHandling(MultipartConfig(maxFileSize = Some(FileUtil.MaxFileSize)))
-  configureMultipartHandling(MultipartConfig(uploadTimeout = Some(FileUtil.UploadTimeout)))
 
   post("/image") {
     execute(

--- a/src/main/scala/gitbucket/core/controller/FileUploadController.scala
+++ b/src/main/scala/gitbucket/core/controller/FileUploadController.scala
@@ -31,6 +31,7 @@ class FileUploadController
     with ReleaseService {
 
   configureMultipartHandling(MultipartConfig(maxFileSize = Some(FileUtil.MaxFileSize)))
+  configureMultipartHandling(MultipartConfig(UploadTimeout = Some(FileUtil.UploadTimeout)))
 
   post("/image") {
     execute(

--- a/src/main/scala/gitbucket/core/controller/FileUploadController.scala
+++ b/src/main/scala/gitbucket/core/controller/FileUploadController.scala
@@ -31,7 +31,7 @@ class FileUploadController
     with ReleaseService {
 
   configureMultipartHandling(MultipartConfig(maxFileSize = Some(FileUtil.MaxFileSize)))
-  configureMultipartHandling(MultipartConfig(UploadTimeout = Some(FileUtil.UploadTimeout)))
+  configureMultipartHandling(MultipartConfig(uploadTimeout = Some(FileUtil.UploadTimeout)))
 
   post("/image") {
     execute(

--- a/src/main/scala/gitbucket/core/util/FileUtil.scala
+++ b/src/main/scala/gitbucket/core/util/FileUtil.scala
@@ -96,10 +96,13 @@ object FileUtil {
     else
       3 * 1024 * 1024
   
+  /**
+   * Add Upload Timeout Var.
+   */
   lazy val UploadTimeout =
     if (System.getProperty("gitbucket.UploadTimeout") != null)
       System.getProperty("gitbucket.UploadTimeout").toLong
     else
-      3e4
+      3 * 10000
 
 }

--- a/src/main/scala/gitbucket/core/util/FileUtil.scala
+++ b/src/main/scala/gitbucket/core/util/FileUtil.scala
@@ -96,11 +96,6 @@ object FileUtil {
     else
       3 * 1024 * 1024
 
-  /**
-   * Add Upload Timeout Var.
-   * travisCI does not like me.... 
-   */
-
   lazy val UploadTimeout =
     if (System.getProperty("gitbucket.UploadTimeout") != null)
       System.getProperty("gitbucket.UploadTimeout").toLong

--- a/src/main/scala/gitbucket/core/util/FileUtil.scala
+++ b/src/main/scala/gitbucket/core/util/FileUtil.scala
@@ -95,5 +95,11 @@ object FileUtil {
       System.getProperty("gitbucket.maxFileSize").toLong
     else
       3 * 1024 * 1024
+  
+  lazy val UploadTimeout =
+    if (System.getProperty("gitbucket.UploadTimeout") != null)
+      System.getProperty("gitbucket.UploadTimeout").toLong
+    else
+      3e4
 
 }

--- a/src/main/scala/gitbucket/core/util/FileUtil.scala
+++ b/src/main/scala/gitbucket/core/util/FileUtil.scala
@@ -98,7 +98,9 @@ object FileUtil {
   
   /**
    * Add Upload Timeout Var.
+   * travisCI does not like me.... 
    */
+
   lazy val UploadTimeout =
     if (System.getProperty("gitbucket.UploadTimeout") != null)
       System.getProperty("gitbucket.UploadTimeout").toLong

--- a/src/main/scala/gitbucket/core/util/FileUtil.scala
+++ b/src/main/scala/gitbucket/core/util/FileUtil.scala
@@ -95,7 +95,7 @@ object FileUtil {
       System.getProperty("gitbucket.maxFileSize").toLong
     else
       3 * 1024 * 1024
-  
+
   /**
    * Add Upload Timeout Var.
    * travisCI does not like me.... 

--- a/src/main/twirl/gitbucket/core/helper/attached.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/attached.scala.html
@@ -66,6 +66,8 @@ $(function(){
 @dropzone(clickable: Boolean, textareaId: Option[String]) = {
   url: '@context.path/upload/file/@repository.owner/@repository.name',
   maxFilesize: @{FileUtil.MaxFileSize / 1024 / 1024},
+  //timeout defaults to 30 secs
+  timeout: @{FileUtil.UploadTimeout},
   clickable: @clickable,
   previewTemplate: "<div class=\"dz-preview\">\n  <div class=\"dz-progress\"><span class=\"dz-upload\" data-dz-uploadprogress>Uploading your files...</span></div>\n  <div class=\"dz-error-message\"><span data-dz-errormessage></span></div>\n</div>",
   success: function(file, id) {

--- a/src/main/twirl/gitbucket/core/releases/form.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/form.scala.html
@@ -73,6 +73,7 @@ $(function(){
   $("#drop").dropzone({
     maxFilesize: @{gitbucket.core.util.FileUtil.MaxFileSize / 1024 / 1024},
     url: '@context.path/upload/release/@repository.owner/@repository.name/@helpers.encodeRefName(tag.name)',
+    timeout:0,
     previewTemplate: "<div class=\"dz-preview\">\n  <div class=\"dz-progress\"><span class=\"dz-upload\" data-dz-uploadprogress>Uploading your files...</span></div>\n  <div class=\"dz-error-message\"><span data-dz-errormessage></span></div>\n</div>",
     success: function(file, id) {
       var attach =

--- a/src/main/twirl/gitbucket/core/releases/form.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/form.scala.html
@@ -73,7 +73,8 @@ $(function(){
   $("#drop").dropzone({
     maxFilesize: @{gitbucket.core.util.FileUtil.MaxFileSize / 1024 / 1024},
     url: '@context.path/upload/release/@repository.owner/@repository.name/@helpers.encodeRefName(tag.name)',
-    timeout:0,
+    //timeout defaults to 30 secs
+    timeout: @{gitbucket.core.util.FileUtil.UploadTimeout},
     previewTemplate: "<div class=\"dz-preview\">\n  <div class=\"dz-progress\"><span class=\"dz-upload\" data-dz-uploadprogress>Uploading your files...</span></div>\n  <div class=\"dz-error-message\"><span data-dz-errormessage></span></div>\n</div>",
     success: function(file, id) {
       var attach =


### PR DESCRIPTION
This is because of large files, i was trying to upload a large file and it stalled in 30s, since we don't have a option yet for this, like gitbucket.UploadTimeout this has to do. please fix

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
