### PR TITLE
Update message for the sidebar repository list setting

### DIFF
--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -425,7 +425,7 @@ trait RepositoryService {
    * @param repositoryUserName the repository owner (if None then returns all repositories which are visible for logged in user)
    * @param withoutPhysicalInfo if true then the result does not include physical repository information such as commit count,
    *                            branches and tags
-   * @param limit if true then result will include only repositories associated with the login account.
+   * @param limit if true then result will include only repositories owned by the login account. otherwise, result will be all visible repositories.
    * @return the repository information which is sorted in descending order of lastActivityDate.
    */
   def getVisibleRepositories(

--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -269,15 +269,15 @@
 <!-- Sidebar -->
 <!--====================================================================-->
 <hr>
-<label><span class="strong">Show Repositories in Sidebar</span></label>
+<label><span class="strong">Show repositories in sidebar</span></label>
 <fieldset>
   <label class="radio">
     <input type="radio" name="limitVisibleRepositories" value="false"@if(!context.settings.limitVisibleRepositories){ checked}>
-    <span class="strong">All</span> <span class="normal">- Show all repositories in sidebar.</span>
+    <span class="strong">All</span> <span class="normal">- Show all visible repositories in sidebar.</span>
   </label>
   <label class="radio">
     <input type="radio" name="limitVisibleRepositories" value="true"@if(context.settings.limitVisibleRepositories){ checked}>
-    <span class="strong">Limited</span> <span class="normal">- Limit the visible repositories in sidebar.</span>
+    <span class="strong">Limited</span> <span class="normal">- Show only owned repositories in sidebar.</span>
   </label>
 </fieldset>
 <script>


### PR DESCRIPTION
This is a follow-up pull request for https://github.com/gitbucket/gitbucket/pull/2421. Improves the messages in the system settings page.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
