### PR TITLE
Fix account table dead lock caused by ApiAuthenticationFilter

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiUserControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiUserControllerBase.scala
@@ -4,7 +4,6 @@ import gitbucket.core.controller.ControllerBase
 import gitbucket.core.service.{AccountService, RepositoryService}
 import gitbucket.core.util.{AdminAuthenticator, UsersAuthenticator}
 import gitbucket.core.util.Implicits._
-import gitbucket.core.util.StringUtil._
 import org.scalatra.NoContent
 
 trait ApiUserControllerBase extends ControllerBase {
@@ -71,7 +70,7 @@ trait ApiUserControllerBase extends ControllerBase {
     } yield {
       val user = createAccount(
         data.login,
-        pbkdf2_sha256(data.password),
+        data.password,
         data.fullName.getOrElse(data.login),
         data.email,
         data.isAdmin.getOrElse(false),

--- a/src/main/scala/gitbucket/core/controller/api/ApiUserControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiUserControllerBase.scala
@@ -4,6 +4,7 @@ import gitbucket.core.controller.ControllerBase
 import gitbucket.core.service.{AccountService, RepositoryService}
 import gitbucket.core.util.{AdminAuthenticator, UsersAuthenticator}
 import gitbucket.core.util.Implicits._
+import gitbucket.core.util.StringUtil._
 import org.scalatra.NoContent
 
 trait ApiUserControllerBase extends ControllerBase {
@@ -70,7 +71,7 @@ trait ApiUserControllerBase extends ControllerBase {
     } yield {
       val user = createAccount(
         data.login,
-        data.password,
+        pbkdf2_sha256(data.password),
         data.fullName.getOrElse(data.login),
         data.email,
         data.isAdmin.getOrElse(false),

--- a/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
@@ -37,9 +37,7 @@ class ApiAuthenticationFilter extends Filter with AccessTokenService with Accoun
       } match {
       case Some(Right(account)) =>
         request.setAttribute(Keys.Session.LoginAccount, account)
-        Database() withTransaction { implicit session =>
-          updateLastLoginDate(account.userName)
-        }
+        updateLastLoginDate(account.userName)
         chain.doFilter(req, res)
       case None => chain.doFilter(req, res)
       case Some(Left(_)) => {

--- a/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
@@ -37,7 +37,9 @@ class ApiAuthenticationFilter extends Filter with AccessTokenService with Accoun
       } match {
       case Some(Right(account)) =>
         request.setAttribute(Keys.Session.LoginAccount, account)
-        updateLastLoginDate(account.userName)
+        Database() withTransaction { implicit session =>
+          updateLastLoginDate(account.userName)
+        }
         chain.doFilter(req, res)
       case None => chain.doFilter(req, res)
       case Some(Left(_)) => {


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
-----
Closes #2392 

1. Setup empty DB.
1. Run `java -jar gitbucket.war` for the first time.
1. `ScalatraBootstrap` registers `TransactionFilter` and then `ApiAuthenticationFilter`.
1. Run `curl http://localhost:8080/api/v3/user -u root:root`.
1. `TransactionFilter` begins transaction.
1. The default *root* user's password is SHA1 hash, so GitBucket tries to update the password by PBKDF2.
https://github.com/gitbucket/gitbucket/blob/f35ecce3c7b08e9579408252f80674b5b4ae7c43/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala#L29
https://github.com/gitbucket/gitbucket/blob/f35ecce3c7b08e9579408252f80674b5b4ae7c43/src/main/scala/gitbucket/core/service/AccountService.scala#L36-L43
1. `ApiAuthenticationFilter` begins another transaction to update `lastLoginDate` and causes dead lock.
https://github.com/gitbucket/gitbucket/blob/f35ecce3c7b08e9579408252f80674b5b4ae7c43/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala#L40-L42

@kounoike @takezoe  I'm not familiar with scalatra and slick yet, is my guess correct?