### PR TITLE
Add Merge PullRequest API

### DIFF
--- a/src/main/scala/gitbucket/core/api/MergeAPullRequest.scala
+++ b/src/main/scala/gitbucket/core/api/MergeAPullRequest.scala
@@ -1,7 +1,7 @@
 package gitbucket.core.api
 
 /**
- * https://developer.github.com/v3/pulls/#merge-a-pull-request
+ * https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request
  */
 case class MergeAPullRequest(
   commit_title: Option[String],
@@ -18,6 +18,6 @@ case class SuccessToMergePrResponse(
 )
 
 case class FailToMergePrResponse(
-  documentation_ur: String,
+  documentation_url: String,
   message: String
 )

--- a/src/main/scala/gitbucket/core/api/MergeAPullRequest.scala
+++ b/src/main/scala/gitbucket/core/api/MergeAPullRequest.scala
@@ -1,0 +1,23 @@
+package gitbucket.core.api
+
+/**
+ * https://developer.github.com/v3/pulls/#merge-a-pull-request
+ */
+case class MergeAPullRequest(
+  commit_title: Option[String],
+  commit_message: Option[String],
+  /* TODO: Not Implemented
+  sha: Option[String],*/
+  merge_method: Option[String]
+)
+
+case class SuccessToMergePrResponse(
+  sha: String,
+  merged: Boolean,
+  message: String
+)
+
+case class FailToMergePrResponse(
+  documentation_ur: String,
+  message: String
+)

--- a/src/main/scala/gitbucket/core/controller/api/ApiPullRequestControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiPullRequestControllerBase.scala
@@ -274,7 +274,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
                 JsonFormat(
                   FailToMergePrResponse(
                     message = "Pull Request is not mergeable",
-                    documentation_url = "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
+                    documentation_url = "https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request",
                   )
                 )
               )

--- a/src/main/scala/gitbucket/core/controller/api/ApiPullRequestControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiPullRequestControllerBase.scala
@@ -217,7 +217,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
 
   /*
    * ix. Merge a pull request (Merge Button)
-   * https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
+   * https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request
    */
   put("/api/v3/repos/:owner/:repository/pulls/:id/merge")(referrersOnly { repository =>
     (for {
@@ -232,7 +232,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
           JsonFormat(
             FailToMergePrResponse(
               message = "Head branch was modified. Review and try the merge again.",
-              documentation_ur = "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
+              documentation_url = "https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request",
             )
           )
         )
@@ -242,7 +242,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
             JsonFormat(
               FailToMergePrResponse(
                 message = "Pull Request is not mergeable, Closed",
-                documentation_ur = "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
+                documentation_url = "https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request",
               )
             )
           )
@@ -274,7 +274,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
                 JsonFormat(
                   FailToMergePrResponse(
                     message = "Pull Request is not mergeable",
-                    documentation_ur = "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
+                    documentation_url = "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
                   )
                 )
               )


### PR DESCRIPTION
I create a API according to the following specifications.
https://developer.github.com/v3/pulls/#merge-a-pull-request

`SHA` and `COMMIT_TITLE` parameters are not supported.

But I have one question here.
If `request.body` is passed empty, it was not be handled and an error occured with 500: InternalServerError. It is returned at that point.
I want advice on this issue.


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
