### PR TITLE
Save editor theme to localStorage

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -126,10 +126,16 @@
 $(function(){
   $('#editor').text($('#initial').val());
   var editor = ace.edit("editor");
+
+  if(typeof localStorage.getItem('gitbucket:editor:theme') == "string"){
+    $('#theme').val(localStorage.getItem('gitbucket:editor:theme'));
+  }
+
   editor.setTheme("ace/theme/" + $('#theme').val());
 
   $('#theme').change(function(){
     editor.setTheme("ace/theme/" + $('#theme').val());
+    localStorage.setItem('gitbucket:editor:theme', $('#theme').val());
   });
 
   if(localStorage.getItem('gitbucket:editor:wrap') == 'true'){


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About This PR

PR #2501 implemented select function for ace editor theme. but did not save function for theme.
This PR add save function for ace editor theme selected by user to web browser storage.