### PR TITLE
Support update latest activity date for commits file via WebUI

### DIFF
--- a/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
@@ -17,7 +17,12 @@ import org.eclipse.jgit.transport.{ReceiveCommand, ReceivePack}
 import scala.util.Using
 
 trait RepositoryCommitFileService {
-  self: AccountService with ActivityService with IssuesService with PullRequestService with WebHookPullRequestService =>
+  self: AccountService
+    with ActivityService
+    with IssuesService
+    with PullRequestService
+    with WebHookPullRequestService
+    with RepositoryService =>
   import RepositoryCommitFileService._
 
   def commitFiles(
@@ -175,6 +180,7 @@ trait RepositoryCommitFileService {
             updatePullRequests(repository.owner, repository.name, branch, loginAccount, "synchronize", settings)
 
             // record activity
+            updateLastActivityDate(repository.owner, repository.name)
             val commitInfo = new CommitInfo(JGitUtil.getRevCommitFromId(git, commitId))
             recordPushActivity(repository.owner, repository.name, loginAccount.userName, branch, List(commitInfo))
 


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct


# About this PR

This resolve #2524 .