### PR TITLE
Correct activity message of reopening pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Support
 - If you can't find same question and report, send it to [gitter room](https://gitter.im/gitbucket/gitbucket) before raising an issue.
 - The highest priority of GitBucket is the ease of installation and API compatibility with GitHub, so your feature request might be rejected if they go against those principles.
 
-What's New in 4.32.x
+What's New in 4.33.x
 -------------
 ### 4.33.0 - 31 Dec 2019
 

--- a/src/main/scala/gitbucket/core/service/ActivityService.scala
+++ b/src/main/scala/gitbucket/core/service/ActivityService.scala
@@ -131,6 +131,23 @@ trait ActivityService {
       currentDate
     )
 
+  def recordReopenPullRequestActivity(
+    userName: String,
+    repositoryName: String,
+    activityUserName: String,
+    issueId: Int,
+    title: String
+  )(implicit s: Session): Unit =
+    Activities insert Activity(
+      userName,
+      repositoryName,
+      activityUserName,
+      "reopen_issue",
+      s"[user:${activityUserName}] reopened pull request [issue:${userName}/${repositoryName}#${issueId}]",
+      Some(title),
+      currentDate
+    )
+
   def recordCommentIssueActivity(
     userName: String,
     repositoryName: String,

--- a/src/main/scala/gitbucket/core/service/HandleCommentService.scala
+++ b/src/main/scala/gitbucket/core/service/HandleCommentService.scala
@@ -39,7 +39,10 @@ trait HandleCommentService {
                   ))
               case "reopen" if (issue.closed) =>
                 false ->
-                  (Some("reopen") -> Some(recordReopenIssueActivity _))
+                  (Some("reopen") -> Some(
+                    if (issue.isPullRequest) recordReopenPullRequestActivity _
+                    else recordReopenIssueActivity _
+                  ))
             }
             .map {
               case (closed, t) =>


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Fixes #2419 
