### PR TITLE
Add get-an-issue-comment API endpoint

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
@@ -39,15 +39,14 @@ trait ApiIssueCommentControllerBase extends ControllerBase {
    * https://docs.github.com/en/rest/reference/issues#get-an-issue-comment
    */
   get("/api/v3/repos/:owner/:repository/issues/comments/:id")(referrersOnly { repository =>
-    (for {
-      commentId <- params("id").toIntOpt
-      comments = getCommentForApi(repository.owner, repository.name, commentId)
-    } yield {
-      JsonFormat(comments.map {
-        case (issueComment, user, issue) =>
+    val commentId = params("id").toInt
+    getCommentForApi(repository.owner, repository.name, commentId) match {
+      case Some((issueComment, user, issue)) =>
+        JsonFormat(
           ApiComment(issueComment, RepositoryName(repository), issue.issueId, ApiUser(user), issue.isPullRequest)
-      })
-    }) getOrElse NotFound()
+        )
+      case _ => NotFound()
+    }
   })
 
   /*

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
@@ -36,7 +36,7 @@ trait ApiIssueCommentControllerBase extends ControllerBase {
 
   /*
    * iii. Get an issue comment
-   * https://developer.github.com/v3/issues/comments/#get-an-issue-comment
+   * https://docs.github.com/en/rest/reference/issues#get-an-issue-comment
    */
   get("/api/v3/repos/:owner/:repository/issues/comments/:id")(referrersOnly { repository =>
     (for {

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
@@ -35,9 +35,20 @@ trait ApiIssueCommentControllerBase extends ControllerBase {
    */
 
   /*
-   * iii. Get a single comment
-   * https://developer.github.com/v3/issues/comments/#get-a-single-comment
+   * iii. Get an issue comment
+   * https://developer.github.com/v3/issues/comments/#get-an-issue-comment
    */
+  get("/api/v3/repos/:owner/:repository/issues/comments/:id")(referrersOnly { repository =>
+    (for {
+      commentId <- params("id").toIntOpt
+      comments = getCommentForApi(repository.owner, repository.name, commentId)
+    } yield {
+      JsonFormat(comments.map {
+        case (issueComment, user, issue) =>
+          ApiComment(issueComment, RepositoryName(repository), issue.issueId, ApiUser(user), issue.isPullRequest)
+      })
+    }) getOrElse NotFound()
+  })
 
   /*
    * iv. Create a comment

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -73,7 +73,7 @@ trait IssuesService {
 
   def getCommentForApi(owner: String, repository: String, commentId: Int)(
     implicit s: Session
-  ): List[(IssueComment, Account, Issue)] =
+  ): Option[(IssueComment, Account, Issue)] =
     IssueComments
       .filter(_.byRepository(owner, repository))
       .filter(_.commentId === commentId)
@@ -83,7 +83,7 @@ trait IssuesService {
       .join(Issues)
       .on { case t1 ~ t2 ~ t3 => t3.byIssue(t1.userName, t1.repositoryName, t1.issueId) }
       .map { case t1 ~ t2 ~ t3 => (t1, t2, t3) }
-      .list
+      .firstOption
 
   def getIssueLabels(owner: String, repository: String, issueId: Int)(implicit s: Session): List[Label] = {
     IssueLabels

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -71,6 +71,20 @@ trait IssuesService {
     else None
   }
 
+  def getCommentForApi(owner: String, repository: String, commentId: Int)(
+    implicit s: Session
+  ): List[(IssueComment, Account, Issue)] =
+    IssueComments
+      .filter(_.byRepository(owner, repository))
+      .filter(_.commentId === commentId)
+      .filter(_.action inSetBind Set("comment", "close_comment", "reopen_comment"))
+      .join(Accounts)
+      .on { case t1 ~ t2 => t1.commentedUserName === t2.userName }
+      .join(Issues)
+      .on { case t1 ~ t2 ~ t3 => t3.byIssue(t1.userName, t1.repositoryName, t1.issueId) }
+      .map { case t1 ~ t2 ~ t3 => (t1, t2, t3) }
+      .list
+
   def getIssueLabels(owner: String, repository: String, issueId: Int)(implicit s: Session): List[Label] = {
     IssueLabels
       .join(Labels)


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR add "get-an-issue-comment" [API endpoint](https://developer.github.com/v3/issues/comments/#get-an-issue-comment).