### PR TITLE
Remove activity log configuration no longer used

### DIFF
--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -48,7 +48,6 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
     )(RepositoryOperation.apply),
     "gravatar" -> trim(label("Gravatar", boolean())),
     "notification" -> trim(label("Notification", boolean())),
-    "activityLogLimit" -> trim(label("Limit of activity logs", optional(number()))),
     "limitVisibleRepositories" -> trim(label("limitVisibleRepositories", boolean())),
     "ssh" -> mapping(
       "enabled" -> trim(label("SSH access", boolean())),

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -28,7 +28,6 @@ trait SystemSettingsService {
       props.setProperty(RepositoryOperationFork, settings.repositoryOperation.fork.toString)
       props.setProperty(Gravatar, settings.gravatar.toString)
       props.setProperty(Notification, settings.notification.toString)
-      settings.activityLogLimit.foreach(x => props.setProperty(ActivityLogLimit, x.toString))
       props.setProperty(LimitVisibleRepositories, settings.limitVisibleRepositories.toString)
       props.setProperty(SshEnabled, settings.ssh.enabled.toString)
       settings.ssh.sshHost.foreach(x => props.setProperty(SshHost, x.trim))
@@ -112,7 +111,6 @@ trait SystemSettingsService {
         ),
         getValue(props, Gravatar, false),
         getValue(props, Notification, false),
-        getOptionValue[Int](props, ActivityLogLimit, None),
         getValue(props, LimitVisibleRepositories, false),
         Ssh(
           getValue(props, SshEnabled, false),
@@ -200,7 +198,6 @@ object SystemSettingsService {
     repositoryOperation: RepositoryOperation,
     gravatar: Boolean,
     notification: Boolean,
-    activityLogLimit: Option[Int],
     limitVisibleRepositories: Boolean,
     ssh: Ssh,
     useSMTP: Boolean,

--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -266,20 +266,6 @@
   </div>
 </fieldset>
 <!--====================================================================-->
-<!-- Activity -->
-<!--====================================================================-->
-<hr>
-<label><span class="strong">Limit of activity logs</span> (Unlimited if it is not specified or zero)</label>
-<fieldset>
-  <div class="form-group">
-    <label class="control-label col-md-2" for="activityLogLimit">Limit</label>
-    <div class="col-md-10">
-      <input type="text" id="activityLogLimit" name="activityLogLimit" class="form-control input-mini" value="@context.settings.activityLogLimit"/>
-      <span id="error-activityLogLimit" class="error"></span>
-    </div>
-  </div>
-</fieldset>
-<!--====================================================================-->
 <!-- Sidebar -->
 <!--====================================================================-->
 <hr>

--- a/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
+++ b/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
@@ -45,7 +45,6 @@ trait ServiceSpecBase extends MockitoSugar {
       ),
       gravatar = false,
       notification = false,
-      activityLogLimit = None,
       limitVisibleRepositories = false,
       ssh = Ssh(
         enabled = false,

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -131,7 +131,6 @@ class AvatarImageProviderSpec extends FunSpec with MockitoSugar {
       ),
       gravatar = useGravatar,
       notification = false,
-      activityLogLimit = None,
       limitVisibleRepositories = false,
       ssh = Ssh(
         enabled = false,


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
