### PR TITLE
Add "has_issue" boolean to GET /repos/:owner/:repo API

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiRepository.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRepository.scala
@@ -30,8 +30,7 @@ object ApiRepository {
     repository: Repository,
     owner: ApiUser,
     forkedCount: Int = 0,
-    watchers: Int = 0,
-    issueCount: Int = 0
+    watchers: Int = 0
   ): ApiRepository =
     ApiRepository(
       name = repository.repositoryName,
@@ -42,15 +41,14 @@ object ApiRepository {
       `private` = repository.isPrivate,
       default_branch = repository.defaultBranch,
       owner = owner,
-      has_issues = issueCount > 0
+      has_issues = if(repository.options.issuesOption == "DISABLE") false else true
     )
 
   def apply(repositoryInfo: RepositoryInfo, owner: ApiUser): ApiRepository =
     ApiRepository(
       repositoryInfo.repository,
       owner,
-      forkedCount = repositoryInfo.forkedCount,
-      issueCount = repositoryInfo.issueCount
+      forkedCount = repositoryInfo.forkedCount
     )
 
   def apply(repositoryInfo: RepositoryInfo, owner: Account): ApiRepository =

--- a/src/main/scala/gitbucket/core/api/ApiRepository.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRepository.scala
@@ -64,6 +64,6 @@ object ApiRepository {
       `private` = false,
       default_branch = "master",
       owner = owner,
-      has_issues = false
+      has_issues = true
     )
 }

--- a/src/main/scala/gitbucket/core/api/ApiRepository.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRepository.scala
@@ -12,7 +12,8 @@ case class ApiRepository(
   forks: Int,
   `private`: Boolean,
   default_branch: String,
-  owner: ApiUser
+  owner: ApiUser,
+  has_issues: Boolean
 ) {
   val id = 0 // dummy id
   val forks_count = forks
@@ -29,7 +30,8 @@ object ApiRepository {
     repository: Repository,
     owner: ApiUser,
     forkedCount: Int = 0,
-    watchers: Int = 0
+    watchers: Int = 0,
+    issueCount: Int = 0
   ): ApiRepository =
     ApiRepository(
       name = repository.repositoryName,
@@ -39,11 +41,17 @@ object ApiRepository {
       forks = forkedCount,
       `private` = repository.isPrivate,
       default_branch = repository.defaultBranch,
-      owner = owner
+      owner = owner,
+      has_issues = issueCount > 0
     )
 
   def apply(repositoryInfo: RepositoryInfo, owner: ApiUser): ApiRepository =
-    ApiRepository(repositoryInfo.repository, owner, forkedCount = repositoryInfo.forkedCount)
+    ApiRepository(
+      repositoryInfo.repository,
+      owner,
+      forkedCount = repositoryInfo.forkedCount,
+      issueCount = repositoryInfo.issueCount
+    )
 
   def apply(repositoryInfo: RepositoryInfo, owner: Account): ApiRepository =
     this(repositoryInfo, ApiUser(owner))
@@ -57,6 +65,7 @@ object ApiRepository {
       forks = 0,
       `private` = false,
       default_branch = "master",
-      owner = owner
+      owner = owner,
+      has_issues = false
     )
 }

--- a/src/main/scala/gitbucket/core/api/ApiRepository.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRepository.scala
@@ -41,7 +41,7 @@ object ApiRepository {
       `private` = repository.isPrivate,
       default_branch = repository.defaultBranch,
       owner = owner,
-      has_issues = if(repository.options.issuesOption == "DISABLE") false else true
+      has_issues = if (repository.options.issuesOption == "DISABLE") false else true
     )
 
   def apply(repositoryInfo: RepositoryInfo, owner: ApiUser): ApiRepository =

--- a/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
+++ b/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
@@ -184,7 +184,8 @@ object ApiSpecModels {
     repository = repository,
     owner = apiUser,
     forkedCount = repositoryInfo.forkedCount,
-    watchers = 0
+    watchers = 0,
+    issueCount = repositoryInfo.issueCount
   )
 
   val apiLabel = ApiLabel(
@@ -444,6 +445,7 @@ object ApiSpecModels {
        |"private":false,
        |"default_branch":"master",
        |"owner":$jsonUser,
+       |"has_issues":true,
        |"id":0,
        |"forks_count":1,
        |"watchers_count":0,

--- a/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
+++ b/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
@@ -184,8 +184,7 @@ object ApiSpecModels {
     repository = repository,
     owner = apiUser,
     forkedCount = repositoryInfo.forkedCount,
-    watchers = 0,
-    issueCount = repositoryInfo.issueCount
+    watchers = 0
   )
 
   val apiLabel = ApiLabel(


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR add `has_issue` bool to response of GET /repos/:owner/:repo API and resolve #2462 .
