### PR TITLE
Restrict information visibility if allowAnonymousAccess is false

### DIFF
--- a/src/main/twirl/gitbucket/core/signin.scala.html
+++ b/src/main/twirl/gitbucket/core/signin.scala.html
@@ -5,11 +5,13 @@
   <div class="content-wrapper main-center">
     <div class="content body">
       <div class="signin-form">
-        @context.settings.information.map { information =>
-          <div class="alert alert-info" style="background-color: white; color: #555; border-color: #4183c4; font-size: small; line-height: 120%;">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            @Html(information)
-          </div>
+        @if(context.settings.allowAnonymousAccess){
+          @context.settings.information.map { information =>
+            <div class="alert alert-info" style="background-color: white; color: #555; border-color: #4183c4; font-size: small; line-height: 120%;">
+              <button type="button" class="close" data-dismiss="alert">&times;</button>
+              @Html(information)
+            </div>
+          }
         }
         @gitbucket.core.helper.html.error(error)
         @gitbucket.core.html.signinform(context.settings, userName, password)


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Fixes #2428