### PR TITLE
Set time to create war instead of specifying SOURCE_DATE_EPOCH

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,8 +127,6 @@ test in Test := {
   (test in Test).value
 }
 
-envVars := Map("SOURCE_DATE_EPOCH" -> (System.currentTimeMillis() / 1000).toString)
-
 val executableKey = TaskKey[File]("executable")
 executableKey := {
   import java.util.jar.Attributes.{Name => AttrName}
@@ -188,7 +186,9 @@ executableKey := {
   manifest.getMainAttributes put (AttrName.MANIFEST_VERSION, "1.0")
   manifest.getMainAttributes put (AttrName.MAIN_CLASS, "JettyLauncher")
   val outputFile = workDir / warName
-  IO jar (contentMappings.map { case (file, path) => (file, path.toString) }, outputFile, manifest)
+  IO jar (contentMappings.map { case (file, path) => (file, path.toString) }, outputFile, manifest, Some(
+    System.currentTimeMillis() / 1000
+  ))
 
   // generate checksums
   Seq(


### PR DESCRIPTION
This would be better than #2623. See #2620 also.

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
