### PR TITLE
Max files for getting commit info becomes configurable

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -931,7 +931,14 @@ trait RepositoryViewerControllerBase extends ControllerBase {
                 if (path == ".") revCommit else JGitUtil.getLastModifiedCommit(git, revCommit, path)
               val commitCount = JGitUtil.getCommitCount(git, lastModifiedCommit.getName)
               // get files
-              val files = JGitUtil.getFileList(git, revision, path, context.settings.baseUrl, commitCount)
+              val files = JGitUtil.getFileList(
+                git,
+                revision,
+                path,
+                context.settings.baseUrl,
+                commitCount,
+                context.settings.repositoryViewer.maxFiles
+              )
               val parentPath = if (path == ".") Nil else path.split("/").toList
               // process README.md or README.markdown
               val readme = files

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -108,7 +108,10 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
       "timeout" -> trim(label("Timeout", long(required))),
       "largeMaxFileSize" -> trim(label("Max file size for large file", long(required))),
       "largeTimeout" -> trim(label("Timeout for large file", long(required)))
-    )(Upload.apply)
+    )(Upload.apply),
+    "repositoryViewer" -> mapping(
+      "maxFiles" -> trim(label("Max files", number(required)))
+    )(RepositoryViewerSettings.apply)
   )(SystemSettings.apply).verifying { settings =>
     Vector(
       if (settings.ssh.enabled && settings.baseUrl.isEmpty) {

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
@@ -42,11 +42,12 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
         case n =>
           (pathStr.take(n), pathStr.drop(n + 1))
       }
-      getFileList(git, revision, dirName).find(f => f.name.equals(fileName))
+      getFileList(git, revision, dirName, maxFiles = context.settings.repositoryViewer.maxFiles)
+        .find(_.name.equals(fileName))
     }
 
     Using.resource(Git.open(getRepositoryDir(params("owner"), params("repository")))) { git =>
-      val fileList = getFileList(git, refStr, path)
+      val fileList = getFileList(git, refStr, path, maxFiles = context.settings.repositoryViewer.maxFiles)
       if (fileList.isEmpty) { // file or NotFound
         getFileInfo(git, refStr, path)
           .flatMap { f =>

--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -740,9 +740,10 @@ trait RepositoryService {
 
     // Get template file from project root. When didn't find, will lookup default folder.
     Using.resource(Git.open(Directory.getRepositoryDir(repository.owner, repository.name))) { git =>
-      choiceTemplate(JGitUtil.getFileList(git, repository.repository.defaultBranch, "."))
+      // maxFiles = 1 means not get commit info because the only objectId and filename are necessary here
+      choiceTemplate(JGitUtil.getFileList(git, repository.repository.defaultBranch, ".", maxFiles = 1))
         .orElse {
-          choiceTemplate(JGitUtil.getFileList(git, repository.repository.defaultBranch, ".gitbucket"))
+          choiceTemplate(JGitUtil.getFileList(git, repository.repository.defaultBranch, ".gitbucket", maxFiles = 1))
         }
         .map { file =>
           JGitUtil.getContentFromId(git, file.id, true).collect {

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -82,6 +82,7 @@ trait SystemSettingsService {
       props.setProperty(UploadTimeout, settings.upload.timeout.toString)
       props.setProperty(UploadLargeMaxFileSize, settings.upload.largeMaxFileSize.toString)
       props.setProperty(UploadLargeTimeout, settings.upload.largeTimeout.toString)
+      props.setProperty(RepositoryViewerMaxFiles, settings.repositoryViewer.maxFiles.toString)
 
       Using.resource(new java.io.FileOutputStream(GitBucketConf)) { out =>
         props.store(out, null)
@@ -177,6 +178,9 @@ trait SystemSettingsService {
           getValue(props, UploadTimeout, 3 * 10000),
           getValue(props, UploadLargeMaxFileSize, 3 * 1024 * 1024),
           getValue(props, UploadLargeTimeout, 3 * 10000)
+        ),
+        RepositoryViewerSettings(
+          getValue(props, RepositoryViewerMaxFiles, 0)
         )
       )
     }
@@ -210,7 +214,8 @@ object SystemSettingsService {
     userDefinedCss: Option[String],
     showMailAddress: Boolean,
     webHook: WebHook,
-    upload: Upload
+    upload: Upload,
+    repositoryViewer: RepositoryViewerSettings
   ) {
 
     def baseUrl(request: HttpServletRequest): String =
@@ -300,6 +305,8 @@ object SystemSettingsService {
 
   case class Upload(maxFileSize: Long, timeout: Long, largeMaxFileSize: Long, largeTimeout: Long)
 
+  case class RepositoryViewerSettings(maxFiles: Int)
+
   val DefaultSshPort = 29418
   val DefaultSmtpPort = 25
   val DefaultLdapPort = 389
@@ -357,6 +364,7 @@ object SystemSettingsService {
   private val UploadTimeout = "upload.timeout"
   private val UploadLargeMaxFileSize = "upload.largeMaxFileSize"
   private val UploadLargeTimeout = "upload.largeTimeout"
+  private val RepositoryViewerMaxFiles = "repository_viewer_max_files"
 
   private def getValue[A: ClassTag](props: java.util.Properties, key: String, default: A): A = {
     getConfigValue(key).getOrElse {

--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -280,6 +280,25 @@
     <span class="strong">Limited</span> <span class="normal">- Show only owned repositories in sidebar.</span>
   </label>
 </fieldset>
+<!--====================================================================-->
+<!-- Repository viewer -->
+<!--====================================================================-->
+<hr>
+<label><span class="strong">Repository viewer</span></label>
+<fieldset>
+  <div class="form-group">
+    <label class="control-label col-md-2" for="repositoryViewerMaxFiles">Max files in directory</label>
+    <div class="col-md-10">
+      <input type="text" name="repositoryViewer.maxFiles" id="repositoryViewerMaxFiles" class="form-control" value="@context.settings.repositoryViewer.maxFiles"/>
+      <span id="error-repositoryViewerMaxFiles" class="error"></span>
+      <p class="muted">
+        If the number of files in the directory is bigger than this number, GitBucket doesn't show detailed commit info on the repository viewer
+        because it can make the entire system quite heavy. 0 or negative number means no limitation.
+      </p>
+    </div>
+  </div>
+</fieldset>
+
 <script>
 $(function(){
   $('#skinName').change(function(evt) {

--- a/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
+++ b/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
@@ -12,7 +12,7 @@ import java.sql.DriverManager
 import java.io.File
 
 import gitbucket.core.controller.Context
-import gitbucket.core.service.SystemSettingsService.{RepositoryOperation, Ssh, SystemSettings}
+import gitbucket.core.service.SystemSettingsService.{RepositoryOperation, RepositoryViewerSettings, Ssh, SystemSettings}
 import javax.servlet.http.{HttpServletRequest, HttpSession}
 import org.mockito.Mockito._
 
@@ -68,6 +68,9 @@ trait ServiceSpecBase {
         timeout = 30 * 10000,
         largeMaxFileSize = 3 * 1024 * 1024,
         largeTimeout = 30 * 10000
+      ),
+      repositoryViewer = RepositoryViewerSettings(
+        maxFiles = 0
       )
     )
 

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -7,7 +7,14 @@ import javax.servlet.http.{HttpServletRequest, HttpSession}
 import gitbucket.core.controller.Context
 import gitbucket.core.model.Account
 import gitbucket.core.service.RequestCache
-import gitbucket.core.service.SystemSettingsService.{RepositoryOperation, Ssh, SystemSettings, Upload, WebHook}
+import gitbucket.core.service.SystemSettingsService.{
+  RepositoryOperation,
+  RepositoryViewerSettings,
+  Ssh,
+  SystemSettings,
+  Upload,
+  WebHook
+}
 import org.mockito.Mockito._
 import org.scalatest.funspec.AnyFunSpec
 import play.twirl.api.Html
@@ -154,6 +161,9 @@ class AvatarImageProviderSpec extends AnyFunSpec {
         timeout = 30 * 10000,
         largeMaxFileSize = 3 * 1024 * 1024,
         largeTimeout = 30 * 10000
+      ),
+      repositoryViewer = RepositoryViewerSettings(
+        maxFiles = 0
       )
     )
 


### PR DESCRIPTION
Closes #2507

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
