### PR TITLE
Prevent execution of empty SQL strings during database import

### DIFF
--- a/src/main/scala/gitbucket/core/util/JDBCUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JDBCUtil.scala
@@ -84,7 +84,7 @@ object JDBCUtil {
               if (c == ';' && !stringLiteral) {
                 val sql = new String(out.toByteArray, "UTF-8")
                 if (sql != null && !sql.isEmpty()) {
-                  conn.update(sql.trim)                 
+                  conn.update(sql.trim)
                 }
                 out = new ByteArrayOutputStream()
               } else {

--- a/src/main/scala/gitbucket/core/util/JDBCUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JDBCUtil.scala
@@ -83,7 +83,9 @@ object JDBCUtil {
               }
               if (c == ';' && !stringLiteral) {
                 val sql = new String(out.toByteArray, "UTF-8")
-                conn.update(sql.trim)
+                if(sql != null && !sql.isEmpty()) {
+                  conn.update(sql.trim)                 
+                }
                 out = new ByteArrayOutputStream()
               } else {
                 out.write(c)

--- a/src/main/scala/gitbucket/core/util/JDBCUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JDBCUtil.scala
@@ -83,7 +83,7 @@ object JDBCUtil {
               }
               if (c == ';' && !stringLiteral) {
                 val sql = new String(out.toByteArray, "UTF-8")
-                if(sql != null && !sql.isEmpty()) {
+                if (sql != null && !sql.isEmpty()) {
                   conn.update(sql.trim)                 
                 }
                 out = new ByteArrayOutputStream()


### PR DESCRIPTION
This is to address issue #1694 which can result in the execution of an empty SQL string, preventing the import database process from completing successfully. 