### PR TITLE
Add function to close multiple issues with one keyword on commits

### DIFF
--- a/src/main/scala/gitbucket/core/util/StringUtil.scala
+++ b/src/main/scala/gitbucket/core/util/StringUtil.scala
@@ -151,8 +151,13 @@ object StringUtil {
    * @return the iterator of issue id
    */
   def extractCloseId(message: String): Seq[String] =
-    "(?i)(?<!\\w)(?:fix(?:e[sd])?|resolve[sd]?|close[sd]?)\\s+#(\\d+)(?!\\w)".r
-      .findAllIn(message)
+    "#(\\d+)".r
+      .findAllIn(
+        "(?i)(?<!\\w)(?:fix(?:e[sd])?|resolve[sd]?|close[sd]?)\\s+#(\\d+)(,\\s?#(\\d+))*(?!\\w)".r
+          .findAllIn(message)
+          .toSeq
+          .mkString(",")
+      )
       .matchData
       .map(_.group(1))
       .toSeq

--- a/src/test/scala/gitbucket/core/util/StringUtilSpec.scala
+++ b/src/test/scala/gitbucket/core/util/StringUtilSpec.scala
@@ -64,6 +64,9 @@ class StringUtilSpec extends FunSpec {
     it("should returns Nil from message which does not contain close command") {
       assert(StringUtil.extractCloseId("(refs #123)").toSeq == Nil)
     }
+    it("should extract 'close #x, #y, #z' and return extracted multi id") {
+      assert(StringUtil.extractCloseId("(close #1, #2, #3, wip #4, close #5)").toSeq == Seq("1", "2", "3", "5"))
+    }
   }
 
   describe("getRepositoryViewerUrl") {


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## Changes

This PR add function to close multiple issue with one keyword on comment to fix #2396 

Before

```
scala> extractCloseId("fix #1, #2, #3 edit #4, $5 close #6, #7")
val res7: Seq[String] = List(1, 6)
```

After

```
scala> extractCloseId("fix #1, #2, #3 edit #4, $5 close #6, #7")
val res8: Seq[String] = List(1, 2, 3, 6, 7)
```
