### PR TITLE
Show userName as link only when a user is not removed

### DIFF
--- a/src/main/twirl/gitbucket/core/admin/userlist.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/userlist.scala.html
@@ -27,7 +27,11 @@
             </div>
             <div class="strong">
               @helpers.avatarLink(account.userName, 20)
-              <a href="@helpers.url(account.userName)">@account.userName</a>
+              @if(account.isRemoved){
+                @account.userName
+              } else {
+                <a href="@helpers.url(account.userName)">@account.userName</a>
+              }
               @if(account.isGroupAccount){
                 (Group)
               } else {


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

### before
![before](https://user-images.githubusercontent.com/17608272/90496143-6f719680-e180-11ea-864f-e502ff1d1ffc.gif)

-----

### after
![after](https://user-images.githubusercontent.com/17608272/90496137-6e406980-e180-11ea-987b-af70d38ca7a1.gif)


