### PR TITLE
Add activity record for issue closing by comment

### DIFF
--- a/src/main/scala/gitbucket/core/service/MergeService.scala
+++ b/src/main/scala/gitbucket/core/service/MergeService.scala
@@ -215,6 +215,13 @@ trait MergeService {
                 .foreach { issueId =>
                   getIssue(localRepository.owner, localRepository.name, issueId.toString).foreach { issue =>
                     callIssuesWebHook("closed", localRepository, issue, loginAccount, settings)
+                    recordCloseIssueActivity(
+                      localRepository.owner,
+                      localRepository.name,
+                      localUserName,
+                      issue.issueId,
+                      issue.title
+                    )
                     PluginRegistry().getIssueHooks
                       .foreach(
                         _.closedByCommitComment(issue, localRepository, commit.fullMessage, loginAccount)
@@ -337,6 +344,13 @@ trait MergeService {
                           ).foreach { issueId =>
                             getIssue(repository.owner, repository.name, issueId.toString).foreach { issue =>
                               callIssuesWebHook("closed", repository, issue, loginAccount, context.settings)
+                              recordCloseIssueActivity(
+                                repository.owner,
+                                repository.name,
+                                loginAccount.userName,
+                                issue.issueId,
+                                issue.title
+                              )
                               PluginRegistry().getIssueHooks
                                 .foreach(_.closedByCommitComment(issue, repository, commit.fullMessage, loginAccount))
                             }
@@ -351,6 +365,13 @@ trait MergeService {
                         ).foreach { issueId =>
                           getIssue(repository.owner, repository.name, issueId.toString).foreach { issue =>
                             callIssuesWebHook("closed", repository, issue, loginAccount, context.settings)
+                            recordCloseIssueActivity(
+                              repository.owner,
+                              repository.name,
+                              loginAccount.userName,
+                              issue.issueId,
+                              issue.title
+                            )
                             PluginRegistry().getIssueHooks
                               .foreach(_.closedByCommitComment(issue, repository, issueContent, loginAccount))
                           }
@@ -359,6 +380,13 @@ trait MergeService {
                           .foreach { issueId =>
                             getIssue(repository.owner, repository.name, issueId.toString).foreach { issue =>
                               callIssuesWebHook("closed", repository, issue, loginAccount, context.settings)
+                              recordCloseIssueActivity(
+                                repository.owner,
+                                repository.name,
+                                loginAccount.userName,
+                                issue.issueId,
+                                issue.title
+                              )
                               PluginRegistry().getIssueHooks
                                 .foreach(_.closedByCommitComment(issue, repository, issueContent, loginAccount))
                             }

--- a/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
@@ -186,6 +186,13 @@ trait RepositoryCommitFileService {
               closeIssuesFromMessage(message, committerName, repository.owner, repository.name).foreach { issueId =>
                 getIssue(repository.owner, repository.name, issueId.toString).foreach { issue =>
                   callIssuesWebHook("closed", repository, issue, loginAccount, settings)
+                  recordCloseIssueActivity(
+                    repository.owner,
+                    repository.name,
+                    loginAccount.userName,
+                    issue.issueId,
+                    issue.title
+                  )
                   PluginRegistry().getIssueHooks
                     .foreach(_.closedByCommitComment(issue, repository, message, loginAccount))
                 }

--- a/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
@@ -322,6 +322,13 @@ class CommitLogHook(owner: String, repository: String, pusher: String, baseUrl: 
                       closeIssuesFromMessage(commit.fullMessage, pusher, owner, repository).foreach { issueId =>
                         getIssue(owner, repository, issueId.toString).foreach { issue =>
                           callIssuesWebHook("closed", repositoryInfo, issue, pusherAccount, settings)
+                          recordCloseIssueActivity(
+                            owner,
+                            repository,
+                            pusherAccount.userName,
+                            issue.issueId,
+                            issue.title
+                          )
                           PluginRegistry().getIssueHooks
                             .foreach(_.closedByCommitComment(issue, repositoryInfo, commit.fullMessage, pusherAccount))
                         }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Current GitBucket does not record activity when issue closed by comment such as `fix #1, #2`
This PR add activity record for issue closing by comment.