### PR TITLE
executable: Allow saving sessions to disk

### DIFF
--- a/src/main/java/JettyLauncher.java
+++ b/src/main/java/JettyLauncher.java
@@ -4,6 +4,10 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
+import org.eclipse.jetty.server.session.DefaultSessionCache;
+import org.eclipse.jetty.server.session.FileSessionDataStore;
+import org.eclipse.jetty.server.session.SessionCache;
+import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 import java.io.File;
@@ -21,6 +25,7 @@ public class JettyLauncher {
         String contextPath = "/";
         String tmpDirPath="";
         boolean forceHttps = false;
+        boolean saveSessions = false;
 
         host = getEnvironmentVariable("gitbucket.host");
         port = getEnvironmentVariable("gitbucket.port");
@@ -28,6 +33,9 @@ public class JettyLauncher {
         tmpDirPath = getEnvironmentVariable("gitbucket.tempDir");
 
         for(String arg: args) {
+            if(arg.equals("--save_sessions")) {
+                saveSessions = true;
+            }
             if(arg.startsWith("--") && arg.contains("=")) {
                 String[] dim = arg.split("=");
                 if(dim.length >= 2) {
@@ -86,6 +94,19 @@ public class JettyLauncher {
         }
 
         WebAppContext context = new WebAppContext();
+
+        if(saveSessions) {
+            File sessDir = new File(getGitBucketHome(), "sessions");
+            if(!sessDir.exists()){
+                sessDir.mkdirs();
+            }
+            SessionHandler sessions = context.getSessionHandler();
+            SessionCache cache = new DefaultSessionCache(sessions);
+            FileSessionDataStore fsds = new FileSessionDataStore();
+            fsds.setStoreDir(sessDir);
+            cache.setSessionDataStore(fsds);
+            sessions.setSessionCache(cache);
+        }
 
         File tmpDir;
         if(tmpDirPath == null || tmpDirPath.equals("")){


### PR DESCRIPTION
This commit allows saving sessions to disk in ~/.gitbucket/sessions
or wherever the gitbucket home is so that logins and other session
data persist between restarts of the program.

Usage: java -jar gitbucket.war --save_sessions

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct