### PR TITLE
Fix timestamp which is set to create war file to epoch millis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ executableKey := {
   manifest.getMainAttributes put (AttrName.MAIN_CLASS, "JettyLauncher")
   val outputFile = workDir / warName
   IO jar (contentMappings.map { case (file, path) => (file, path.toString) }, outputFile, manifest, Some(
-    System.currentTimeMillis() / 1000
+    System.currentTimeMillis()
   ))
 
   // generate checksums


### PR DESCRIPTION
#2625 was not enough.

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
