### PR TITLE
Add assignee and assignees properties to some issues api payload

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiIssue.scala
+++ b/src/main/scala/gitbucket/core/api/ApiIssue.scala
@@ -12,6 +12,7 @@ case class ApiIssue(
   number: Int,
   title: String,
   user: ApiUser,
+  assignee: Option[ApiUser],
   labels: List[ApiLabel],
   state: String,
   created_at: Date,
@@ -36,11 +37,18 @@ case class ApiIssue(
 }
 
 object ApiIssue {
-  def apply(issue: Issue, repositoryName: RepositoryName, user: ApiUser, labels: List[ApiLabel]): ApiIssue =
+  def apply(
+    issue: Issue,
+    repositoryName: RepositoryName,
+    user: ApiUser,
+    assignee: Option[ApiUser],
+    labels: List[ApiLabel]
+  ): ApiIssue =
     ApiIssue(
       number = issue.issueId,
       title = issue.title,
       user = user,
+      assignee = assignee,
       labels = labels,
       state = if (issue.closed) { "closed" } else { "open" },
       body = issue.content.getOrElse(""),

--- a/src/main/scala/gitbucket/core/api/ApiIssue.scala
+++ b/src/main/scala/gitbucket/core/api/ApiIssue.scala
@@ -20,7 +20,7 @@ case class ApiIssue(
   body: String
 )(repositoryName: RepositoryName, isPullRequest: Boolean) {
   val id = 0 // dummy id
-  val assignees = List(assignee).filter(user => user.nonEmpty)
+  val assignees = List(assignee).flatten
   val comments_url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/issues/${number}/comments")
   val html_url = ApiPath(s"/${repositoryName.fullName}/${if (isPullRequest) { "pull" } else { "issues" }}/${number}")
   val pull_request = if (isPullRequest) {

--- a/src/main/scala/gitbucket/core/api/ApiIssue.scala
+++ b/src/main/scala/gitbucket/core/api/ApiIssue.scala
@@ -20,6 +20,7 @@ case class ApiIssue(
   body: String
 )(repositoryName: RepositoryName, isPullRequest: Boolean) {
   val id = 0 // dummy id
+  val assignees = List(assignee).filter(user => user.nonEmpty)
   val comments_url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/issues/${number}/comments")
   val html_url = ApiPath(s"/${repositoryName.fullName}/${if (isPullRequest) { "pull" } else { "issues" }}/${number}")
   val pull_request = if (isPullRequest) {

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
@@ -45,6 +45,7 @@ trait ApiIssueControllerBase extends ControllerBase {
           issue = issue,
           repositoryName = RepositoryName(repository),
           user = ApiUser(issueUser),
+          assignee = None, // TODO Get assigned user
           labels = getIssueLabels(repository.owner, repository.name, issue.issueId)
             .map(ApiLabel(_, RepositoryName(repository)))
         )
@@ -66,6 +67,7 @@ trait ApiIssueControllerBase extends ControllerBase {
           issue,
           RepositoryName(repository),
           ApiUser(openedUser),
+          None, // TODO Get assigned user
           getIssueLabels(repository.owner, repository.name, issue.issueId).map(ApiLabel(_, RepositoryName(repository)))
         )
       )
@@ -98,6 +100,7 @@ trait ApiIssueControllerBase extends ControllerBase {
             issue,
             RepositoryName(repository),
             ApiUser(loginAccount),
+            None, // TODO Get assigned user
             getIssueLabels(repository.owner, repository.name, issue.issueId)
               .map(ApiLabel(_, RepositoryName(repository)))
           )

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
@@ -31,7 +31,7 @@ trait ApiIssueControllerBase extends ControllerBase {
     val condition = IssueSearchCondition(request)
     val baseOwner = getAccountByUserName(repository.owner).get
 
-    val issues: List[(Issue, Account)] =
+    val issues: List[(Issue, Account, Option[Account])] =
       searchIssueByApi(
         condition = condition,
         offset = (page - 1) * PullRequestLimit,
@@ -40,12 +40,12 @@ trait ApiIssueControllerBase extends ControllerBase {
       )
 
     JsonFormat(issues.map {
-      case (issue, issueUser) =>
+      case (issue, issueUser, assignedUser) =>
         ApiIssue(
           issue = issue,
           repositoryName = RepositoryName(repository),
           user = ApiUser(issueUser),
-          assignee = None, // TODO Get assigned user
+          assignee = assignedUser.map(ApiUser(_)),
           labels = getIssueLabels(repository.owner, repository.name, issue.issueId)
             .map(ApiLabel(_, RepositoryName(repository)))
         )

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -265,7 +265,7 @@ trait IssuesService {
   }
 
   /** for api
-   * @return (issue, issueUser, commentCount)
+   * @return (issue, issueUser, assignedUser)
    */
   def searchIssueByApi(condition: IssueSearchCondition, offset: Int, limit: Int, repos: (String, String)*)(
     implicit s: Session

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -269,13 +269,15 @@ trait IssuesService {
    */
   def searchIssueByApi(condition: IssueSearchCondition, offset: Int, limit: Int, repos: (String, String)*)(
     implicit s: Session
-  ): List[(Issue, Account)] = {
+  ): List[(Issue, Account, Option[Account])] = {
     // get issues and comment count and labels
     searchIssueQueryBase(condition, false, offset, limit, repos)
       .join(Accounts)
       .on { case t1 ~ t2 ~ i ~ t3 => t3.userName === t1.openedUserName }
-      .sortBy { case t1 ~ t2 ~ i ~ t3 => i asc }
-      .map { case t1 ~ t2 ~ i ~ t3 => (t1, t3) }
+      .joinLeft(Accounts)
+      .on { case t1 ~ t2 ~ i ~ t3 ~ t4 => t4.userName === t1.assignedUserName }
+      .sortBy { case t1 ~ t2 ~ i ~ t3 ~ t4 => i asc }
+      .map { case t1 ~ t2 ~ i ~ t3 ~ t4 => (t1, t3, t4) }
       .list
   }
 

--- a/src/main/scala/gitbucket/core/service/WebHookService.scala
+++ b/src/main/scala/gitbucket/core/service/WebHookService.scala
@@ -331,6 +331,7 @@ trait WebHookPullRequestService extends WebHookService {
             issue,
             RepositoryName(repository),
             ApiUser(issueUser),
+            None, // TODO Get assigned user
             getIssueLabels(repository.owner, repository.name, issue.issueId)
               .map(ApiLabel(_, RepositoryName(repository)))
           ),
@@ -700,6 +701,7 @@ object WebHookService {
           issue,
           RepositoryName(repository),
           ApiUser(issueUser),
+          None, // TODO Get assigned user
           labels.map(ApiLabel(_, RepositoryName(repository)))
         ),
         comment =

--- a/src/main/scala/gitbucket/core/service/WebHookService.scala
+++ b/src/main/scala/gitbucket/core/service/WebHookService.scala
@@ -318,7 +318,8 @@ trait WebHookPullRequestService extends WebHookService {
     sender: Account
   )(implicit s: Session, context: JsonFormat.Context): Unit = {
     callWebHookOf(repository.owner, repository.name, WebHook.Issues) {
-      val users = getAccountsByUserNames(Set(repository.owner, issue.openedUserName), Set(sender))
+      val users =
+        getAccountsByUserNames(Set(repository.owner, issue.openedUserName) ++ issue.assignedUserName, Set(sender))
       for {
         repoOwner <- users.get(repository.owner)
         issueUser <- users.get(issue.openedUserName)
@@ -331,7 +332,7 @@ trait WebHookPullRequestService extends WebHookService {
             issue,
             RepositoryName(repository),
             ApiUser(issueUser),
-            None, // TODO Get assigned user
+            issue.assignedUserName.flatMap(users.get(_)).map(ApiUser(_)),
             getIssueLabels(repository.owner, repository.name, issue.issueId)
               .map(ApiLabel(_, RepositoryName(repository)))
           ),

--- a/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
+++ b/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
@@ -199,6 +199,14 @@ object ApiSpecModels {
     labels = List(apiLabel)
   )
 
+  val apiNotAssignedIssue = ApiIssue(
+    issue = issue,
+    repositoryName = repo1Name,
+    user = apiUser,
+    assignee = None,
+    labels = List(apiLabel)
+  )
+
   val apiIssuePR = ApiIssue(
     issue = issuePR,
     repositoryName = repo1Name,
@@ -459,6 +467,21 @@ object ApiSpecModels {
        |"body":"I'm having a problem with this.",
        |"id":0,
        |"assignees":[$jsonUser],
+       |"comments_url":"http://gitbucket.exmple.com/api/v3/repos/octocat/Hello-World/issues/1347/comments",
+       |"html_url":"http://gitbucket.exmple.com/octocat/Hello-World/issues/1347"
+       |}""".stripMargin
+
+  val jsonNotAssignedIssue = s"""{
+       |"number":1347,
+       |"title":"Found a bug",
+       |"user":$jsonUser,
+       |"labels":[$jsonLabel],
+       |"state":"open",
+       |"created_at":"2011-04-14T16:00:49Z",
+       |"updated_at":"2011-04-14T16:00:49Z",
+       |"body":"I'm having a problem with this.",
+       |"id":0,
+       |"assignees":[],
        |"comments_url":"http://gitbucket.exmple.com/api/v3/repos/octocat/Hello-World/issues/1347/comments",
        |"html_url":"http://gitbucket.exmple.com/octocat/Hello-World/issues/1347"
        |}""".stripMargin

--- a/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
+++ b/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
@@ -195,6 +195,7 @@ object ApiSpecModels {
     issue = issue,
     repositoryName = repo1Name,
     user = apiUser,
+    assignee = Some(apiUser),
     labels = List(apiLabel)
   )
 
@@ -202,6 +203,7 @@ object ApiSpecModels {
     issue = issuePR,
     repositoryName = repo1Name,
     user = apiUser,
+    assignee = Some(apiUser),
     labels = List(apiLabel)
   )
 
@@ -449,12 +451,14 @@ object ApiSpecModels {
        |"number":1347,
        |"title":"Found a bug",
        |"user":$jsonUser,
+       |"assignee":$jsonUser,
        |"labels":[$jsonLabel],
        |"state":"open",
        |"created_at":"2011-04-14T16:00:49Z",
        |"updated_at":"2011-04-14T16:00:49Z",
        |"body":"I'm having a problem with this.",
        |"id":0,
+       |"assignees":[$jsonUser],
        |"comments_url":"http://gitbucket.exmple.com/api/v3/repos/octocat/Hello-World/issues/1347/comments",
        |"html_url":"http://gitbucket.exmple.com/octocat/Hello-World/issues/1347"
        |}""".stripMargin
@@ -463,12 +467,14 @@ object ApiSpecModels {
        |"number":1347,
        |"title":"new-feature",
        |"user":$jsonUser,
+       |"assignee":$jsonUser,
        |"labels":[$jsonLabel],
        |"state":"closed",
        |"created_at":"2011-04-14T16:00:49Z",
        |"updated_at":"2011-04-14T16:00:49Z",
        |"body":"Please pull these awesome changes",
        |"id":0,
+       |"assignees":[$jsonUser],
        |"comments_url":"http://gitbucket.exmple.com/api/v3/repos/octocat/Hello-World/issues/1347/comments",
        |"html_url":"http://gitbucket.exmple.com/octocat/Hello-World/pull/1347",
        |"pull_request":{

--- a/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
+++ b/src/test/scala/gitbucket/core/api/JsonFormatSpec.scala
@@ -34,6 +34,7 @@ class JsonFormatSpec extends FunSuite {
   }
   test("apiIssue") {
     assert(JsonFormat(apiIssue) == expected(jsonIssue))
+    assert(JsonFormat(apiNotAssignedIssue) == expected(jsonNotAssignedIssue))
     assert(JsonFormat(apiIssuePR) == expected(jsonIssuePR))
   }
   test("apiPullRequest") {

--- a/src/test/scala/gitbucket/core/service/WebHookJsonFormatSpec.scala
+++ b/src/test/scala/gitbucket/core/service/WebHookJsonFormatSpec.scala
@@ -118,6 +118,7 @@ class WebHookJsonFormatSpec extends FunSuite {
       commentUser = account,
       repository = repositoryInfo,
       repositoryUser = account,
+      assignedUser = Some(account),
       sender = account,
       labels = List(label)
     )


### PR DESCRIPTION
This PR adds assignee and assignees properties to the following api payload.

- [list-issues-for-a-repository api](https://developer.github.com/v3/issues/#list-issues-for-a-repository)
- [get-a-single-issues api](https://developer.github.com/v3/issues/#get-a-single-issue)
- [create-an-issue api](https://developer.github.com/v3/issues/#create-an-issue)
- [issuesevent webhook](https://developer.github.com/v3/activity/events/types/#issuesevent)
- [issuecommentevent webhook](https://developer.github.com/v3/activity/events/types/#issuecommentevent)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
