### PR TITLE
update latest activity date when pr merged

### DIFF
--- a/src/main/scala/gitbucket/core/service/MergeService.scala
+++ b/src/main/scala/gitbucket/core/service/MergeService.scala
@@ -282,6 +282,7 @@ trait MergeService {
                   // record activity
                   val mergeInfo = MergeInfo(repository.owner, repository.name, loginAccount.userName, issueId, message)
                   recordActivity(mergeInfo)
+                  updateLastActivityDate(repository.owner, repository.name)
 
                   val (commits, _) = getRequestCompareInfo(
                     repository.owner,


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR add function to update latest activity date of repository when PR merged.