### PR TITLE
Add list-milestones and get-a-milestone API

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiMilestone.scala
+++ b/src/main/scala/gitbucket/core/api/ApiMilestone.scala
@@ -1,0 +1,52 @@
+package gitbucket.core.api
+
+import gitbucket.core.model.{Milestone, Repository}
+import gitbucket.core.util.RepositoryName
+import java.util.Date
+
+/**
+ * https://docs.github.com/en/rest/reference/issues#milestones
+ */
+case class ApiMilestone(
+  url: ApiPath,
+//  html_url: ApiPath,
+//  label_url: ApiPath,
+  id: Int,
+  number: Int,
+  state: String,
+  title: String,
+  description: String,
+  creator: ApiUser,
+  open_issues: Int,
+  closed_issues: Int,
+//  created_at: Option[Date],
+//  updated_at: Option[Date],
+  closed_at: Option[Date],
+  due_on: Option[Date]
+)
+
+object ApiMilestone {
+  def apply(
+    repository: Repository,
+    milestone: Milestone,
+    user: ApiUser,
+    milestone_number: Int,
+    open_issue_count: Int = 0,
+    closed_issue_count: Int = 0
+  ): ApiMilestone =
+    ApiMilestone(
+      url = ApiPath(s"/api/v3/repos/${RepositoryName(repository).fullName}/milestones/${milestone_number}"),
+//      html_url = ApiPath(s"/${RepositoryName(repository).fullName}/milestones/${milestone.title}"),
+//      label_url = ApiPath(s"/api/v3/repos/${RepositoryName(repository).fullName}/milestones/${milestone_number}/labels"),
+      id = milestone.milestoneId,
+      number = milestone_number,
+      state = if (milestone.closedDate.isDefined) "closed" else "open",
+      title = milestone.title,
+      description = milestone.description.getOrElse(""),
+      creator = user,
+      open_issues = open_issue_count,
+      closed_issues = closed_issue_count,
+      closed_at = milestone.closedDate,
+      due_on = milestone.dueDate
+    )
+}

