### PR TITLE
Add list repository tags API

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiTag.scala
+++ b/src/main/scala/gitbucket/core/api/ApiTag.scala
@@ -1,0 +1,29 @@
+package gitbucket.core.api
+
+import gitbucket.core.util.RepositoryName
+
+case class ApiTagCommit(
+  sha: String,
+  url: ApiPath
+)
+
+case class ApiTag(
+  name: String,
+  commit: ApiTagCommit,
+  zipball_url: ApiPath,
+  tarball_url: ApiPath
+)
+
+object ApiTag {
+  def apply(
+    tagName: String,
+    repositoryName: RepositoryName,
+    commitId: String
+  ): ApiTag =
+    ApiTag(
+      name = tagName,
+      commit = ApiTagCommit(sha = commitId, url = ApiPath(s"/${repositoryName.fullName}/commits/${commitId}")),
+      zipball_url = ApiPath(s"/${repositoryName.fullName}/zipball/${tagName}"),
+      tarball_url = ApiPath(s"/${repositoryName.fullName}/tarball/${tagName}")
+    )
+}

--- a/src/main/scala/gitbucket/core/api/ApiTag.scala
+++ b/src/main/scala/gitbucket/core/api/ApiTag.scala
@@ -23,7 +23,7 @@ object ApiTag {
     ApiTag(
       name = tagName,
       commit = ApiTagCommit(sha = commitId, url = ApiPath(s"/${repositoryName.fullName}/commits/${commitId}")),
-      zipball_url = ApiPath(s"/${repositoryName.fullName}/zipball/${tagName}"),
-      tarball_url = ApiPath(s"/${repositoryName.fullName}/tarball/${tagName}")
+      zipball_url = ApiPath(s"/${repositoryName.fullName}/archive/${tagName}.zip"),
+      tarball_url = ApiPath(s"/${repositoryName.fullName}/archive/${tagName}.tar.gz")
     )
 }

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryControllerBase.scala
@@ -178,9 +178,14 @@ trait ApiRepositoryControllerBase extends ControllerBase {
    */
 
   /*
-   * xiii. List tags
-   * https://developer.github.com/v3/repos/#list-tags
+   * xiii. List repository tags
+   * https://docs.github.com/en/rest/reference/repos#list-repository-tags
    */
+  get("/api/v3/repos/:owner/:repository/tags")(referrersOnly { repository =>
+    JsonFormat(
+      repository.tags.map(tagInfo => ApiTag(tagInfo.name, RepositoryName(repository), tagInfo.id))
+    )
+  })
 
   /*
    * xiv. Delete a repository


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct


### About this PR

Tis PR add [List repository tags API](https://docs.github.com/en/rest/reference/repos#list-repository-tags).
Maybe related to #2506 ...??

Note: [`zipball_url` and `tarball_url`](https://docs.github.com/en/rest/reference/repos#download-a-repository-archive) is not supported by GitBucket, yet I added to follow GitHub structure response. 