### PR TITLE
Add function to refer issue/PR of other repositories within issue/PR conversations

### DIFF
--- a/src/main/scala/gitbucket/core/util/StringUtil.scala
+++ b/src/main/scala/gitbucket/core/util/StringUtil.scala
@@ -12,6 +12,7 @@ import org.apache.commons.io.input.BOMInputStream
 import org.apache.commons.io.IOUtils
 
 import scala.util.control.Exception._
+import scala.util.matching.Regex.Match.unapply
 
 object StringUtil {
 
@@ -143,6 +144,19 @@ object StringUtil {
       .map(_.group(2))
       .toSeq
       .distinct
+
+  /**
+   * Extract issue id like ```owner/repository#issueId``` from the given message.
+   *
+   *@param message the message which may contains issue id
+   * @return the iterator of issue id
+   */
+  def extractGlobalIssueId(message: String): List[(Option[String], Option[String], Option[String])] =
+    "\\s?([\\w-\\.]+)?\\/?([\\w\\-\\.]+)?#(\\d+)\\s?".r
+      .findAllIn(message)
+      .matchData
+      .map(i => (Option(i.group(1)), Option(i.group(2)), Option(i.group(3))))
+      .toList
 
   /**
    * Extract close issue id like ```close #issueId ``` from the given message.

--- a/src/main/scala/gitbucket/core/view/LinkConverter.scala
+++ b/src/main/scala/gitbucket/core/view/LinkConverter.scala
@@ -10,18 +10,30 @@ trait LinkConverter { self: RequestCache =>
   /**
    * Creates a link to the issue or the pull request from the issue id.
    */
-  protected def createIssueLink(repository: RepositoryService.RepositoryInfo, issueId: Int, title: String)(
+  protected def createIssueLink(owner: String, repository: String, issueId: Int, title: String)(
     implicit context: Context
   ): String = {
-    val userName = repository.repository.userName
-    val repositoryName = repository.repository.repositoryName
-
-    getIssueFromCache(userName, repositoryName, issueId.toString) match {
+    getIssueFromCache(owner, repository, issueId.toString) match {
       case Some(issue) =>
-        s"""<a href="${context.path}/${userName}/${repositoryName}/${if (issue.isPullRequest) "pull" else "issues"}/${issueId}"><strong>${StringUtil
+        s"""<a href="${context.path}/${owner}/${repository}/${if (issue.isPullRequest) "pull" else "issues"}/${issueId}"><strong>${StringUtil
           .escapeHtml(title)}</strong> #${issueId}</a>"""
       case None =>
         s"Unknown #${issueId}"
+    }
+  }
+
+  /**
+   * Creates a global link to the issue or the pull request from the issue id.
+   */
+  protected def createGlobalIssueLink(owner: String, repository: String, issueId: Int, title: String)(
+    implicit context: Context
+  ): String = {
+    getIssueFromCache(owner, repository, issueId.toString) match {
+      case Some(issue) =>
+        s"""<a href="${context.path}/${owner}/${repository}/${if (issue.isPullRequest) "pull" else "issues"}/${issueId}"><strong>${StringUtil
+          .escapeHtml(title)}</strong> ${owner}/${repository}#${issueId}</a>"""
+      case None =>
+        s"Unknown ${owner}/${repository}#${issueId}"
     }
   }
 

--- a/src/main/scala/gitbucket/core/view/helpers.scala
+++ b/src/main/scala/gitbucket/core/view/helpers.scala
@@ -159,10 +159,19 @@ object helpers extends AvatarImageProvider with LinkConverter with RequestCache 
   /**
    * Creates a link to the issue or the pull request from the issue id.
    */
-  def issueLink(repository: RepositoryService.RepositoryInfo, issueId: Int, title: String)(
+  def issueLink(owner: String, repository: String, issueId: Int, title: String)(
     implicit context: Context
   ): Html = {
-    Html(createIssueLink(repository, issueId, title))
+    Html(createIssueLink(owner, repository, issueId, title))
+  }
+
+  /**
+   * Creates a global link to the issue or the pull request from the issue id.
+   */
+  def issueGlobalLink(owner: String, repository: String, issueId: Int, title: String)(
+    implicit context: Context
+  ): Html = {
+    Html(createGlobalIssueLink(owner, repository, issueId, title))
   }
 
   /**

--- a/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/commentlist.scala.html
@@ -114,9 +114,26 @@
             @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
           </div>
           <div style="discussion-item-content">
-            @defining(comment.content.split(":")){ case Array(issueId, rest @ _*) => {
-              @helpers.issueLink(repository, issueId.toInt, rest.mkString(":"))
-            }}
+            @defining(comment.content.split(":")){
+              case Array(issueId, rest @ _*) => {@helpers.issueLink(repository.owner, repository.name, issueId.toInt, rest.mkString(":"))}
+            }
+          </div>
+        </div>
+      }
+      case "refer_global" => {
+        <div class="discussion-item discussion-item-refer">
+          <div class="discussion-item-header">
+            <span class="discussion-item-icon"><i class="octicon octicon-bookmark"></i></span>
+            @helpers.avatarLink(comment.commentedUserName, 16)
+            @helpers.user(comment.commentedUserName, styleClass="username strong")
+            referenced the @issueOrPullRequest()
+            @gitbucket.core.helper.html.datetimeago(comment.registeredDate)
+          </div>
+          <div style="discussion-item-content">
+          @defining(comment.content.split(":")){
+            case Array(issueId, ownerName, repositoryName, rest @ _*) => {
+              @helpers.issueGlobalLink(ownerName, repositoryName, issueId.toInt, rest.mkString(":"))
+          }}
           </div>
         </div>
       }

--- a/src/test/scala/gitbucket/core/util/StringUtilSpec.scala
+++ b/src/test/scala/gitbucket/core/util/StringUtilSpec.scala
@@ -57,6 +57,20 @@ class StringUtilSpec extends AnyFunSpec {
     }
   }
 
+  describe("extractGlobalIssueId") {
+    it("should extract '#xxx' and return extracted id") {
+      assert(StringUtil.extractGlobalIssueId("(refs #123)").toSeq == List((None, None, Some("123"))))
+    }
+    it("should extract 'owner/repository#xxx' and return extracted owner, repository and id") {
+      assert(
+        StringUtil.extractGlobalIssueId("(refs root/test#123)").toSeq == List((Some("root"), Some("test"), Some("123")))
+      )
+    }
+    it("should return Nil from message which does not contain #xxx") {
+      assert(StringUtil.extractGlobalIssueId("this is test!").toSeq == Nil)
+    }
+  }
+
   describe("extractCloseId") {
     it("should extract 'close #xxx' and return extracted id") {
       assert(StringUtil.extractCloseId("(close #123)").toSeq == Seq("123"))


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

## About this PR

This PR implements #2607 

## ScreenGIF

![dc](https://user-images.githubusercontent.com/26293997/102748742-1d4ab700-43a6-11eb-9b6d-187b0e74253a.gif)
