### PR TITLE
Fixed some grammar and spelling issues, modified sign in form

### DIFF
--- a/src/main/twirl/gitbucket/core/account/hooks.scala.html
+++ b/src/main/twirl/gitbucket/core/account/hooks.scala.html
@@ -13,7 +13,7 @@
         <p>
           These webhooks notify external services when certain events occur within any of your repositories.
           When any of the specified events occur, GitBucket will send a POST request to all of the endpoints (URLs) you provide.
-          Learn more about this feature on the <a href="https://github.com/takezoe/gitbucket/wiki/API-WebHook" target="_blank">GitBucket Wiki</a>.
+          Learn more about this feature on the <a href="https://github.com/gitbucket/gitbucket/wiki/API-WebHook" target="_blank">GitBucket Wiki</a>.
         </p>
         <a href="@helpers.url(account.userName)/_hooks/new" class="btn btn-success pull-right" style="margin-bottom: 10px;">Add webhook</a>
 

--- a/src/main/twirl/gitbucket/core/account/hooks.scala.html
+++ b/src/main/twirl/gitbucket/core/account/hooks.scala.html
@@ -11,9 +11,9 @@
       </div>
       <div class="panel-body">
         <p>
-          Webhooks allow external services to be notified when certain events happen within your repository.
-          When the specified events happen, we’ll send a POST request to each of the URLs you provide.
-          Learn more in <a href="https://github.com/takezoe/gitbucket/wiki/API-WebHook" target="_blank">GitBucket Wiki Webhook Page</a>.
+          These webhooks notify external services when certain events occur within any of your repositories.
+          When any of the specified events occur, GitBucket will send a POST request to all of the endpoints (URLs) you provide.
+          Learn more about this feature on the <a href="https://github.com/takezoe/gitbucket/wiki/API-WebHook" target="_blank">GitBucket Wiki</a>.
         </p>
         <a href="@helpers.url(account.userName)/_hooks/new" class="btn btn-success pull-right" style="margin-bottom: 10px;">Add webhook</a>
 

