### PR TITLE
Implement API for creating, updating and deleting refs.

### DIFF
--- a/src/main/scala/gitbucket/core/api/CreateARef.scala
+++ b/src/main/scala/gitbucket/core/api/CreateARef.scala
@@ -1,7 +1,7 @@
 package gitbucket.core.api
 
 /**
- * https://developer.github.com/v3/git/refs/#create-a-reference
+ * https://docs.github.com/en/free-pro-team@latest/rest/reference/git#create-a-reference
  * api form
  */
 case class CreateARef(ref: String, sha: String)

--- a/src/main/scala/gitbucket/core/api/CreateARef.scala
+++ b/src/main/scala/gitbucket/core/api/CreateARef.scala
@@ -1,0 +1,7 @@
+package gitbucket.core.api
+
+/**
+ * https://developer.github.com/v3/git/refs/#create-a-reference
+ * api form
+ */
+case class CreateARef(ref: String, sha: String)

--- a/src/main/scala/gitbucket/core/api/UpdateARef.scala
+++ b/src/main/scala/gitbucket/core/api/UpdateARef.scala
@@ -1,0 +1,7 @@
+package gitbucket.core.api
+
+/**
+ * https://developer.github.com/v3/git/refs/#update-a-reference
+ * api form
+ */
+case class UpdateARef(sha: String, force: Boolean)

--- a/src/main/scala/gitbucket/core/api/UpdateARef.scala
+++ b/src/main/scala/gitbucket/core/api/UpdateARef.scala
@@ -1,7 +1,7 @@
 package gitbucket.core.api
 
 /**
- * https://developer.github.com/v3/git/refs/#update-a-reference
+ * https://docs.github.com/en/free-pro-team@latest/rest/reference/git#update-a-reference
  * api form
  */
 case class UpdateARef(sha: String, force: Boolean)

