### PR TITLE
Fix typo on UI of commit with new branch

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/delete.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/delete.scala.html
@@ -49,7 +49,7 @@
             <div class="col-md-12">
               <label class="radio">
                 <input type="radio" id="newBranch" name="newBranch" value="false" checked>
-                <i class='octicon octicon-git-commit'></i><span>Commit directory to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
+                <i class='octicon octicon-git-commit'></i><span>Commit directly to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
               </label>
               <label class="radio">
                 <input type="radio" id="newBranch"  name="newBranch" value="true">

--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -104,7 +104,7 @@
             <div class="col-md-12">
               <label class="radio">
                 <input type="radio" id="newBranch" name="newBranch" value="false" checked>
-                <i class='octicon octicon-git-commit'></i><span>Commit directory to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
+                <i class='octicon octicon-git-commit'></i><span>Commit directly to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
               </label>
               <label class="radio">
                 <input type="radio" id="newBranch"  name="newBranch" value="true">

--- a/src/main/twirl/gitbucket/core/repo/upload.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/upload.scala.html
@@ -42,7 +42,7 @@
             <div class="col-md-12">
               <label class="radio">
                 <input type="radio" id="newBranch" name="newBranch" value="false" checked>
-                <i class='octicon octicon-git-commit'></i><span>Commit directory to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
+                <i class='octicon octicon-git-commit'></i><span>Commit directly to the <strong style="background-color: lightblue; font-family: Consolas">@branch</strong> branch.</span>
               </label>
               <label class="radio">
                 <input type="radio" id="newBranch"  name="newBranch" value="true">


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
