### PR TITLE
fix TLS/SSL LDAP under IBM JVM

### DIFF
--- a/src/main/scala/gitbucket/core/util/LDAPUtil.scala
+++ b/src/main/scala/gitbucket/core/util/LDAPUtil.scala
@@ -127,8 +127,14 @@ object LDAPUtil {
   private def getSslProvider(): Provider = {
     val cachedInstance = provider.get()
     if (cachedInstance == null) {
-      val newInstance = Class
-        .forName("com.sun.net.ssl.internal.ssl.Provider")
+      val cls = try {
+        Class.forName("com.sun.net.ssl.internal.ssl.Provider")
+      } catch {
+        case e: ClassNotFoundException =>
+          Class.forName("com.ibm.jsse.IBMJSSEProvider")
+        case e: Throwable => throw e
+      }
+      val newInstance = cls
         .getDeclaredConstructor()
         .newInstance()
         .asInstanceOf[Provider]


### PR DESCRIPTION
### Problem

as @dsdphh has commented: https://github.com/gitbucket/gitbucket/issues/557#issuecomment-648830641

LDAP authentication fails when both conditions following are met:
- run under IBM JVM
- connect LDAP server using TLS/SSL

### Cause

IBM JVM does not include [`com.sun.net.ssl.internal.ssl.Provider`](https://github.com/gitbucket/gitbucket/blob/cf0d8ea2d0b9e74218c1e37728619976435a4c9e/src/main/scala/gitbucket/core/util/LDAPUtil.scala#L131).

### Solution

using `com.ibm.jsse.IBEJSSEProvider` instead.

### Note

reproduced and checked fix under:
```plain
java version "1.8.0_251"
Java(TM) SE Runtime Environment (build 8.0.6.11 - pxa6480sr6fp11-20200602_01(SR6 FP11))
IBM J9 VM (build 2.9, JRE 1.8.0 Linux amd64-64-Bit Compressed References 20200601_448156 (JIT enabled, AOT enabled)
OpenJ9 - 6c940fd
OMR - 91c4c01
IBM - 19f2e5e)
JCL - 20200520_01 based on Oracle jdk8u251-b08
```

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
