### PR TITLE
Improve issue comment management

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IssuesController.scala
+++ b/src/main/scala/gitbucket/core/controller/IssuesController.scala
@@ -240,7 +240,7 @@ trait IssuesControllerBase extends ControllerBase {
       case (owner, name) =>
         getComment(owner, name, params("id")).map { comment =>
           if (isEditableContent(owner, name, comment.commentedUserName)) {
-            Ok(deleteComment(comment.issueId, comment.commentId))
+            Ok(deleteComment(repository.owner, repository.name, comment.issueId, comment.commentId))
           } else Unauthorized()
         } getOrElse NotFound()
     }

--- a/src/main/scala/gitbucket/core/controller/IssuesController.scala
+++ b/src/main/scala/gitbucket/core/controller/IssuesController.scala
@@ -239,7 +239,7 @@ trait IssuesControllerBase extends ControllerBase {
     defining(repository.owner, repository.name) {
       case (owner, name) =>
         getComment(owner, name, params("id")).map { comment =>
-          if (isEditableContent(owner, name, comment.commentedUserName)) {
+          if (isDeletableComment(owner, name, comment.commentedUserName)) {
             Ok(deleteComment(repository.owner, repository.name, comment.issueId, comment.commentId))
           } else Unauthorized()
         } getOrElse NotFound()
@@ -486,5 +486,14 @@ trait IssuesControllerBase extends ControllerBase {
     implicit context: Context
   ): Boolean = {
     hasDeveloperRole(owner, repository, context.loginAccount) || author == context.loginAccount.get.userName
+  }
+
+  /**
+   * Tests whether an issue comment is deletable by a logged-in user.
+   */
+  private def isDeletableComment(owner: String, repository: String, author: String)(
+    implicit context: Context
+  ): Boolean = {
+    hasOwnerRole(owner, repository, context.loginAccount) || author == context.loginAccount.get.userName
   }
 }

--- a/src/main/scala/gitbucket/core/controller/IssuesController.scala
+++ b/src/main/scala/gitbucket/core/controller/IssuesController.scala
@@ -112,6 +112,7 @@ trait IssuesControllerBase extends ControllerBase {
                 getLabels(owner, name),
                 isIssueEditable(repository),
                 isIssueManageable(repository),
+                isIssueCommentManageable(repository),
                 repository
               )
             }

--- a/src/main/scala/gitbucket/core/service/HandleCommentService.scala
+++ b/src/main/scala/gitbucket/core/service/HandleCommentService.scala
@@ -142,7 +142,7 @@ trait HandleCommentService {
   ): Option[IssueComment] = context.loginAccount.flatMap { _ =>
     comment.action match {
       case "comment" =>
-        val deleteResult = deleteComment(comment.issueId, comment.commentId)
+        val deleteResult = deleteComment(repoInfo.owner, repoInfo.name, comment.issueId, comment.commentId)
         val registry = PluginRegistry()
         val hooks: Seq[IssueHook] = if (issue.isPullRequest) registry.getPullRequestHooks else registry.getIssueHooks
         hooks.foreach(_.deletedComment(comment.commentId, issue, repoInfo))

--- a/src/main/scala/gitbucket/core/service/IssueCreationService.scala
+++ b/src/main/scala/gitbucket/core/service/IssueCreationService.scala
@@ -75,6 +75,13 @@ trait IssueCreationService {
   }
 
   /**
+   * Tests whether an logged-in user can manage issues comment.
+   */
+  protected def isIssueCommentManageable(repository: RepositoryInfo)(implicit context: Context, s: Session): Boolean = {
+    hasOwnerRole(repository.owner, repository.name, context.loginAccount)
+  }
+
+  /**
    * Tests whether an logged-in user can post issues.
    */
   protected def isIssueEditable(repository: RepositoryInfo)(implicit context: Context, s: Session): Boolean = {

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -652,7 +652,10 @@ trait IssuesService {
     IssueComments.filter(_.byPrimaryKey(commentId)).map(t => (t.content, t.updatedDate)).update(content, currentDate)
   }
 
-  def deleteComment(issueId: Int, commentId: Int)(implicit s: Session): Int = {
+  def deleteComment(owner: String, repository: String, issueId: Int, commentId: Int)(
+    implicit context: Context,
+    s: Session
+  ): Int = {
     Issues.filter(_.issueId === issueId.bind).map(_.updatedDate).update(currentDate)
     IssueComments.filter(_.byPrimaryKey(commentId)).firstOption match {
       case Some(c) if c.action == "reopen_comment" =>
@@ -661,6 +664,16 @@ trait IssuesService {
         IssueComments.filter(_.byPrimaryKey(commentId)).map(t => (t.content, t.action)).update("Close", "close")
       case Some(_) =>
         IssueComments.filter(_.byPrimaryKey(commentId)).delete
+        IssueComments insert IssueComment(
+          userName = owner,
+          repositoryName = repository,
+          issueId = issueId,
+          action = "delete_comment",
+          commentedUserName = context.loginAccount.map(_.userName).getOrElse("Unknown user"),
+          content = s"",
+          registeredDate = currentDate,
+          updatedDate = currentDate
+        )
     }
   }
 

--- a/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
@@ -254,6 +254,17 @@
           </div>
         </div>
       }
+      case "delete_comment" => {
+        <div class="discussion-item discussion-item-delete-comment">
+          <div class="discussion-item-header">
+            <span class="discussion-item-icon"><i class="octicon octicon-trashcan"></i></span>
+            @helpers.avatar(comment.commentedUserName, 16)
+            @helpers.user(comment.commentedUserName, styleClass="username strong")
+            deleted the comment
+            @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
+          </div>
+        </div>
+      }
       case _ => {
         @showFormattedComment(comment)
       }

--- a/src/main/twirl/gitbucket/core/issues/issue.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/issue.scala.html
@@ -7,6 +7,7 @@
   labels: List[gitbucket.core.model.Label],
   isEditable: Boolean,
   isManageable: Boolean,
+  isCommentManageable: Boolean,
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main(s"${issue.title} - Issue #${issue.issueId} - ${repository.owner}/${repository.name}", Some(repository)){
@@ -51,7 +52,7 @@
     <hr>
     <div style="margin-top: 15px;">
       <div class="col-md-9">
-        @gitbucket.core.issues.html.commentlist(Some(issue), comments, isManageable, repository)
+        @gitbucket.core.issues.html.commentlist(Some(issue), comments, isCommentManageable, repository)
         @gitbucket.core.issues.html.commentform(issue, true, isEditable, isManageable, repository)
       </div>
       <div class="col-md-3">

--- a/src/main/webapp/assets/common/css/gitbucket.css
+++ b/src/main/webapp/assets/common/css/gitbucket.css
@@ -950,6 +950,12 @@ pre.reset.discussion-item-content-text{
   color: white;
 }
 
+.discussion-item-delete-comment .discussion-item-icon {
+  background-color: #767676;
+  padding-top: 1px;
+  color: white;
+}
+
 .priority-sort-handle {
   margin-top: 3px;
   padding-right: 10px;


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR is related to #2146 .
By this PR, issue comment behavior will be like below

- Only repo admins and comment author can delete comments. (developer, guest are not allowed)
- If a comment is deleted, a message will be shown.

"restore comment" function is not so easy to implement, so this PR does not handle this.