### PR TITLE
Add api endpoints for repository collaborator

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiRepositoryCollaborator.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRepositoryCollaborator.scala
@@ -1,0 +1,6 @@
+package gitbucket.core.api
+
+case class ApiRepositoryCollaborator(
+  permission: String,
+  user: ApiUser
+)


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR add api endpoints below and fixed link to GitHub REST API references. 

- [Check if a user is a repository collaborator](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#check-if-a-user-is-a-repository-collaborator)

- [Get repository permissions for a user](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-repository-permissions-for-a-user)
