### PR TITLE
Make Authorization header auth-scheme case-insencitive

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -16,7 +16,7 @@ class ScalatraBootstrap extends LifeCycle with SystemSettingsService {
       context.getSessionCookieConfig.setSecure(true)
     }
 
-    // Register TransactionFilter and BasicAuthenticationFilter at first
+    // Register TransactionFilter at first
     context.addFilter("transactionFilter", new TransactionFilter)
     context
       .getFilterRegistration("transactionFilter")

--- a/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
@@ -24,7 +24,7 @@ class ApiAuthenticationFilter extends Filter with AccessTokenService with Accoun
     val response = res.asInstanceOf[HttpServletResponse]
     Option(request.getHeader("Authorization"))
       .map {
-        case auth if auth.startsWith("token ") =>
+        case auth if auth.toLowerCase().startsWith("token ") =>
           AccessTokenService.getAccountByAccessToken(auth.substring(6).trim).toRight(())
         case auth if auth.startsWith("Basic ") => doBasicAuth(auth, loadSystemSettings(), request).toRight(())
         case _                                 => Left(())

--- a/src/main/scala/gitbucket/core/util/Directory.scala
+++ b/src/main/scala/gitbucket/core/util/Directory.scala
@@ -62,7 +62,7 @@ object Directory {
     new File(getRepositoryFilesDir(owner, repository), "releases")
 
   /**
-   * Directory for files which are attached to issue.
+   * Directory for Git LFS files.
    */
   def getLfsDir(owner: String, repository: String): File =
     new File(getRepositoryFilesDir(owner, repository), "lfs")


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

GitHub REST API adopts case-insensitive comparison for Authorization header auth-scheme. So `token`, `TOKEN` and `Token` are all valid.
Current GitBucket allows only `token`, but there are some tools that use different case, like octokit.net (which sends `Authorization: Token <token>`).