### PR TITLE
Revert workaround for timestamp issue in war file creation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,9 +186,7 @@ executableKey := {
   manifest.getMainAttributes put (AttrName.MANIFEST_VERSION, "1.0")
   manifest.getMainAttributes put (AttrName.MAIN_CLASS, "JettyLauncher")
   val outputFile = workDir / warName
-  IO jar (contentMappings.map { case (file, path) => (file, path.toString) }, outputFile, manifest, Some(
-    System.currentTimeMillis()
-  ))
+  IO jar (contentMappings.map { case (file, path) => (file, path.toString) }, outputFile, manifest)
 
   // generate checksums
   Seq(


### PR DESCRIPTION
We introduced a workaround for  timestamp issue in war file creation reported in https://github.com/gitbucket/gitbucket/issues/2620, but this issue was fixed in sbt 1.4.8 (https://github.com/sbt/sbt/pull/6290) so this workaround is no longer necessary.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
