### PR TITLE
Add get-a-repository-README endpoint

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -908,10 +908,6 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     lazy val isValid: Boolean = fileIds.nonEmpty
   }
 
-  private val readmeFiles = PluginRegistry().renderableExtensions.map { extension =>
-    s"readme.${extension}"
-  } ++ Seq("readme.txt", "readme")
-
   /**
    * Provides HTML of the file list.
    *

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
@@ -13,10 +13,13 @@ import scala.util.Using
 trait ApiRepositoryContentsControllerBase extends ControllerBase {
   self: ReferrerAuthenticator with WritableUsersAuthenticator with RepositoryCommitFileService =>
 
-  /*
+  /**
    * i. Get the README
    * https://developer.github.com/v3/repos/contents/#get-the-readme
    */
+  get("/api/v3/repos/:owner/:repository/readme")(referrersOnly { repository =>
+    getContents(repository, "README.md", params.getOrElse("ref", repository.repository.defaultBranch))
+  })
 
   /**
    * ii. Get contents

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
@@ -41,18 +41,18 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
     repository: RepositoryService.RepositoryInfo,
     path: String,
     refStr: String,
-    matchByLowCase: Boolean = false
+    ignoreCase: Boolean = false
   ) = {
-    def getFileInfo(git: Git, revision: String, pathStr: String, matchByLowCase: Boolean): Option[FileInfo] = {
+    def getFileInfo(git: Git, revision: String, pathStr: String, ignoreCase: Boolean): Option[FileInfo] = {
       val (dirName, fileName) = pathStr.lastIndexOf('/') match {
         case -1 =>
           (".", pathStr)
         case n =>
           (pathStr.take(n), pathStr.drop(n + 1))
       }
-      if (matchByLowCase) {
+      if (ignoreCase) {
         getFileList(git, revision, dirName, maxFiles = context.settings.repositoryViewer.maxFiles)
-          .find(_.name.toLowerCase.equals(if (matchByLowCase) { fileName.toLowerCase } else fileName))
+          .find(_.name.toLowerCase.equals(fileName.toLowerCase))
       } else {
         getFileList(git, revision, dirName, maxFiles = context.settings.repositoryViewer.maxFiles)
           .find(_.name.equals(fileName))
@@ -62,7 +62,7 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
     Using.resource(Git.open(getRepositoryDir(params("owner"), params("repository")))) { git =>
       val fileList = getFileList(git, refStr, path, maxFiles = context.settings.repositoryViewer.maxFiles)
       if (fileList.isEmpty) { // file or NotFound
-        getFileInfo(git, refStr, path, matchByLowCase)
+        getFileInfo(git, refStr, path, ignoreCase)
           .flatMap { f =>
             val largeFile = params.get("large_file").exists(s => s.equals("true"))
             val content = getContentFromId(git, f.id, largeFile)

--- a/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
@@ -116,6 +116,11 @@ trait RepositoryCommitFileService {
     }
   }
 
+  def readmeFiles: Seq[String] =
+    PluginRegistry().renderableExtensions.map { extension =>
+      s"readme.${extension}"
+    } ++ Seq("readme.txt", "readme")
+
   private def _commitFile(
     repository: RepositoryService.RepositoryInfo,
     branch: String,


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR add an "Get a repository README" [API endpoint](https://developer.github.com/v3/repos/contents/#get-a-repository-readme).