### PR TITLE
Fix milestone api

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiMilestone.scala
+++ b/src/main/scala/gitbucket/core/api/ApiMilestone.scala
@@ -16,7 +16,7 @@ case class ApiMilestone(
   state: String,
   title: String,
   description: String,
-  creator: ApiUser,
+//  creator: ApiUser,  // MILESTONE table does not have created user column
   open_issues: Int,
   closed_issues: Int,
 //  created_at: Option[Date],
@@ -29,7 +29,6 @@ object ApiMilestone {
   def apply(
     repository: Repository,
     milestone: Milestone,
-    user: ApiUser,
     open_issue_count: Int = 0,
     closed_issue_count: Int = 0
   ): ApiMilestone =
@@ -42,7 +41,6 @@ object ApiMilestone {
       state = if (milestone.closedDate.isDefined) "closed" else "open",
       title = milestone.title,
       description = milestone.description.getOrElse(""),
-      creator = user,
       open_issues = open_issue_count,
       closed_issues = closed_issue_count,
       closed_at = milestone.closedDate,

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueMilestoneControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueMilestoneControllerBase.scala
@@ -1,7 +1,6 @@
 package gitbucket.core.controller.api
 import gitbucket.core.api._
 import gitbucket.core.controller.ControllerBase
-import gitbucket.core.model.Repository
 import gitbucket.core.service.MilestonesService
 import gitbucket.core.service.RepositoryService.RepositoryInfo
 import gitbucket.core.util.{ReferrerAuthenticator, WritableUsersAuthenticator}
@@ -24,7 +23,6 @@ trait ApiIssueMilestoneControllerBase extends ControllerBase {
         ApiMilestone(
           repository.repository,
           milestoneWithIssue._1,
-          ApiUser(context.loginAccount.get),
           milestoneWithIssue._2,
           milestoneWithIssue._3
         )
@@ -112,7 +110,6 @@ trait ApiIssueMilestoneControllerBase extends ControllerBase {
           ApiMilestone(
             repository.repository,
             milestoneWithIssue._1,
-            ApiUser(context.loginAccount.get),
             milestoneWithIssue._2,
             milestoneWithIssue._3
         )


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

Fix milestone APIs implemented in #2546, #2561. 
I removed `creator` attribute from response because currently MILESTONE table does not have created user column. it means there is no way to know who created a milestone. 