### PR TITLE
Fix browser_download_url of releases APIs

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiRelease.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRelease.scala
@@ -6,7 +6,7 @@ case class ApiReleaseAsset(name: String, size: Long)(tag: String, fileName: Stri
   val label = name
   val file_id = fileName
   val browser_download_url = ApiPath(
-    s"/api/v3/repos/${repositoryName.fullName}/releases/${tag}/assets/${fileName}"
+    s"/${repositoryName.fullName}/releases/${tag}/assets/${fileName}"
   )
 }
 

--- a/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
+++ b/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
@@ -707,7 +707,7 @@ object ApiSpecModels {
       |"size":100,
       |"label":"release.zip",
       |"file_id":"${assetFileName}",
-      |"browser_download_url":"http://gitbucket.exmple.com/api/v3/repos/octocat/Hello-World/releases/tag1/assets/${assetFileName}"
+      |"browser_download_url":"http://gitbucket.exmple.com/octocat/Hello-World/releases/tag1/assets/${assetFileName}"
       |}""".stripMargin
 
   val jsonRelease =


### PR DESCRIPTION
This issue was reported on Gitter:
https://gitter.im/gitbucket/gitbucket?at=5eb277793d58de7a38f94978

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