--- a/src/main/twirl/gitbucket/core/account/newrepo.scala.html
+++ b/src/main/twirl/gitbucket/core/account/newrepo.scala.html
@@ -6,7 +6,7 @@ isCreateRepoOptionPublic: Boolean)(implicit context: gitbucket.core.controller.C
   <div class="content body">
     <h2>Create a new repository</h2>
     <p class="muted">
-      A repository contains all the files for your project including the revision history.
+      A repository contains all your project's files, including revision history.
     </p>
     <form id="form" method="post" action="@context.path/new" validate="true" autocomplete="off">
       <fieldset class="border-top form-group">
@@ -62,28 +62,28 @@ isCreateRepoOptionPublic: Boolean)(implicit context: gitbucket.core.controller.C
           <input type="radio" name="initOption" value="EMPTY" checked/>
           <span class="strong">Create an empty repository</span>
           <div class="normal muted">
-            Create an empty repository. You have to initialize by yourself initially.
+            Create an empty repository. You must initialize it yourself.
           </div>
         </label>
         <label class="radio">
           <input type="radio" name="initOption" value="EMPTY_COMMIT"/>
           <span class="strong">Initialize this repository with an empty commit</span>
           <div class="normal muted">
-            Create an empty repository with empty commit. You can clone the repository immediately.
+            Create an empty repository with an empty commit. You can clone the repository immediately.
           </div>
         </label>
         <label class="radio">
           <input type="radio" name="initOption" value="README"/>
           <span class="strong">Initialize this repository with a README</span>
           <div class="normal muted">
-            Create a repository which has README.md. You can clone the repository immediately.
+            Create a repository and commit README.md. You can clone the repository immediately.
           </div>
         </label>
         <label class="radio">
           <input type="radio" name="initOption" value="COPY"/>
           <span class="strong">Copy existing git repository</span>
           <div class="normal muted">
-            Create new repository from existing git repository.
+            Create a new repository by cloning an existing git repository.
           </div>
         </label>
         <input type="text" class="form-control" name="sourceUrl" id="sourceUrl" disabled placeholder="Source git repository URL..."/>

--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -22,8 +22,8 @@
     <td class="danger">
       <p>@gitbucket.core.util.DatabaseConfig.url</p>
       <p>
-        Your GitBucket is running on embedded H2 database.
-        Recommend to <a href="https://github.com/gitbucket/gitbucket/wiki/External-database-configuration">configure to use external database</a> if you would like to use GitBucket for important purpose.
+        GitBucket is using the embedded H2 database.
+        It's recommended that you <a href="https://github.com/gitbucket/gitbucket/wiki/External-database-configuration">configure GitBucket to use an external database</a> if you're running GitBucket in a production environment.
       </p>
     </td>
     }else{
@@ -43,15 +43,15 @@
     </div>
 </fieldset>
 <p class="muted">
-  The base URL is used for redirect, notification email, git repository URL box and more.
-  If the base URL is empty, GitBucket generates URL from the request information.
-  You can use this property to adjust to URL differences between the reverse proxy and GitBucket.
+  The base URL is used for redirects, notification emails, git repository URL boxes, and more.
+  If the base URL is empty, GitBucket generates the URL from the request information.
+  You can use this property to adjust to URL differences between a reverse proxy and GitBucket.
 </p>
 <!--====================================================================-->
 <!-- Information -->
 <!--====================================================================-->
 <hr>
-<label><span class="strong">Information</span> (HTML is available)</label>
+<label><span class="strong">Site notification</span> (Supports HTML)</label>
 <fieldset>
   <textarea name="information" class="form-control" style="height: 100px;">@context.settings.information</textarea>
 </fieldset>

--- a/src/main/twirl/gitbucket/core/dashboard/sidebar.scala.html
+++ b/src/main/twirl/gitbucket/core/dashboard/sidebar.scala.html
@@ -3,11 +3,11 @@
 <div class="main-sidebar">
   <div class="sidebar">
   <ul class="nav sidebar-menu">
-    <li class="header">Recent updated repositories</li>
+    <li class="header">Recently updated repositories</li>
     @if(recentRepositories.isEmpty){
       <li>No repositories</li>
     } else {
-      <li><form class="sidebar-form"><input type="text" id="filter-box" class="form-control input-sm" placeholder="Find repository"/></form></li>
+      <li><form class="sidebar-form"><input type="text" id="filter-box" class="form-control input-sm" placeholder="Find a repository"/></form></li>
       @recentRepositories.zipWithIndex.map { case (repository, i) =>
         <li class="repo-link menu-item-hover">
           <a href="@helpers.url(repository)">@gitbucket.core.helper.html.repositoryicon(repository, false) <span>@repository.owner/<span class="strong">@repository.name</span></span></a>

--- a/src/main/twirl/gitbucket/core/main.scala.html
+++ b/src/main/twirl/gitbucket/core/main.scala.html
@@ -78,7 +78,7 @@
           }
           <form id="search" action="@context.path/search" method="GET" class="pc navbar-form navbar-left" role="search">
             <div class="form-group">
-              <input type="text" name="query" id="navbar-search-input" class="form-control" placeholder="Search repository"/>
+              <input type="text" name="query" id="navbar-search-input" class="form-control" placeholder="Find a repository"/>
             </div>
           </form>
           <ul class="pc nav navbar-nav">

--- a/src/main/twirl/gitbucket/core/settings/branches.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/branches.scala.html
@@ -18,7 +18,7 @@
         <div class="panel panel-default">
           <div class="panel-heading strong">Default branch</div>
           <div class="panel-body">
-            <p>The default branch is considered the “base” branch in your repository, against which all pull requests and code commits are automatically made, unless you specify a different branch.</p>
+            <p>The default branch is considered the “base” branch in your repository, against which all pull requests and code commits are automatically made (unless you specify a different branch.)</p>
             <form id="form" method="post" action="@helpers.url(repository)/settings/update_default_branch" validate="true" class="form-inline">
               <span class="error" id="error-defaultBranch"></span>
               <select name="defaultBranch" id="defaultBranch" class="form-control">
@@ -34,7 +34,7 @@
         <div class="panel panel-default">
           <div class="panel-heading strong">Protected branches</div>
           <div class="panel-body">
-            <p>Protect branches to disable force pushing, prevent branches from being deleted, and optionally require status checks before merging. New to protected branches?
+            <p>Protect branches to disable force pushing, prevent branches from being deleted, and optionally, require status checks before merging.
               <form class="form-inline">
                 <select name="protectBranch" id="protectBranch" onchange="location=$(this).val()" class="form-control">
                   <option>Choose a branch...</option>

--- a/src/main/twirl/gitbucket/core/settings/branches.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/branches.scala.html
@@ -18,7 +18,7 @@
         <div class="panel panel-default">
           <div class="panel-heading strong">Default branch</div>
           <div class="panel-body">
-            <p>The default branch is considered the “base” branch in your repository, against which all pull requests and code commits are automatically made (unless you specify a different branch.)</p>
+            <p>The default branch is considered the “base” branch in your repository, against which all pull requests and code commits are automatically made (unless you specify a different branch).</p>
             <form id="form" method="post" action="@helpers.url(repository)/settings/update_default_branch" validate="true" class="form-inline">
               <span class="error" id="error-defaultBranch"></span>
               <select name="defaultBranch" id="defaultBranch" class="form-control">

--- a/src/main/twirl/gitbucket/core/settings/danger.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/danger.scala.html
@@ -21,7 +21,7 @@
               <fieldset class="border-top form-group">
                 <label class="strong">Rename repository</label>
                 <div>
-                  Rename this repository. The current URL will be unavailable.
+                  Rename this repository. This will make the current URL unavailable.
                   <div class="pull-right">
                     <input type="text" name="repositoryName" id="repositoryName" class="form-control" style="width: 200px; display: inline; vertical-align: middle;" value="@repository.name"/>
                     <input type="submit" class="btn btn-danger" value="Rename"/>
@@ -38,7 +38,7 @@
               <fieldset class="border-top form-group">
                 <label class="strong">Transfer Ownership</label>
                 <div>
-                  Transfer this repo to another user or to group.
+                  Transfer this repository to another user or to group.
                   <div class="pull-right">
                     @gitbucket.core.helper.html.account("newOwner", 200, true, true)
                     <input type="submit" class="btn btn-danger" value="Transfer"/>
@@ -55,7 +55,7 @@
               <fieldset class="border-top form-group">
                 <label class="strong">Delete repository</label>
                 <div>
-                  Once you delete a repository, there is no going back.
+                  Permanently deletes this repository. This cannot be undone.
                   <input type="submit" class="btn btn-danger pull-right" value="Delete this repository"/>
                 </div>
               </fieldset>

--- a/src/main/twirl/gitbucket/core/settings/danger.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/danger.scala.html
@@ -55,7 +55,7 @@
               <fieldset class="border-top form-group">
                 <label class="strong">Delete repository</label>
                 <div>
-                  Permanently deletes this repository. This cannot be undone.
+                  Permanently delete this repository. This cannot be undone.
                   <input type="submit" class="btn btn-danger pull-right" value="Delete this repository"/>
                 </div>
               </fieldset>

--- a/src/main/twirl/gitbucket/core/settings/hooks.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/hooks.scala.html
@@ -14,7 +14,7 @@
           <p>
             Webhooks notify external services when certain events occur within this repository.
             When any of the specified events occur, GitBucket will send a POST request to all of the endpoints (URLs) you provide.
-            Learn more about this feature on the <a href="https://github.com/takezoe/gitbucket/wiki/API-WebHook" target="_blank">GitBucket Wiki</a>.
+            Learn more about this feature on the <a href="https://github.com/gitbucket/gitbucket/wiki/API-WebHook" target="_blank">GitBucket Wiki</a>.
           </p>
           <a href="@helpers.url(repository)/settings/hooks/new" class="btn btn-success pull-right" style="margin-bottom: 10px;">Add webhook</a>
 

--- a/src/main/twirl/gitbucket/core/settings/hooks.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/hooks.scala.html
@@ -12,9 +12,9 @@
         </div>
         <div class="panel-body">
           <p>
-            Webhooks allow external services to be notified when certain events happen within your repository.
-            When the specified events happen, we’ll send a POST request to each of the URLs you provide.
-            Learn more in <a href="https://github.com/takezoe/gitbucket/wiki/API-WebHook" target="_blank">GitBucket Wiki Webhook Page</a>.
+            Webhooks notify external services when certain events occur within this repository.
+            When any of the specified events occur, GitBucket will send a POST request to all of the endpoints (URLs) you provide.
+            Learn more about this feature on the <a href="https://github.com/takezoe/gitbucket/wiki/API-WebHook" target="_blank">GitBucket Wiki</a>.
           </p>
           <a href="@helpers.url(repository)/settings/hooks/new" class="btn btn-success pull-right" style="margin-bottom: 10px;">Add webhook</a>
 

--- a/src/main/twirl/gitbucket/core/settings/options.scala.html
+++ b/src/main/twirl/gitbucket/core/settings/options.scala.html
@@ -51,22 +51,22 @@
             <fieldset class="form-group">
               <div class="radio">
                 <label>
-                  <input type="radio" name="issuesOption" value="DISABLE" @if(repository.repository.options.issuesOption == "DISABLE"){ checked}> Disable issue tracking and pull request system
+                  <input type="radio" name="issuesOption" value="DISABLE" @if(repository.repository.options.issuesOption == "DISABLE"){ checked}> Disable issue tracking and pull requests
                 </label>
               </div>
               <div class="radio">
                 <label>
-                  <input type="radio" name="issuesOption" value="PRIVATE" @if(repository.repository.options.issuesOption == "PRIVATE"){ checked}> Developers can view, create and comment on issues and pull requests
+                  <input type="radio" name="issuesOption" value="PRIVATE" @if(repository.repository.options.issuesOption == "PRIVATE"){ checked}> Developers can view, create, and comment on issues and pull requests
                 </label>
               </div>
               <div class="radio">
                 <label>
-                  <input type="radio" name="issuesOption" value="PUBLIC" @if(repository.repository.options.issuesOption == "PUBLIC"){ checked}> Developers and guests can view, create and comment on issues and pull requests
+                  <input type="radio" name="issuesOption" value="PUBLIC" @if(repository.repository.options.issuesOption == "PUBLIC"){ checked}> Developers and guests can view, create, and comment on issues and pull requests
                 </label>
               </div>
               <div class="radio for-public-repo">
                 <label>
-                  <input type="radio" name="issuesOption" value="ALL" @if(repository.repository.options.issuesOption == "ALL"){ checked}> All users can view, create and comment on issues and pull requests
+                  <input type="radio" name="issuesOption" value="ALL" @if(repository.repository.options.issuesOption == "ALL"){ checked}> All users can view, create, and comment on issues and pull requests
                 </label>
               </div>
               <label for="externalIssuesUrl" class="strong">External URL:
@@ -87,17 +87,17 @@
               </div>
               <div class="radio">
                 <label>
-                  <input type="radio" name="wikiOption" value="PRIVATE" @if(repository.repository.options.wikiOption == "PRIVATE"){ checked}> Developers can view, create and edit wiki pages
+                  <input type="radio" name="wikiOption" value="PRIVATE" @if(repository.repository.options.wikiOption == "PRIVATE"){ checked}> Developers can view, create, and edit wiki pages
                 </label>
               </div>
               <div class="radio">
                 <label>
-                  <input type="radio" name="wikiOption" value="PUBLIC" @if(repository.repository.options.wikiOption == "PUBLIC"){ checked}> Developers and guests can view, create and edit wiki pages
+                  <input type="radio" name="wikiOption" value="PUBLIC" @if(repository.repository.options.wikiOption == "PUBLIC"){ checked}> Developers and guests can view, create, and edit wiki pages
                 </label>
               </div>
               <div class="radio for-public-repo">
                 <label>
-                  <input type="radio" name="wikiOption" value="ALL" @if(repository.repository.options.wikiOption == "ALL"){ checked}> All users can view, create and edit wiki pages
+                  <input type="radio" name="wikiOption" value="ALL" @if(repository.repository.options.wikiOption == "ALL"){ checked}> All users can view, create, and edit wiki pages
                 </label>
               </div>
               <label for="externalWikiUrl" class="strong">External URL:

--- a/src/main/twirl/gitbucket/core/signinform.scala.html
+++ b/src/main/twirl/gitbucket/core/signinform.scala.html
@@ -26,11 +26,19 @@
           <input type="password" name="password" id="password" class="form-control" value="@password"/>
         </div>
         <input type="hidden" name="hash"/>
-        <input type="submit" class="btn btn-success" value="Sign in" onClick="this.form.hash.value = window.location.hash;"/>
-        @if(systemSettings.allowAccountRegistration){
-          or <a href="@context.path/register">Create new account</a>
-        }
+        <div>
+          <input type="submit" class="btn btn-success btn-block" value="Sign in" onClick="this.form.hash.value = window.location.hash;"/>
+        </div>
       </form>
     </li>
   </ul>
 </div>
+@if(systemSettings.allowAccountRegistration){
+  <div class="panel panel-default">
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item text-center">
+        Don't have an account? <a href="@context.path/register">Create one.</a>
+      </li>
+    </ul>
+  </div>
+}

--- a/src/main/twirl/gitbucket/core/wiki/edit.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/edit.scala.html
@@ -33,7 +33,7 @@
       </div>
       <div class="form-group">
         <label for="message">Edit Message</label>
-        <input type="text" id="message" name="message" value="" class="form-control" placeholder="Write a small message here explaining this change. (Optional)"/>
+        <input type="text" id="message" name="message" value="" class="form-control" placeholder="(Optional) Write a summary of this edit."/>
       </div>
       <div class="form-group pull-right">
         <input type="hidden" name="currentPageName" value="@pageName"/>


### PR DESCRIPTION
There were some grammatical and spelling errors that bothered me, so I fixed them. I think. At least, the ones I noticed.
I also slightly modified the Sign In form to have a more consistent and better look.

Here's what it looks like now:
![](https://i.imgur.com/wEbuM8F.png)

It is functionally the same as it was before, but now it looks a little better.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
