### PR TITLE
Add list-branches-for-head-commit API

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiBranch.scala
+++ b/src/main/scala/gitbucket/core/api/ApiBranch.scala
@@ -22,3 +22,12 @@ case class ApiBranchForList(
   name: String,
   commit: ApiBranchCommit
 )
+
+/**
+ * https://docs.github.com/en/rest/reference/repos#list-branches-for-head-commit
+ */
+case class ApiBranchForHeadCommit(
+  name: String,
+  commit: ApiBranchCommit,
+  `protected`: Boolean
+)

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryCommitControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryCommitControllerBase.scala
@@ -1,19 +1,20 @@
 package gitbucket.core.controller.api
-import gitbucket.core.api.{ApiCommits, JsonFormat}
+import gitbucket.core.api.{ApiBranchCommit, ApiBranchForHeadCommit, ApiCommits, JsonFormat}
 import gitbucket.core.controller.ControllerBase
 import gitbucket.core.model.Account
-import gitbucket.core.service.{AccountService, CommitsService}
+import gitbucket.core.service.{AccountService, CommitsService, ProtectedBranchService}
 import gitbucket.core.util.Directory.getRepositoryDir
 import gitbucket.core.util.Implicits._
-import gitbucket.core.util.JGitUtil.CommitInfo
+import gitbucket.core.util.JGitUtil.{CommitInfo, getBranches, getBranchesOfCommit}
 import gitbucket.core.util.{JGitUtil, ReferrerAuthenticator, RepositoryName}
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.revwalk.RevWalk
+
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
 trait ApiRepositoryCommitControllerBase extends ControllerBase {
-  self: AccountService with CommitsService with ReferrerAuthenticator =>
+  self: AccountService with CommitsService with ProtectedBranchService with ReferrerAuthenticator =>
   /*
    * i. List commits on a repository
    * https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
@@ -107,7 +108,25 @@ trait ApiRepositoryCommitControllerBase extends ControllerBase {
    */
 
   /*
- * v. Commit signature verification
- * https://developer.github.com/v3/repos/commits/#commit-signature-verification
- */
+   * v. Commit signature verification
+   * https://developer.github.com/v3/repos/commits/#commit-signature-verification
+   */
+
+  /*
+   * vi. List branches for HEAD commit
+   * https://docs.github.com/en/rest/reference/repos#list-branches-for-head-commit
+   */
+  get("/api/v3/repos/:owner/:repository/commits/:sha/branches-where-head")(referrersOnly { repository =>
+    val sha = params("sha")
+    Using.resource(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
+      val apiBranchForCommits = for {
+        branch <- getBranchesOfCommit(git, sha)
+        br <- getBranches(git, branch, repository.repository.originUserName.isEmpty).find(_.name == branch)
+      } yield {
+        val protection = getProtectedBranchInfo(repository.owner, repository.name, branch)
+        ApiBranchForHeadCommit(branch, ApiBranchCommit(br.commitId), protection.enabled)
+      }
+      JsonFormat(apiBranchForCommits)
+    }
+  })
 }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR add [List branches for HEAD commit](https://docs.github.com/en/rest/reference/repos#list-branches-for-head-commit).