### PR TITLE
Resurrect ActivityComponent for binary compatibility in 4.35.1

### DIFF
--- a/src/main/scala/gitbucket/core/model/Activity.scala
+++ b/src/main/scala/gitbucket/core/model/Activity.scala
@@ -1,19 +1,19 @@
 package gitbucket.core.model
 
-// /**
-//  * ActivityComponent has been deprecated, but keep it for binary compatibility.
-//  */
-// @deprecated("ActivityComponent has been deprecated, but keep it for binary compatibility.", "4.34.0")
-// trait ActivityComponent extends TemplateComponent { self: Profile =>
-//   import profile.api._
-//   import self._
+/**
+ * ActivityComponent has been deprecated, but keep it for binary compatibility.
+ */
+@deprecated("ActivityComponent has been deprecated, but keep it for binary compatibility.", "4.34.0")
+trait ActivityComponent extends TemplateComponent { self: Profile =>
+  import profile.api._
+  import self._
 
-//   lazy val Activities = TableQuery[Activities]
+  lazy val Activities = TableQuery[Activities]
 
-//   class Activities(tag: Tag) extends Table[Activity](tag, "ACTIVITY") with BasicTemplate {
-//     def * = ???
-//   }
-// }
+  class Activities(tag: Tag) extends Table[Activity](tag, "ACTIVITY") with BasicTemplate {
+    def * = ???
+  }
+}
 
 case class Activity(
   userName: String,

--- a/src/main/scala/gitbucket/core/model/Profile.scala
+++ b/src/main/scala/gitbucket/core/model/Profile.scala
@@ -45,6 +45,7 @@ trait CoreProfile
     with Profile
     with AccessTokenComponent
     with AccountComponent
+    with ActivityComponent
     with CollaboratorComponent
     with CommitCommentComponent
     with CommitStatusComponent


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
