### PR TITLE
Make developer documentation a separate section in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ The current version of GitBucket provides many features such as:
 - Account and group management with LDAP integration
 - a Plug-in system
 
-If you want to try the development version of GitBucket, see the [Developer's Guide](https://github.com/gitbucket/gitbucket/blob/master/doc/readme.md).
-
 Installation
 --------
 GitBucket requires **Java8**. You have to install it, if it is not already installed.
@@ -49,6 +47,12 @@ GitBucket has a plug-in system that allows extra functionality. Officially the f
 - [gitbucket-notifications-plugin](https://github.com/gitbucket/gitbucket-notifications-plugin)
 
 You can find more plugins made by the community at [GitBucket community plugins](https://gitbucket-plugins.github.io/).
+
+Building and Development
+-----------
+If you want to try the development version of GitBucket, or want to contribute to the project, please see the [Developer's Guide](https://github.com/gitbucket/gitbucket/blob/master/doc/readme.md).
+It provides instructions on building from source and on setting up an IDE for debugging. 
+It also contains documentation of the core concepts used within the project.
 
 Support
 --------


### PR DESCRIPTION
## Developer information is hard to find

I've been looking for instructions on how to build gitbucket a couple of times, and I've never found them until takzoe pointed me towards `doc/build.md`. After knowing about this, I read through the readme once again, looking for such a link, and then I've found it as the last sentence within a section named `Features`.

What I've been looking for:
 - either a file named `INSTALL.md`, `BUILD.md` in `/`
 - or a section (or a link) in the main readme

I've put the link to `doc/readme.md` into a separate section "Building and Development" and added a short summary. I'm not so sure about the order of the new section and "Plugins".

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
