### PR TITLE
Revert "Fix get a reference API path (#2459)"

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiGitReferenceControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiGitReferenceControllerBase.scala
@@ -16,7 +16,7 @@ trait ApiGitReferenceControllerBase extends ControllerBase {
    * i. Get a reference
    * https://developer.github.com/v3/git/refs/#get-a-reference
    */
-  get("/api/v3/repos/:owner/:repository/git/ref/*")(referrersOnly { repository =>
+  get("/api/v3/repos/:owner/:repository/git/refs/*")(referrersOnly { repository =>
     val revstr = multiParams("splat").head
     Using.resource(Git.open(getRepositoryDir(params("owner"), params("repository")))) { git =>
       val ref = git.getRepository().findRef(revstr)


### PR DESCRIPTION
This reverts commit 0e9026447d0f4a1f6fa782586db3764e420cccd8.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