--- a/src/main/scala/gitbucket/core/api/ApiMilestone.scala
+++ b/src/main/scala/gitbucket/core/api/ApiMilestone.scala
@@ -9,7 +9,7 @@ import java.util.Date
  */
 case class ApiMilestone(
   url: ApiPath,
-//  html_url: ApiPath,
+  html_url: ApiPath,
 //  label_url: ApiPath,
   id: Int,
   number: Int,
@@ -36,7 +36,7 @@ object ApiMilestone {
   ): ApiMilestone =
     ApiMilestone(
       url = ApiPath(s"/api/v3/repos/${RepositoryName(repository).fullName}/milestones/${milestone_number}"),
-//      html_url = ApiPath(s"/${RepositoryName(repository).fullName}/milestones/${milestone.title}"),
+      html_url = ApiPath(s"/${RepositoryName(repository).fullName}/issues?milestone=${milestone.title}&state=open"),
 //      label_url = ApiPath(s"/api/v3/repos/${RepositoryName(repository).fullName}/milestones/${milestone_number}/labels"),
       id = milestone.milestoneId,
       number = milestone_number,

--- a/src/main/scala/gitbucket/core/api/ApiMilestone.scala
+++ b/src/main/scala/gitbucket/core/api/ApiMilestone.scala
@@ -30,16 +30,15 @@ object ApiMilestone {
     repository: Repository,
     milestone: Milestone,
     user: ApiUser,
-    milestone_number: Int,
     open_issue_count: Int = 0,
     closed_issue_count: Int = 0
   ): ApiMilestone =
     ApiMilestone(
-      url = ApiPath(s"/api/v3/repos/${RepositoryName(repository).fullName}/milestones/${milestone_number}"),
+      url = ApiPath(s"/api/v3/repos/${RepositoryName(repository).fullName}/milestones/${milestone.milestoneId}"),
       html_url = ApiPath(s"/${RepositoryName(repository).fullName}/issues?milestone=${milestone.title}&state=open"),
 //      label_url = ApiPath(s"/api/v3/repos/${RepositoryName(repository).fullName}/milestones/${milestone_number}/labels"),
       id = milestone.milestoneId,
-      number = milestone_number,
+      number = milestone.milestoneId, // use milestoneId as number
       state = if (milestone.closedDate.isDefined) "closed" else "open",
       title = milestone.title,
       description = milestone.description.getOrElse(""),

--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -13,6 +13,7 @@ class ApiController
     with ApiIssueCommentControllerBase
     with ApiIssueControllerBase
     with ApiIssueLabelControllerBase
+    with ApiIssueMilestoneControllerBase
     with ApiOrganizationControllerBase
     with ApiPullRequestControllerBase
     with ApiReleaseControllerBase

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueMilestoneControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueMilestoneControllerBase.scala
@@ -1,0 +1,82 @@
+package gitbucket.core.controller.api
+import gitbucket.core.api._
+import gitbucket.core.controller.ControllerBase
+import gitbucket.core.service.{AccountService, IssueCreationService, IssuesService, MilestonesService}
+import gitbucket.core.util.{ReadableUsersAuthenticator, ReferrerAuthenticator}
+import gitbucket.core.util.Implicits._
+
+trait ApiIssueMilestoneControllerBase extends ControllerBase {
+  self: AccountService
+    with IssuesService
+    with IssueCreationService
+    with MilestonesService
+    with ReadableUsersAuthenticator
+    with ReferrerAuthenticator =>
+
+  /*
+   * i. List milestones
+   * https://docs.github.com/en/rest/reference/issues#list-milestones
+   */
+  get("/api/v3/repos/:owner/:repository/milestones")(referrersOnly { repository =>
+    val state = params.getOrElse("state", "all")
+    // TODO "sort", "direction" params should be implemented.
+    val apiMilestones = (for ((milestoneWithIssue, i) <- getMilestonesWithIssueCount(repository.owner, repository.name)
+                                .sortBy(p => p._1.milestoneId)
+                                .zipWithIndex)
+      yield {
+        ApiMilestone(
+          repository.repository,
+          milestoneWithIssue._1,
+          ApiUser(context.loginAccount.get),
+          i + 1,
+          milestoneWithIssue._2,
+          milestoneWithIssue._3
+        )
+      }).reverse
+    state match {
+      case "all" => JsonFormat(apiMilestones)
+      case "open" | "closed" =>
+        JsonFormat(
+          apiMilestones.filter(p => p.state == state)
+        )
+      case _ => NotFound()
+    }
+  })
+
+  /*
+   * ii. Create a milestone
+   * https://docs.github.com/en/rest/reference/issues#create-a-milestone
+   */
+
+  /*
+   * iii. Get a milestone
+   * https://docs.github.com/en/rest/reference/issues#get-a-milestone
+   */
+  get("/api/v3/repos/:owner/:repository/milestones/:number")(referrersOnly { repository =>
+    val milestoneNumber = params("number").toInt
+    val milestoneWithIssue = getMilestonesWithIssueCount(repository.owner, repository.name)
+      .sortBy(p => p._1.milestoneId)
+      .apply(milestoneNumber - 1)
+    JsonFormat(
+      ApiMilestone(
+        repository.repository,
+        milestoneWithIssue._1,
+        ApiUser(context.loginAccount.get),
+        milestoneNumber,
+        milestoneWithIssue._2,
+        milestoneWithIssue._3
+      )
+    )
+  })
+
+  /*
+   * iv.Update a milestone
+   * https://docs.github.com/en/rest/reference/issues#update-a-milestone
+   */
+
+  /*
+ * v. Delete a milestone
+ * https://docs.github.com/en/rest/reference/issues#delete-a-milestone
+ */
+
+}


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR add api endpoints for milestones below.

- [List milestones](https://docs.github.com/en/rest/reference/issues#list-milestones)
- [Get a milestone](https://docs.github.com/en/rest/reference/issues#get-a-milestone)
- [Delete a milestone](https://docs.github.com/en/rest/reference/issues#delete-a-milestone)

