### PR TITLE
Ignore Limited settings, when searching repositories.

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -293,7 +293,13 @@ trait IndexControllerBase extends ControllerBase {
 
     val repositories = {
       context.settings.limitVisibleRepositories match {
-        case true  => getVisibleRepositories(context.loginAccount)
+        case true =>
+          getVisibleRepositories(
+            context.loginAccount,
+            None,
+            withoutPhysicalInfo = true,
+            limit = false
+          )
         case false => visibleRepositories
       }
     }.filter { repository =>

--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -290,10 +290,16 @@ trait IndexControllerBase extends ControllerBase {
         withoutPhysicalInfo = true,
         limit = context.settings.limitVisibleRepositories
       )
-    val repositories = visibleRepositories.filter { repository =>
+
+    val repositories = {
+      context.settings.limitVisibleRepositories match {
+        case true  => getVisibleRepositories(context.loginAccount)
+        case false => visibleRepositories
+      }
+    }.filter { repository =>
       repository.name.toLowerCase.indexOf(query) >= 0 || repository.owner.toLowerCase.indexOf(query) >= 0
     }
+
     gitbucket.core.search.html.repositories(query, repositories, visibleRepositories)
   }
-
 }


### PR DESCRIPTION
This PR is to ignore Limited settings (#2421) , when searching repositories.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
