### PR TITLE
adding support for wiki page deletion recording

### DIFF
--- a/src/main/scala/gitbucket/core/controller/WikiController.scala
+++ b/src/main/scala/gitbucket/core/controller/WikiController.scala
@@ -1,7 +1,7 @@
 package gitbucket.core.controller
 
 import gitbucket.core.model.WebHook
-import gitbucket.core.model.activity.{CreateWikiPageInfo, EditWikiPageInfo}
+import gitbucket.core.model.activity.{CreateWikiPageInfo, DeleteWikiInfo, EditWikiPageInfo}
 import gitbucket.core.service.RepositoryService.RepositoryInfo
 import gitbucket.core.service.WebHookService.WebHookGollumPayload
 import gitbucket.core.wiki.html
@@ -251,14 +251,13 @@ trait WikiControllerBase extends ControllerBase {
       val pageName = StringUtil.urlDecode(params("page"))
 
       defining(context.loginAccount.get) { loginAccount =>
-        deleteWikiPage(
+        val deleteWikiInfo = DeleteWikiInfo(
           repository.owner,
           repository.name,
-          pageName,
-          loginAccount.fullName,
-          loginAccount.mailAddress,
-          s"Destroyed ${pageName}"
+          loginAccount.userName,
+          pageName
         )
+        recordActivity(deleteWikiInfo)
         updateLastActivityDate(repository.owner, repository.name)
 
         redirect(s"/${repository.owner}/${repository.name}/wiki")

--- a/src/main/scala/gitbucket/core/model/activity/WikiActivityInfo.scala
+++ b/src/main/scala/gitbucket/core/model/activity/WikiActivityInfo.scala
@@ -45,3 +45,23 @@ final case class EditWikiPageInfo(
       UUID.randomUUID().toString
     )
 }
+
+final case class DeleteWikiInfo(
+  userName: String,
+  repositoryName: String,
+  activityUserName: String,
+  pageName: String,
+) extends BaseActivityInfo {
+
+  override def toActivity: Activity =
+    Activity(
+      userName,
+      repositoryName,
+      activityUserName,
+      "delete_wiki",
+      s"[user:$activityUserName] deleted the page [$pageName] in the [repo:$userName/$repositoryName] wiki",
+      additionalInfo = None,
+      currentDate,
+      UUID.randomUUID().toString
+    )
+}


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

I can't appear to close issues, so I'll leave the last one unchecked. This is work that was initially done in #2523, but the commits got messed up somehow.
