### PR TITLE
As is, the unsuspend API cannot unsuspend since it's not searching su…

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiUserControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiUserControllerBase.scala
@@ -104,7 +104,7 @@ trait ApiUserControllerBase extends ControllerBase {
    */
   delete("/api/v3/users/:userName/suspended")(adminOnly {
     val userName = params("userName")
-    getAccountByUserName(userName) match {
+    getAccountByUserName(userName, true) match {
       case Some(targetAccount) =>
         updateAccount(targetAccount.copy(isRemoved = false))
         NoContent()


### PR DESCRIPTION
…spended accounts. This should allow the api to function without getting a 404.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
