### PR TITLE
Add update-an-issue-comment API

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
@@ -89,11 +89,14 @@ trait ApiIssueCommentControllerBase extends ControllerBase {
                           issue.isPullRequest
                         )
                       )
+                    case _ => NotFound()
                   }
+                case _ => NotFound()
               }
             } else {
               Unauthorized()
             }
+          case _ => NotFound()
         }
       case _ => NotFound()
     }

--- a/src/main/scala/gitbucket/core/plugin/IssueHook.scala
+++ b/src/main/scala/gitbucket/core/plugin/IssueHook.scala
@@ -13,6 +13,10 @@ trait IssueHook {
     implicit session: Session,
     context: Context
   ): Unit = ()
+  def updatedComment(commentId: Int, content: String, issue: Issue, repository: RepositoryInfo)(
+    implicit session: Session,
+    context: Context
+  ): Unit = ()
   def closed(issue: Issue, repository: RepositoryInfo)(implicit session: Session, context: Context): Unit = ()
   def reopened(issue: Issue, repository: RepositoryInfo)(implicit session: Session, context: Context): Unit = ()
   def assigned(


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR add [API endpoint of "Update an issue comment"](https://developer.github.com/v3/issues/comments/#update-an-issue-comment).