### PR TITLE
Use attr() instead of data() to prevent parsing of json

### DIFF
--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -77,10 +77,12 @@ function displayErrors(data, elem){
  */
 function diffUsingJS(oldTextId, newTextId, outputId, viewType, ignoreSpace) {
   var old = $('#' + oldTextId), head = $('#' + newTextId);
+  old.is("textarea") ? (oldTextValue = old.data('val')) : (oldTextValue = old.attr('data-val'));
+  head.is("textarea") ? (headTextvalue = head.data('val')) : (headTextValue = head.attr('data-val'));
   var render = new JsDiffRender({
-    oldText    : old.attr('data-val'),
+    oldText    : oldTextValue,
     oldTextName: old.data('file-name'),
-    newText    : head.attr('data-val'),
+    newText    : headTextValue,
     newTextName: head.data('file-name'),
     ignoreSpace: ignoreSpace,
     contextSize: 4

--- a/src/main/webapp/assets/common/js/gitbucket.js
+++ b/src/main/webapp/assets/common/js/gitbucket.js
@@ -78,9 +78,9 @@ function displayErrors(data, elem){
 function diffUsingJS(oldTextId, newTextId, outputId, viewType, ignoreSpace) {
   var old = $('#' + oldTextId), head = $('#' + newTextId);
   var render = new JsDiffRender({
-    oldText    : old.data('val'),
+    oldText    : old.attr('data-val'),
     oldTextName: old.data('file-name'),
-    newText    : head.data('val'),
+    newText    : head.attr('data-val'),
     newTextName: head.data('file-name'),
     ignoreSpace: ignoreSpace,
     contextSize: 4


### PR DESCRIPTION
Fixes #2503 
Valid JSON text will be converted to a JSON object, not text , when using .data(). using .attr() prevents this behavior.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
