### PR TITLE
Fix file name of the commit comment

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commentform.scala.html
@@ -111,9 +111,9 @@
         } else {
           var $v = $('<div class="commit-comment-box reply-comment-box">')
             .append($('<input type="text" class="form-control reply-comment" placeholder="Reply...">')
-              .data('filename', '@fileName')
-              .data('newline',  @newLineNumber.getOrElse("undefined"))
-              .data('oldline',  @oldLineNumber.getOrElse("undefined")));
+              .attr('data-filename', '@fileName')
+              .attr('data-newline',  @newLineNumber.getOrElse("undefined"))
+              .attr('data-oldline',  @oldLineNumber.getOrElse("undefined")));
 
           @if(oldLineNumber.isDefined){
             @if(newLineNumber.isDefined){


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

### About this PR

close #2455

I fixed the way to add the data attribute of the HTML displayed after adding a comment.
jQuery data() method to update data does not affect attributes in the DOM. (https://api.jquery.com/data/)
