### PR TITLE
Improve file list performance

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -928,8 +928,9 @@ trait RepositoryViewerControllerBase extends ControllerBase {
             defining(JGitUtil.getRevCommitFromId(git, objectId)) { revCommit =>
               val lastModifiedCommit =
                 if (path == ".") revCommit else JGitUtil.getLastModifiedCommit(git, revCommit, path)
+              val commitCount = JGitUtil.getCommitCount(git, lastModifiedCommit.getName)
               // get files
-              val files = JGitUtil.getFileList(git, revision, path, context.settings.baseUrl)
+              val files = JGitUtil.getFileList(git, revision, path, context.settings.baseUrl, commitCount)
               val parentPath = if (path == ".") Nil else path.split("/").toList
               // process README.md or README.markdown
               val readme = files
@@ -950,7 +951,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
                 repository,
                 if (path == ".") Nil else path.split("/").toList, // current path
                 new JGitUtil.CommitInfo(lastModifiedCommit), // last modified commit
-                JGitUtil.getCommitCount(git, lastModifiedCommit.getName),
+                commitCount,
                 files,
                 readme,
                 hasDeveloperRole(repository.owner, repository.name, context.loginAccount),

--- a/src/main/twirl/gitbucket/core/helper/datetimeago.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/datetimeago.scala.html
@@ -1,10 +1,12 @@
 @(latestUpdatedDate: java.util.Date,
   recentOnly: Boolean = true)
 @import gitbucket.core.view.helpers
-<span data-toggle="tooltip" title="@helpers.datetime(latestUpdatedDate)">
-  @if(recentOnly){
-    @helpers.datetimeAgoRecentOnly(latestUpdatedDate)
-  } else {
-    @helpers.datetimeAgo(latestUpdatedDate)
-  }
-</span>
+@if(latestUpdatedDate != null){
+  <span data-toggle="tooltip" title="@helpers.datetime(latestUpdatedDate)">
+    @if(recentOnly){
+      @helpers.datetimeAgoRecentOnly(latestUpdatedDate)
+    } else {
+      @helpers.datetimeAgo(latestUpdatedDate)
+    }
+  </span>
+}


### PR DESCRIPTION
- Simplify an internal method to retrieving commit info
- Introduce in-memory cache for large repositories
- Introduce the upper limit for the number of files to retrieving commit info

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