--- a/src/main/scala/gitbucket/core/controller/api/ApiGitReferenceControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiGitReferenceControllerBase.scala
@@ -20,7 +20,7 @@ trait ApiGitReferenceControllerBase extends ControllerBase {
 
   /*
    * i. Get a reference
-   * https://developer.github.com/v3/git/refs/#get-a-reference
+   * https://docs.github.com/en/free-pro-team@latest/rest/reference/git#get-a-reference
    */
   get("/api/v3/repos/:owner/:repository/git/ref/*")(referrersOnly { repository =>
     getRef()
@@ -58,12 +58,12 @@ trait ApiGitReferenceControllerBase extends ControllerBase {
 
   /*
    * ii. Get all references
-   * https://developer.github.com/v3/git/refs/#get-all-references
+   * https://docs.github.com/en/free-pro-team@latest/rest/reference/git#list-matching-references
    */
 
   /*
    * iii. Create a reference
-   * https://developer.github.com/v3/git/refs/#create-a-reference
+   * https://docs.github.com/en/free-pro-team@latest/rest/reference/git#create-a-reference
    */
   post("/api/v3/repos/:owner/:repository/git/refs")(referrersOnly { _ =>
     extractFromJsonBody[CreateARef].map {
@@ -87,7 +87,7 @@ trait ApiGitReferenceControllerBase extends ControllerBase {
 
   /*
    * iv. Update a reference
-   * https://developer.github.com/v3/git/refs/#update-a-reference
+   * https://docs.github.com/en/free-pro-team@latest/rest/reference/git#update-a-reference
    */
   patch("/api/v3/repos/:owner/:repository/git/refs/*")(referrersOnly { _ =>
     val refName = multiParams("splat").mkString("/")
@@ -114,7 +114,7 @@ trait ApiGitReferenceControllerBase extends ControllerBase {
 
   /*
    * v. Delete a reference
-   * https://developer.github.com/v3/git/refs/#delete-a-reference
+   * https://docs.github.com/en/free-pro-team@latest/rest/reference/git#delete-a-reference
    */
   delete("/api/v3/repos/:owner/:repository/git/refs/*")(referrersOnly { _ =>
     val refName = multiParams("splat").mkString("/")

--- a/src/main/scala/gitbucket/core/controller/api/ApiGitReferenceControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiGitReferenceControllerBase.scala
@@ -1,10 +1,13 @@
 package gitbucket.core.controller.api
-import gitbucket.core.api.{ApiObject, ApiRef, JsonFormat}
+import gitbucket.core.api.{ApiObject, ApiRef, CreateARef, JsonFormat, UpdateARef}
 import gitbucket.core.controller.ControllerBase
 import gitbucket.core.util.Directory.getRepositoryDir
 import gitbucket.core.util.ReferrerAuthenticator
 import gitbucket.core.util.Implicits._
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.RefUpdate.Result
+import org.scalatra.{BadRequest, NoContent, UnprocessableEntity}
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._
@@ -62,14 +65,72 @@ trait ApiGitReferenceControllerBase extends ControllerBase {
    * iii. Create a reference
    * https://developer.github.com/v3/git/refs/#create-a-reference
    */
+  post("/api/v3/repos/:owner/:repository/git/refs")(referrersOnly { _ =>
+    extractFromJsonBody[CreateARef].map {
+      data =>
+        Using.resource(Git.open(getRepositoryDir(params("owner"), params("repository")))) { git =>
+          val ref = git.getRepository.findRef(data.ref)
+          if (ref == null) {
+            val update = git.getRepository.updateRef(data.ref)
+            update.setNewObjectId(ObjectId.fromString(data.sha))
+            val result = update.update()
+            result match {
+              case Result.NEW => JsonFormat(ApiRef(update.getName, ApiObject(update.getNewObjectId.getName)))
+              case _          => UnprocessableEntity(result.name())
+            }
+          } else {
+            UnprocessableEntity("Ref already exists.")
+          }
+        }
+    } getOrElse BadRequest()
+  })
 
   /*
    * iv. Update a reference
    * https://developer.github.com/v3/git/refs/#update-a-reference
    */
+  patch("/api/v3/repos/:owner/:repository/git/refs/*")(referrersOnly { _ =>
+    val refName = multiParams("splat").mkString("/")
+    extractFromJsonBody[UpdateARef].map {
+      data =>
+        Using.resource(Git.open(getRepositoryDir(params("owner"), params("repository")))) { git =>
+          val ref = git.getRepository.findRef(refName)
+          if (ref == null) {
+            UnprocessableEntity("Ref does not exist.")
+          } else {
+            val update = git.getRepository.updateRef(ref.getName)
+            update.setNewObjectId(ObjectId.fromString(data.sha))
+            update.setForceUpdate(data.force)
+            val result = update.update()
+            result match {
+              case Result.FORCED | Result.FAST_FORWARD | Result.NO_CHANGE =>
+                JsonFormat(ApiRef(update.getName, ApiObject(update.getNewObjectId.getName)))
+              case _ => UnprocessableEntity(result.name())
+            }
+          }
+        }
+    } getOrElse BadRequest()
+  })
 
   /*
- * v. Delete a reference
- * https://developer.github.com/v3/git/refs/#delete-a-reference
- */
+   * v. Delete a reference
+   * https://developer.github.com/v3/git/refs/#delete-a-reference
+   */
+  delete("/api/v3/repos/:owner/:repository/git/refs/*")(referrersOnly { _ =>
+    val refName = multiParams("splat").mkString("/")
+    Using.resource(Git.open(getRepositoryDir(params("owner"), params("repository")))) { git =>
+      val ref = git.getRepository.findRef(refName)
+      if (ref == null) {
+        UnprocessableEntity("Ref does not exist.")
+      } else {
+        val update = git.getRepository.updateRef(ref.getName)
+        update.setForceUpdate(true)
+        val result = update.delete()
+        result match {
+          case Result.FORCED => NoContent()
+          case _             => UnprocessableEntity(result.name())
+        }
+      }
+    }
+  })
 }

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
@@ -85,7 +85,7 @@ trait ApiIssueCommentControllerBase extends ControllerBase {
    * iv. Delete a comment
    * https://docs.github.com/en/rest/reference/issues#delete-an-issue-comment
    */
-  delete("/api/v3/repos/{owner}/{repo}/issues/comments/:id")(readableUsersOnly { repository =>
+  delete("/api/v3/repos/:owner/:repo/issues/comments/:id")(readableUsersOnly { repository =>
     val maybeDeleteResponse: Option[Either[ActionResult, Option[Int]]] =
       for {
         commentId <- params("id").toIntOpt


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

This pull requests implements create, update and delete operations on refs, according to GitHub API specs.

I tried to follow existing conventions. Did not implement "get all refs" since the existing get API already implements it if I understood it correctly.

I'm not a Scala pro so i'm sure there is room for improvements.. :)

In the first commit I also fixed a bug I discovered during testing my changes.