### PR TITLE
Move the settings link down

### DIFF
--- a/src/main/twirl/gitbucket/core/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/menu.scala.html
@@ -53,13 +53,13 @@
           @menuitem(externalWikiUrl, "wiki", "Wiki", "book")
         }
       }
-      @if(context.loginAccount.isDefined && (context.loginAccount.get.isAdmin || repository.managers.contains(context.loginAccount.get.userName))){
-        @menuitem("/settings", "settings", "Settings", "gear")
-      }
       @gitbucket.core.plugin.PluginRegistry().getRepositoryMenus.map { menu =>
         @menu(repository, context).map { link =>
           @menuitem(link.path, link.id, link.label, link.icon.getOrElse("ruby"))
         }
+      }
+      @if(context.loginAccount.isDefined && (context.loginAccount.get.isAdmin || repository.managers.contains(context.loginAccount.get.userName))){
+        @menuitem("/settings", "settings", "Settings", "gear")
       }
     </ul>
   </div>


### PR DESCRIPTION
This pull request moves the `Settings` link to bottom of plugin links.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
