### PR TITLE
Add function to create new branch with commit on UI and start PR

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -564,10 +564,11 @@ trait RepositoryViewerControllerBase extends ControllerBase {
 
   private def getNewBranchName(repository: RepositoryInfo): String = {
     var i = 1
-    while (repository.branchList.exists(p => p.contains(s"pr-patch-$i"))) {
+    val branchNamePrefix = cutTail(context.loginAccount.get.userName.replaceAll("[^a-zA-Z0-9-_]", "-"), 25)
+    while (repository.branchList.exists(p => p.contains(s"$branchNamePrefix-patch-$i"))) {
       i += 1
     }
-    s"pr-patch-$i"
+    s"$branchNamePrefix-patch-$i"
   }
 
   private def createNewBranchForPullRequest(repository: RepositoryInfo, baseBranchName: String): String = {
@@ -601,7 +602,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       originRepository = repository,
       issueId = issueId,
       originBranch = baseBranch,
-      requestUserName = context.loginAccount.get.userName,
+      requestUserName = repository.owner,
       requestRepositoryName = repository.name,
       requestBranch = requestBranch,
       commitIdFrom = commitIdFrom,

--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -563,7 +563,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
   })
 
   private def getNewBranchName(repository: RepositoryInfo): String = {
-    var i = 0
+    var i = 1
     while (repository.branchList.exists(p => p.contains(s"pr-patch-$i"))) {
       i += 1
     }

--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -16,7 +16,8 @@ import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.Implicits._
 import gitbucket.core.util.Directory._
 import gitbucket.core.model.{Account, CommitState, CommitStatus}
-import gitbucket.core.util.JGitUtil.CommitInfo
+import gitbucket.core.service.RepositoryService.RepositoryInfo
+import gitbucket.core.util.JGitUtil.{CommitInfo, createBranch}
 import gitbucket.core.view
 import gitbucket.core.view.helpers
 import org.apache.commons.compress.archivers.{ArchiveEntry, ArchiveOutputStream}
@@ -90,7 +91,9 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     branch: String,
     path: String,
     uploadFiles: String,
-    message: Option[String]
+    message: Option[String],
+    commit: String,
+    newBranch: Boolean
   )
 
   case class EditorForm(
@@ -102,7 +105,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     lineSeparator: String,
     newFileName: String,
     oldFileName: Option[String],
-    commit: String
+    commit: String,
+    newBranch: Boolean
   )
 
   case class DeleteForm(
@@ -110,7 +114,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     path: String,
     message: Option[String],
     fileName: String,
-    commit: String
+    commit: String,
+    newBranch: Boolean
   )
 
   case class CommentForm(
@@ -133,6 +138,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     "path" -> trim(label("Path", text())),
     "uploadFiles" -> trim(label("Upload files", text(required))),
     "message" -> trim(label("Message", optional(text()))),
+    "commit" -> trim(label("Commit", text(required, conflict))),
+    "newBranch" -> trim(label("New Branch", boolean()))
   )(UploadForm.apply)
 
   val editorForm = mapping(
@@ -144,7 +151,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     "lineSeparator" -> trim(label("Line Separator", text(required))),
     "newFileName" -> trim(label("Filename", text(required))),
     "oldFileName" -> trim(label("Old filename", optional(text()))),
-    "commit" -> trim(label("Commit", text(required, conflict)))
+    "commit" -> trim(label("Commit", text(required, conflict))),
+    "newBranch" -> trim(label("New Branch", boolean()))
   )(EditorForm.apply)
 
   val deleteForm = mapping(
@@ -152,7 +160,8 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     "path" -> trim(label("Path", text())),
     "message" -> trim(label("Message", optional(text()))),
     "fileName" -> trim(label("Filename", text(required))),
-    "commit" -> trim(label("Commit", text(required, conflict)))
+    "commit" -> trim(label("Commit", text(required, conflict))),
+    "newBranch" -> trim(label("New Branch", boolean()))
   )(DeleteForm.apply)
 
   val commentForm = mapping(
@@ -337,7 +346,16 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     val (branch, path) = repository.splitPath(multiParams("splat").head)
     val protectedBranch = getProtectedBranchInfo(repository.owner, repository.name, branch)
       .needStatusCheck(context.loginAccount.get.userName)
-    html.upload(branch, repository, if (path.length == 0) Nil else path.split("/").toList, protectedBranch)
+    Using.resource(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
+      val revCommit = JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(branch))
+      html.upload(
+        branch,
+        repository,
+        if (path.length == 0) Nil else path.split("/").toList,
+        protectedBranch,
+        revCommit.name
+      )
+    }
   })
 
   post("/:owner/:repository/upload", uploadForm)(writableUsersOnly { (form, repository) =>
@@ -350,36 +368,47 @@ trait RepositoryViewerControllerBase extends ControllerBase {
       file.copy(name = if (form.path.length == 0) file.name else s"${form.path}/${file.name}")
     }
 
-    commitFiles(
-      repository = repository,
-      branch = form.branch,
-      path = form.path,
-      files = files.toIndexedSeq,
-      message = form.message.getOrElse("Add files via upload"),
-      loginAccount = context.loginAccount.get,
-      settings = context.settings
-    ) {
-      case (git, headTip, builder, inserter) =>
-        JGitUtil.processTree(git, headTip) { (path, tree) =>
-          if (!newFiles.exists(_.name.contains(path))) {
-            builder.add(JGitUtil.createDirCacheEntry(path, tree.getEntryFileMode, tree.getEntryObjectId))
-          }
-        }
-
-        newFiles.foreach { file =>
-          val bytes =
-            FileUtils.readFileToByteArray(new File(getTemporaryDir(session.getId), FileUtil.checkFilename(file.id)))
-          builder.add(
-            JGitUtil.createDirCacheEntry(file.name, FileMode.REGULAR_FILE, inserter.insert(Constants.OBJ_BLOB, bytes))
-          )
-          builder.finish()
-        }
+    if (form.newBranch) {
+      val newBranchName = createNewBranchForPullRequest(repository, form.branch)
+      val objectId = _commit(newBranchName)
+      val issueId =
+        createIssueAndPullRequest(repository, form.branch, newBranchName, form.commit, objectId.name, form.message)
+      redirect(s"/${repository.owner}/${repository.name}/pull/${issueId}")
+    } else {
+      _commit(form.branch)
+      if (form.path.length == 0) {
+        redirect(s"/${repository.owner}/${repository.name}/tree/${form.branch}")
+      } else {
+        redirect(s"/${repository.owner}/${repository.name}/tree/${form.branch}/${form.path}")
+      }
     }
 
-    if (form.path.length == 0) {
-      redirect(s"/${repository.owner}/${repository.name}/tree/${form.branch}")
-    } else {
-      redirect(s"/${repository.owner}/${repository.name}/tree/${form.branch}/${form.path}")
+    def _commit(branchName: String): ObjectId = {
+      commitFiles(
+        repository = repository,
+        branch = branchName,
+        path = form.path,
+        files = files.toIndexedSeq,
+        message = form.message.getOrElse("Add files via upload"),
+        loginAccount = context.loginAccount.get,
+        settings = context.settings
+      ) {
+        case (git, headTip, builder, inserter) =>
+          JGitUtil.processTree(git, headTip) { (path, tree) =>
+            if (!newFiles.exists(_.name.contains(path))) {
+              builder.add(JGitUtil.createDirCacheEntry(path, tree.getEntryFileMode, tree.getEntryObjectId))
+            }
+          }
+
+          newFiles.foreach { file =>
+            val bytes =
+              FileUtils.readFileToByteArray(new File(getTemporaryDir(session.getId), FileUtil.checkFilename(file.id)))
+            builder.add(
+              JGitUtil.createDirCacheEntry(file.name, FileMode.REGULAR_FILE, inserter.insert(Constants.OBJ_BLOB, bytes))
+            )
+            builder.finish()
+          }
+      }
     }
   })
 
@@ -434,70 +463,155 @@ trait RepositoryViewerControllerBase extends ControllerBase {
   })
 
   post("/:owner/:repository/create", editorForm)(writableUsersOnly { (form, repository) =>
-    commitFile(
-      repository = repository,
-      branch = form.branch,
-      path = form.path,
-      newFileName = Some(form.newFileName),
-      oldFileName = None,
-      content = appendNewLine(convertLineSeparator(form.content, form.lineSeparator), form.lineSeparator),
-      charset = form.charset,
-      message = form.message.getOrElse(s"Create ${form.newFileName}"),
-      commit = form.commit,
-      loginAccount = context.loginAccount.get,
-      settings = context.settings
-    )
+    if (form.newBranch) {
+      val newBranchName = createNewBranchForPullRequest(repository, form.branch)
+      val objectId = _commit(newBranchName)
+      val issueId =
+        createIssueAndPullRequest(repository, form.branch, newBranchName, form.commit, objectId.name, form.message)
+      redirect(s"/${repository.owner}/${repository.name}/pull/${issueId}")
+    } else {
+      _commit(form.branch)
+      redirect(
+        s"/${repository.owner}/${repository.name}/blob/${form.branch}/${if (form.path.length == 0) urlEncode(form.newFileName)
+        else s"${form.path}/${urlEncode(form.newFileName)}"}"
+      )
+    }
 
-    redirect(
-      s"/${repository.owner}/${repository.name}/blob/${form.branch}/${if (form.path.length == 0) urlEncode(form.newFileName)
-      else s"${form.path}/${urlEncode(form.newFileName)}"}"
-    )
+    def _commit(branchName: String): ObjectId = {
+      commitFile(
+        repository = repository,
+        branch = branchName,
+        path = form.path,
+        newFileName = Some(form.newFileName),
+        oldFileName = None,
+        content = appendNewLine(convertLineSeparator(form.content, form.lineSeparator), form.lineSeparator),
+        charset = form.charset,
+        message = form.message.getOrElse(s"Create ${form.newFileName}"),
+        commit = form.commit,
+        loginAccount = context.loginAccount.get,
+        settings = context.settings
+      )
+    }
   })
 
   post("/:owner/:repository/update", editorForm)(writableUsersOnly { (form, repository) =>
-    commitFile(
-      repository = repository,
-      branch = form.branch,
-      path = form.path,
-      newFileName = Some(form.newFileName),
-      oldFileName = form.oldFileName,
-      content = appendNewLine(convertLineSeparator(form.content, form.lineSeparator), form.lineSeparator),
-      charset = form.charset,
-      message = if (form.oldFileName.contains(form.newFileName)) {
-        form.message.getOrElse(s"Update ${form.newFileName}")
-      } else {
-        form.message.getOrElse(s"Rename ${form.oldFileName.get} to ${form.newFileName}")
-      },
-      commit = form.commit,
-      loginAccount = context.loginAccount.get,
-      settings = context.settings
-    )
+    if (form.newBranch) {
+      val newBranchName = createNewBranchForPullRequest(repository, form.branch)
+      val objectId = _commit(newBranchName)
+      val issueId =
+        createIssueAndPullRequest(repository, form.branch, newBranchName, form.commit, objectId.name, form.message)
+      redirect(s"/${repository.owner}/${repository.name}/pull/${issueId}")
+    } else {
+      _commit(form.branch)
+      redirect(
+        s"/${repository.owner}/${repository.name}/blob/${urlEncode(form.branch)}/${if (form.path.length == 0) urlEncode(form.newFileName)
+        else s"${form.path}/${urlEncode(form.newFileName)}"}"
+      )
+    }
 
-    redirect(
-      s"/${repository.owner}/${repository.name}/blob/${urlEncode(form.branch)}/${if (form.path.length == 0) urlEncode(form.newFileName)
-      else s"${form.path}/${urlEncode(form.newFileName)}"}"
-    )
+    def _commit(branchName: String): ObjectId = {
+      commitFile(
+        repository = repository,
+        branch = branchName,
+        path = form.path,
+        newFileName = Some(form.newFileName),
+        oldFileName = form.oldFileName,
+        content = appendNewLine(convertLineSeparator(form.content, form.lineSeparator), form.lineSeparator),
+        charset = form.charset,
+        message = if (form.oldFileName.contains(form.newFileName)) {
+          form.message.getOrElse(s"Update ${form.newFileName}")
+        } else {
+          form.message.getOrElse(s"Rename ${form.oldFileName.get} to ${form.newFileName}")
+        },
+        commit = form.commit,
+        loginAccount = context.loginAccount.get,
+        settings = context.settings
+      )
+    }
   })
 
   post("/:owner/:repository/remove", deleteForm)(writableUsersOnly { (form, repository) =>
-    commitFile(
-      repository = repository,
-      branch = form.branch,
-      path = form.path,
-      newFileName = None,
-      oldFileName = Some(form.fileName),
-      content = "",
-      charset = "",
-      message = form.message.getOrElse(s"Delete ${form.fileName}"),
-      commit = form.commit,
+    if (form.newBranch) {
+      val newBranchName = createNewBranchForPullRequest(repository, form.branch)
+      val objectId = _commit(newBranchName)
+      val issueId =
+        createIssueAndPullRequest(repository, form.branch, newBranchName, form.commit, objectId.name, form.message)
+      redirect(s"/${repository.owner}/${repository.name}/pull/${issueId}")
+    } else {
+      _commit(form.branch)
+      redirect(
+        s"/${repository.owner}/${repository.name}/tree/${form.branch}${if (form.path.length == 0) ""
+        else "/" + form.path}"
+      )
+    }
+
+    def _commit(branchName: String): ObjectId = {
+      commitFile(
+        repository = repository,
+        branch = branchName,
+        path = form.path,
+        newFileName = None,
+        oldFileName = Some(form.fileName),
+        content = "",
+        charset = "",
+        message = form.message.getOrElse(s"Delete ${form.fileName}"),
+        commit = form.commit,
+        loginAccount = context.loginAccount.get,
+        settings = context.settings
+      )
+    }
+  })
+
+  private def getNewBranchName(repository: RepositoryInfo): String = {
+    var i = 0
+    while (repository.branchList.exists(p => p.contains(s"pr-patch-$i"))) {
+      i += 1
+    }
+    s"pr-patch-$i"
+  }
+
+  private def createNewBranchForPullRequest(repository: RepositoryInfo, baseBranchName: String): String = {
+    val newBranchName = getNewBranchName(repository)
+    Using.resource(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
+      JGitUtil.createBranch(git, baseBranchName, newBranchName)
+    }
+    newBranchName
+  }
+
+  private def createIssueAndPullRequest(
+    repository: RepositoryInfo,
+    baseBranch: String,
+    requestBranch: String,
+    commitIdFrom: String,
+    commitIdTo: String,
+    commitMessage: Option[String]
+  ): Int = {
+    val issueId = insertIssue(
+      owner = repository.owner,
+      repository = repository.name,
+      loginUser = context.loginAccount.get.userName,
+      title = requestBranch,
+      content = commitMessage,
+      assignedUserName = None,
+      milestoneId = None,
+      priorityId = None,
+      isPullRequest = true
+    )
+    createPullRequest(
+      originRepository = repository,
+      issueId = issueId,
+      originBranch = baseBranch,
+      requestUserName = context.loginAccount.get.userName,
+      requestRepositoryName = repository.name,
+      requestBranch = requestBranch,
+      commitIdFrom = commitIdFrom,
+      commitIdTo = commitIdTo,
+      isDraft = false,
       loginAccount = context.loginAccount.get,
       settings = context.settings
     )
-
-    redirect(
-      s"/${repository.owner}/${repository.name}/tree/${form.branch}${if (form.path.length == 0) "" else "/" + form.path}"
-    )
-  })
+    issueId
+  }
 
   get("/:owner/:repository/raw/*")(referrersOnly { repository =>
     val (id, path) = repository.splitPath(multiParams("splat").head)

--- a/src/main/twirl/gitbucket/core/repo/delete.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/delete.scala.html
@@ -45,6 +45,18 @@
           <div class="form-group">
             <input type="text" name="message" class="form-control"/>
           </div>
+          <div class="form-group">
+            <div class="col-md-12">
+              <label class="radio">
+                <input type="radio" id="newBranch" name="newBranch" value="false" checked>
+                <i class='octicon octicon-git-commit'></i><span>Commit directory to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
+              </label>
+              <label class="radio">
+                <input type="radio" id="newBranch"  name="newBranch" value="true">
+                <i class='octicon octicon-git-pull-request'></i><span>Create a <strong>new branch</strong> for this commit and start a pull request.</span>
+              </label>
+            </div>
+          </div>
           <div style="text-align: right;">
             <a href="@helpers.url(repository)/blob/@helpers.encodeRefName((branch :: pathList ::: List(fileName)).mkString("/"))" class="btn btn-default">Cancel</a>
             <input type="submit" id="commitButton" class="btn btn-success" value="Commit changes"/>

--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -100,6 +100,18 @@
           <div class="form-group">
             <input type="text" id="message" name="message" class="form-control"/>
           </div>
+          <div class="form-group">
+            <div class="col-md-12">
+              <label class="radio">
+                <input type="radio" id="newBranch" name="newBranch" value="false" checked>
+                <i class='octicon octicon-git-commit'></i><span>Commit directory to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
+              </label>
+              <label class="radio">
+                <input type="radio" id="newBranch"  name="newBranch" value="true">
+                <i class='octicon octicon-git-pull-request'></i><span>Create a <strong>new branch</strong> for this commit and start a pull request.</span>
+              </label>
+            </div>
+          </div>
           <div style="text-align: right;">
             @if(fileName.isEmpty){
               <a href="@helpers.url(repository)/tree/@helpers.encodeRefName((branch :: pathList).mkString("/"))" class="btn btn-default">Cancel</a>

--- a/src/main/twirl/gitbucket/core/repo/upload.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/upload.scala.html
@@ -1,7 +1,8 @@
 @(branch: String,
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
   pathList: List[String],
-  protectedBranch: Boolean)(implicit context: gitbucket.core.controller.Context)
+  protectedBranch: Boolean,
+  commit: String)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @import gitbucket.core.util.FileUtil
 @gitbucket.core.html.main(s"Upload Files at ${branch} - ${repository.owner}/${repository.name}", Some(repository)) {
@@ -37,10 +38,23 @@
           <div class="form-group">
             <input type="text" name="message" class="form-control"/>
           </div>
+          <div class="form-group">
+            <div class="col-md-12">
+              <label class="radio">
+                <input type="radio" id="newBranch" name="newBranch" value="false" checked>
+                <i class='octicon octicon-git-commit'></i><span>Commit directory to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
+              </label>
+              <label class="radio">
+                <input type="radio" id="newBranch"  name="newBranch" value="true">
+                <i class='octicon octicon-git-pull-request'></i><span>Create a <strong>new branch</strong> for this commit and start a pull request.</span>
+              </label>
+            </div>
+          </div>
           <div style="text-align: right;">
             <a href="@helpers.url(repository)/tree/@helpers.encodeRefName(branch + "/" + pathList.mkString("/"))" class="btn btn-default">Cancel</a>
             <input type="submit" id="commit" class="btn btn-success" value="Commit changes" disabled="true"/>
             <input type="hidden" id="upload-files-data" name="uploadFiles" value=""/>
+            <input type="hidden" id="commit" name="commit" value="@commit"/>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

- This PR resolve #2559

- This function will be added to
    - upload files on UI (`/:owner/:repository/upload`)
    - edit/create file on UI (`/:owner/:repository/edit/*`)
    - delete file on UI (`/:owner/:repository/remove/*`)

- New branch name will be named automatically like ~`pr-patch-{number}`~`{username}-patch-{number}`. 

### Screenshot GIF

![pr_screenshot_list](https://user-images.githubusercontent.com/26293997/95023367-9e53b580-06b7-11eb-8eb2-42d0dffd6c15.gif)
