### PR TITLE
Add start and due date to issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.pgp.PgpKeys._
 
 val Organization = "io.github.gitbucket"
 val Name = "gitbucket"
-val GitBucketVersion = "4.33.0"
+val GitBucketVersion = "4.34.0"
 val ScalatraVersion = "2.7.0-RC1"
 val JettyVersion = "9.4.26.v20200117"
 val JgitVersion = "5.6.0.201912101111-r"

--- a/src/main/resources/update/gitbucket-core_4.34.xml
+++ b/src/main/resources/update/gitbucket-core_4.34.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeSet>
+  <addColumn tableName="ISSUE">
+    <column name="START_DATE" type="datetime" nullable="true"/>
+    <column name="DUE_DATE" type="datetime" nullable="true"/>
+  </addColumn>
+</changeSet>

--- a/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
+++ b/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
@@ -65,5 +65,6 @@ object GitBucketCoreModule
       new Version("4.31.1"),
       new Version("4.31.2"),
       new Version("4.32.0", new LiquibaseMigration("update/gitbucket-core_4.32.xml")),
-      new Version("4.33.0")
+      new Version("4.33.0"),
+      new Version("4.34.0", new LiquibaseMigration("update/gitbucket-core_4.34.xml"))
     )

--- a/src/main/scala/gitbucket/core/model/Issue.scala
+++ b/src/main/scala/gitbucket/core/model/Issue.scala
@@ -34,6 +34,8 @@ trait IssueComponent extends TemplateComponent { self: Profile =>
     val registeredDate = column[java.util.Date]("REGISTERED_DATE")
     val updatedDate = column[java.util.Date]("UPDATED_DATE")
     val pullRequest = column[Boolean]("PULL_REQUEST")
+    val startDate = column[java.util.Date]("START_DATE")
+    val dueDate = column[java.util.Date]("DUE_DATE")
     def * =
       (
         userName,
@@ -48,7 +50,9 @@ trait IssueComponent extends TemplateComponent { self: Profile =>
         closed,
         registeredDate,
         updatedDate,
-        pullRequest
+        pullRequest,
+        startDate.?,
+        dueDate.?
       ) <> (Issue.tupled, Issue.unapply)
 
     def byPrimaryKey(owner: String, repository: String, issueId: Int) = byIssue(owner, repository, issueId)
@@ -68,5 +72,7 @@ case class Issue(
   closed: Boolean,
   registeredDate: java.util.Date,
   updatedDate: java.util.Date,
-  isPullRequest: Boolean
+  isPullRequest: Boolean,
+  startDate: Option[java.util.Date],
+  dueDate: Option[java.util.Date]
 )

--- a/src/main/scala/gitbucket/core/service/IssueCreationService.scala
+++ b/src/main/scala/gitbucket/core/service/IssueCreationService.scala
@@ -19,7 +19,9 @@ trait IssueCreationService {
     milestoneId: Option[Int],
     priorityId: Option[Int],
     labelNames: Seq[String],
-    loginAccount: Account
+    loginAccount: Account,
+    startDate: Option[java.util.Date] = None,
+    dueDate: Option[java.util.Date] = None
   )(implicit context: Context, s: Session): Issue = {
 
     val owner = repository.owner
@@ -36,7 +38,9 @@ trait IssueCreationService {
       body,
       if (manageable) assignee else None,
       if (manageable) milestoneId else None,
-      if (manageable) priorityId else None
+      if (manageable) priorityId else None,
+      startDate = startDate,
+      dueDate = dueDate
     )
     val issue: Issue = getIssue(owner, name, issueId.toString).get
 

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -21,6 +21,7 @@ import gitbucket.core.model.Profile.profile._
 import gitbucket.core.model.Profile.profile.blockingApi._
 import gitbucket.core.model.Profile.dateColumnType
 import gitbucket.core.plugin.PluginRegistry
+import gitbucket.core.view.helpers
 
 trait IssuesService {
   self: AccountService with RepositoryService with LabelsService with PrioritiesService with MilestonesService =>
@@ -340,6 +341,16 @@ trait IssuesService {
                 case "asc"  => t2.priority asc
                 case "desc" => t2.priority desc
               }
+            case "startDate" =>
+              condition.direction match {
+                case "asc"  => t1.startDate.asc.nullsLast
+                case "desc" => t1.startDate.desc.nullsFirst
+              }
+            case "dueDate" =>
+              condition.direction match {
+                case "asc"  => t1.dueDate.asc.nullsLast
+                case "desc" => t1.dueDate.desc.nullsFirst
+              }
           }
       }
       .drop(offset)
@@ -408,7 +419,9 @@ trait IssuesService {
     assignedUserName: Option[String],
     milestoneId: Option[Int],
     priorityId: Option[Int],
-    isPullRequest: Boolean = false
+    isPullRequest: Boolean = false,
+    startDate: Option[java.util.Date] = None,
+    dueDate: Option[java.util.Date] = None
   )(implicit s: Session): Int = {
     // next id number
     sql"SELECT ISSUE_ID + 1 FROM ISSUE_ID WHERE USER_NAME = $owner AND REPOSITORY_NAME = $repository FOR UPDATE"
@@ -428,7 +441,9 @@ trait IssuesService {
           false,
           currentDate,
           currentDate,
-          isPullRequest
+          isPullRequest,
+          startDate,
+          dueDate
         )
 
         // increment issue id
@@ -535,6 +550,80 @@ trait IssuesService {
         t.pullRequest
       }
       .update(true)
+  }
+
+  private def insertIssueDateComment(
+    owner: String,
+    repository: String,
+    issueId: Int,
+    action: String,
+    content: String
+  )(
+    implicit context: Context,
+    s: Session
+  ): Int = {
+    IssueComments insert IssueComment(
+      userName = owner,
+      repositoryName = repository,
+      issueId = issueId,
+      action = action,
+      commentedUserName = context.loginAccount.map(_.userName).getOrElse("Unknown user"),
+      content = content,
+      registeredDate = currentDate,
+      updatedDate = currentDate
+    )
+  }
+
+  private def dateOpt(date: Option[java.util.Date]): String = {
+    date match { case Some(d) => helpers.date(d); case _ => "None" }
+  }
+
+  private def dateRange(oldDate: Option[java.util.Date], newDate: Option[java.util.Date]): String = {
+    s"${dateOpt(oldDate)}:${dateOpt(newDate)}"
+  }
+
+  def updateIssueStartDate(
+    owner: String,
+    repository: String,
+    issueId: Int,
+    startDate: Option[java.util.Date],
+    insertComment: Boolean = false
+  )(
+    implicit context: Context,
+    s: Session
+  ): Int = {
+    if (insertComment) {
+      val oldDate = getIssue(owner, repository, s"${issueId}").get.startDate
+      insertIssueDateComment(owner, repository, issueId, "change_start_date", dateRange(oldDate, startDate))
+    }
+    Issues
+      .filter(_.byPrimaryKey(owner, repository, issueId))
+      .map { t =>
+        (t.startDate ?, t.updatedDate)
+      }
+      .update(startDate, currentDate)
+  }
+
+  def updateIssueDueDate(
+    owner: String,
+    repository: String,
+    issueId: Int,
+    dueDate: Option[java.util.Date],
+    insertComment: Boolean = false
+  )(
+    implicit context: Context,
+    s: Session
+  ): Int = {
+    if (insertComment) {
+      val oldDate = getIssue(owner, repository, s"${issueId}").get.dueDate
+      insertIssueDateComment(owner, repository, issueId, "change_due_date", dateRange(oldDate, dueDate))
+    }
+    Issues
+      .filter(_.byPrimaryKey(owner, repository, issueId))
+      .map { t =>
+        (t.dueDate ?, t.updatedDate)
+      }
+      .update(dueDate, currentDate)
   }
 
   def updateAssignedUserName(
@@ -843,6 +932,8 @@ object IssuesService {
               case ("updated", "asc")   => Some("sort:updated-asc")
               case ("priority", "desc") => Some("sort:priority-desc")
               case ("priority", "asc")  => Some("sort:priority-asc")
+              case ("startDate", "asc") => Some("sort:startDate-asc")
+              case ("dueDate", "asc")   => Some("sort:dueDate-asc")
               case x                    => throw new MatchError(x)
             },
             visibility.map(visibility => s"visibility:${visibility}")
@@ -904,7 +995,8 @@ object IssuesService {
         },
         param(request, "mentioned"),
         param(request, "state", Seq("open", "closed")).getOrElse("open"),
-        param(request, "sort", Seq("created", "comments", "updated", "priority")).getOrElse("created"),
+        param(request, "sort", Seq("created", "comments", "updated", "priority", "startDate", "dueDate"))
+          .getOrElse("created"),
         param(request, "direction", Seq("asc", "desc")).getOrElse("desc"),
         param(request, "visibility"),
         param(request, "groups").map(_.split(",").toSet).getOrElse(Set.empty)

--- a/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
@@ -243,6 +243,28 @@
           </div>
         </div>
       }
+      case "change_start_date" => {
+        <div class="discussion-item discussion-item-pencil">
+          <div class="discussion-item-header">
+            <span class="discussion-item-icon" style="padding-left:10px"><i class="octicon octicon-triangle-right"></i></span>
+            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.user(comment.commentedUserName, styleClass="username strong")
+            change start date from <code>@comment.content.split(":")(0)</code> to <code>@comment.content.split(":")(1)</code>
+            @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
+          </div>
+        </div>
+      }
+      case "change_due_date" => {
+        <div class="discussion-item discussion-item-pencil">
+          <div class="discussion-item-header">
+            <span class="discussion-item-icon" style="padding-left:7px"><i class="octicon octicon-primitive-square"></i></span>
+            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.user(comment.commentedUserName, styleClass="username strong")
+            change due date from <code>@comment.content.split(":")(0)</code> to <code>@comment.content.split(":")(1)</code>
+            @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
+          </div>
+        </div>
+      }
       case _ => {
         @showFormattedComment(comment)
       }

--- a/src/main/twirl/gitbucket/core/issues/issueinfo.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/issueinfo.scala.html
@@ -102,16 +102,16 @@
 </div>
 <div id="milestone-progress-area">
   @issue.flatMap(_.milestoneId).map { milestoneId =>
-    @milestones.collect { case (milestone, openCount, closeCount) if(milestone.milestoneId == milestoneId) => {
+    @milestones.collect { case (milestone, openCount, closeCount) if(milestone.milestoneId == milestoneId) =>
       @gitbucket.core.issues.milestones.html.progress(openCount + closeCount, closeCount)
-    }}
+    }
   }
 </div>
 <span id="label-milestone">
   @issue.flatMap(_.milestoneId).map { milestoneId =>
-    @milestones.collect { case (milestone, _, _) if(milestone.milestoneId == milestoneId) => {
+    @milestones.collect { case (milestone, _, _) if(milestone.milestoneId == milestoneId) =>
       <a class="strong small username" href="@helpers.url(repository)/issues?milestone=@helpers.urlEncode(milestone.title)&state=open">@milestone.title</a>
-    }}
+    }
   }.getOrElse {
     <span class="muted small">No milestone</span>
   }
@@ -143,6 +143,32 @@
   }.getOrElse{
     <span class="muted small">No one</span>
   }
+</span>
+<hr/>
+<div style="margin-bottom: 14px;">
+  <span class="muted small strong">Start date</span>
+  <div class="pull-right">
+  </div>
+</div>
+<span>
+@if(isManageable){
+  @gitbucket.core.helper.html.datepicker("startDate", issue.flatMap(_.startDate))
+  <span id="error-startDate" class="error"></span>
+}else{
+  <span class="muted small">@(issue.flatMap(_.startDate) match {case Some(d) => helpers.date(d); case _ => "None"})</span>
+}
+</span>
+<hr/>
+<div style="margin-bottom: 14px;">
+  <span class="muted small strong">Due date</span>
+</div>
+<span>
+@if(isManageable){
+  @gitbucket.core.helper.html.datepicker("dueDate", issue.flatMap(_.dueDate))
+  <span id="error-dueDate" class="error"></span>
+}else{
+  <span class="muted small">@(issue.flatMap(_.dueDate) match {case Some(d) => helpers.date(d); case _ => "None"})</span>
+}
 </span>
 @if(issue.isEmpty){
   <input type="hidden" name="assignedUserName" value=""/>
@@ -210,6 +236,22 @@ $(function(){
       function(){
         displayAssignee($this, userName);
       }
+    );
+  });
+
+  $("#startDate").on("dp.change", function (e) {
+    var value = e.date ? e.date.format("YYYY-MM-DD") : "";
+    $.post('@helpers.url(repository)/issues/@issue.issueId/start_date',
+      { start_date: value },
+      function(){}
+    );
+  });
+
+  $("#dueDate").on("dp.change", function (e) {
+    var value = e.date ? e.date.format("YYYY-MM-DD") : "";
+    $.post('@helpers.url(repository)/issues/@issue.issueId/due_date',
+      { due_date: value },
+      function(){}
     );
   });
 }.getOrElse {

--- a/src/main/twirl/gitbucket/core/issues/listparts.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/listparts.scala.html
@@ -135,6 +135,16 @@
                 @gitbucket.core.helper.html.checkicon(condition.sort == "updated"  && condition.direction == "asc") Least recently updated
               </a>
             </li>
+            <li>
+              <a href="@condition.copy(sort="startDate",  direction="asc" ).toURL">
+                @gitbucket.core.helper.html.checkicon(condition.sort == "startDate"  && condition.direction == "asc") Start date
+              </a>
+            </li>
+            <li>
+              <a href="@condition.copy(sort="dueDate",  direction="asc" ).toURL">
+                @gitbucket.core.helper.html.checkicon(condition.sort == "dueDate"  && condition.direction == "asc") Due date
+              </a>
+            </li>
           }
         </span>
         @if(isManageable){
@@ -208,7 +218,10 @@
     }
     @issues.map { case IssueInfo(issue, labels, milestone, priority, commentCount, commitStatus) => {
       <tr>
-        <td style="padding-top: 12px; padding-bottom: 12px;">
+        <td class="reset-row" style="padding-top: 12px; padding-bottom: 12px;">
+          <div class="col-xs-6 reset-row">
+          <div class="col-md-5">
+            <div class="row">
           @if(isManageable){
             <input type="checkbox" value="@issue.issueId"/>
           }
@@ -227,10 +240,28 @@
           @labels.map { label =>
             <span class="label-color small" style="background-color: #@label.color; color: #@label.fontColor; padding-left: 4px; padding-right: 4px">@label.labelName</span>
           }
-          <span class="pull-right small">
-            @issue.assignedUserName.map { userName =>
+            </div>
+            <div class="row">
+              #@issue.issueId opened @gitbucket.core.helper.html.datetimeago(issue.registeredDate) by @helpers.user(issue.openedUserName, styleClass="username")
+            </div>
+          </div>
+          <div class="col-md-3 small muted" style="max-width:150px">
+            @priority.map(priority => priorities.filter(p => p.priorityName == priority).head).map { priority =>
+            <span><a href="@condition.copy(priority = Some(Some(priority.priorityName))).toURL" class="username"@if(!priority.description.isEmpty) { title="@priority.description.get" }><i class="octicon octicon-flame"></i>
+              <span class="issue-priority issue-priority-inline" style="background-color: #@priority.color; color: #@priority.fontColor;">@priority.priorityName</span></a></span>
+            }
+          </div>
+          <div class="col-md-4 small muted" style="max-width:300px">
+            @milestone.map { milestone =>
+            <span><a href="@condition.copy(milestone = Some(Some(milestone))).toURL" class="username"><i class="octicon octicon-milestone"></i> @milestone</a></span>
+            }
+          </div>
+          </div>
+          <div class="col-xs-2 pull-right text-right" style="max-width:100px">
+              @issue.assignedUserName.map { userName =>
               @helpers.avatar(userName, 20, tooltip = true)
             }
+            <span class="text-nowrap">
             @if(commentCount > 0){
               <a href="@context.path/@issue.userName/@issue.repositoryName/issues/@issue.issueId" class="issue-comment-count">
                 <i class="octicon octicon-comment active"></i> @commentCount
@@ -239,17 +270,24 @@
               <a href="@context.path/@issue.userName/@issue.repositoryName/issues/@issue.issueId" class="issue-comment-count" style="color: silver;">
                 <i class="octicon octicon-comment"></i> @commentCount
               </a>
+            </span>
             }
-          </span>
-          <div class="small muted" style="margin-left: 12px; margin-top: 2px;">
-            #@issue.issueId opened @gitbucket.core.helper.html.datetimeago(issue.registeredDate) by @helpers.user(issue.openedUserName, styleClass="username")
-            @priority.map(priority => priorities.filter(p => p.priorityName == priority).head).map { priority =>
-            <span style="margin: 20px;"><a href="@condition.copy(priority = Some(Some(priority.priorityName))).toURL" class="username"@if(!priority.description.isEmpty) { title="@priority.description.get" }><i class="octicon octicon-flame"></i>
-              <span class="issue-priority issue-priority-inline" style="background-color: #@priority.color; color: #@priority.fontColor;">@priority.priorityName</span></a></span>
-            }
-            @milestone.map { milestone =>
-              <span style="margin: 20px;"><a href="@condition.copy(milestone = Some(Some(milestone))).toURL" class="username"><i class="octicon octicon-milestone"></i> @milestone</a></span>
-            }
+          </div>
+          <div class="col-xs-5 reset-row pull-right" style="max-width:300px">
+            <div class="col-md-6">
+              @if(issue.startDate.isDefined){
+              <span>
+                <i class="octicon octicon-triangle-right"></i> <span class="text-nowrap">@helpers.date(issue.startDate.get)</span>
+              </span>
+              }
+            </div>
+            <div class="col-md-6">
+              @if(issue.dueDate.isDefined){
+              <span>
+                <i class="octicon octicon-primitive-square"></i> <span class="text-nowrap">@helpers.date(issue.dueDate.get)</span>
+              </span>
+              }
+            </div>
           </div>
         </td>
       </tr>

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -255,6 +255,11 @@ div.row {
   margin-right: 0px;
 }
 
+.reset-row{
+  margin-left: -15px;
+  margin-right: -15px;
+}
+
 /*
 ul.nav-tabs {
   height: 42px;

--- a/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
+++ b/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
@@ -108,7 +108,9 @@ object ApiSpecModels {
     closed = false,
     registeredDate = date1,
     updatedDate = date1,
-    isPullRequest = false
+    isPullRequest = false,
+    startDate = None,
+    dueDate = None
   )
 
   val issuePR = issue.copy(


### PR DESCRIPTION
Squash #2422

This PR add `start date`, `due date` to issue.
This PR will change GitBucket version number because of updating database schema.

If this PR is merged, I will implement gantt chart plugin supporting Future Task.


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
