### PR TITLE
Fix delete wiki page function

### DIFF
--- a/src/main/scala/gitbucket/core/controller/WikiController.scala
+++ b/src/main/scala/gitbucket/core/controller/WikiController.scala
@@ -250,17 +250,26 @@ trait WikiControllerBase extends ControllerBase {
     if (isEditable(repository)) {
       val pageName = StringUtil.urlDecode(params("page"))
 
-      defining(context.loginAccount.get) { loginAccount =>
-        val deleteWikiInfo = DeleteWikiInfo(
-          repository.owner,
-          repository.name,
-          loginAccount.userName,
-          pageName
-        )
-        recordActivity(deleteWikiInfo)
-        updateLastActivityDate(repository.owner, repository.name)
+      defining(context.loginAccount.get) {
+        loginAccount =>
+          deleteWikiPage(
+            repository.owner,
+            repository.name,
+            pageName,
+            loginAccount.fullName,
+            loginAccount.mailAddress,
+            s"Destroyed ${pageName}"
+          )
+          val deleteWikiInfo = DeleteWikiInfo(
+            repository.owner,
+            repository.name,
+            loginAccount.userName,
+            pageName
+          )
+          recordActivity(deleteWikiInfo)
+          updateLastActivityDate(repository.owner, repository.name)
 
-        redirect(s"/${repository.owner}/${repository.name}/wiki")
+          redirect(s"/${repository.owner}/${repository.name}/wiki")
       }
     } else Unauthorized()
   })

--- a/src/main/twirl/gitbucket/core/helper/activities.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/activities.scala.html
@@ -58,6 +58,7 @@
               </div>
           }
         }
+        case "delete_wiki" => simpleActivity(activity)
       })
     </div>
   }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

# About this PR

this PR fix #2621 

> WiKi cannot be deleted.

Caused by missing function call of wiki page deletion.

> An error occurs when NewFeed has a history of deleting WiKi.

Caused by missing support of "delete_wiki" event in template.