### PR TITLE
Support HTTP basic authentication

### DIFF
--- a/src/main/scala/gitbucket/core/model/BasicAuthCredentials.scala
+++ b/src/main/scala/gitbucket/core/model/BasicAuthCredentials.scala
@@ -1,0 +1,6 @@
+package gitbucket.core.model
+
+case class BasicAuthCredentials(
+  userName: String,
+  password: String
+)

--- a/src/main/scala/gitbucket/core/util/HttpCredentialParser.scala
+++ b/src/main/scala/gitbucket/core/util/HttpCredentialParser.scala
@@ -1,0 +1,29 @@
+package gitbucket.core.util
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+
+import gitbucket.core.model.BasicAuthCredentials
+
+object HttpCredentialParser {
+  def parseBasicAuth(encoded: String): Option[BasicAuthCredentials] =
+    if (encoded.startsWith("Basic ")) {
+      val encodedUserAndPassword = encoded.substring(6).trim()
+
+      if (encodedUserAndPassword.length <= 0) {
+        None
+      } else {
+        val decodedUserAndPassword = Base64.getDecoder.decode(encodedUserAndPassword)
+        val userAndPassword = new String(decodedUserAndPassword, UTF_8)
+        val parts = userAndPassword.split(":", 2)
+
+        if (parts.length < 2) {
+          Some(BasicAuthCredentials(parts(0), ""))
+        } else {
+          Some(BasicAuthCredentials(parts(0), parts(1)))
+        }
+      }
+    } else {
+      None
+    }
+}

--- a/src/test/scala/gitbucket/core/util/HttpCredentialParserSpec.scala
+++ b/src/test/scala/gitbucket/core/util/HttpCredentialParserSpec.scala
@@ -1,0 +1,37 @@
+package gitbucket.core.util
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+
+import gitbucket.core.model.BasicAuthCredentials
+import gitbucket.core.util.HttpCredentialParser.parseBasicAuth
+import org.scalatest.funspec.AnyFunSpec
+
+class HttpCredentialParserSpec extends AnyFunSpec {
+  describe("parseBasicAuth") {
+    it("is empty when no auth type") {
+      assert(parseBasicAuth("") === None)
+    }
+
+    it("is empty for other auth type") {
+      assert(parseBasicAuth("Foo Bar") === None)
+    }
+
+    it("is empty when basic auth missing credentials") {
+      assert(parseBasicAuth("Basic") === None)
+      assert(parseBasicAuth("Basic ") === None)
+    }
+
+    it("parses user name without password") {
+      val encoded = new String(Base64.getEncoder.encode("qux".getBytes(UTF_8)), UTF_8)
+
+      assert(Some(BasicAuthCredentials("qux", "")) === parseBasicAuth("Basic " + encoded))
+    }
+
+    it("parses user name with password") {
+      val encoded = new String(Base64.getEncoder.encode("foo:bar".getBytes(UTF_8)), UTF_8)
+
+      assert(Some(BasicAuthCredentials("foo", "bar")) === parseBasicAuth("Basic " + encoded))
+    }
+  }
+}


### PR DESCRIPTION
Support HTTP basic authentication, to allow api access on non-public instances of GitBucket.

This change is required to support accessing an H2 plugin generated backup with `curl` when an installation of GitBucket is set to disallow anonymous access to the entire site.

### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
