### PR TITLE
Add list-public-repositories API

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryControllerBase.scala
@@ -56,7 +56,7 @@ trait ApiRepositoryControllerBase extends ControllerBase {
 
   /**
    * iv. List all public repositories
-   * https://developer.github.com/v3/repos/#list-all-public-repositories
+   * https://developer.github.com/v3/repos/#list-public-repositories
    */
   get("/api/v3/repositories") {
     JsonFormat(getPublicRepositories().map { r =>

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryControllerBase.scala
@@ -54,11 +54,15 @@ trait ApiRepositoryControllerBase extends ControllerBase {
     })
   }
 
-  /*
+  /**
    * iv. List all public repositories
    * https://developer.github.com/v3/repos/#list-all-public-repositories
-   * Not implemented
    */
+  get("/api/v3/repositories") {
+    JsonFormat(getPublicRepositories().map { r =>
+      ApiRepository(r, getAccountByUserName(r.owner).get)
+    })
+  }
 
   /*
    * v. Create

--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -381,6 +381,21 @@ trait RepositoryService {
   }
 
   /**
+   * Returns the all public repositories.
+   *
+   * @return the repository information list
+   */
+  def getPublicRepositories(withoutPhysicalInfo: Boolean = false)(implicit s: Session): List[RepositoryInfo] = {
+    Repositories
+      .filter { t1 =>
+        t1.isPrivate === false.bind
+      }
+      .sortBy(_.lastActivityDate desc)
+      .list
+      .map(createRepositoryInfo(_, withoutPhysicalInfo))
+  }
+
+  /**
    * Returns the list of repositories which are owned by the specified user.
    * This list includes group repositories if the specified user is a member of the group.
    */


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR.

This PR adds list public repositories API.
https://docs.github.com/en/rest/reference/repos#list-public-repositories

but still since param is not suppoted.