### PR TITLE
Fixed file names passed to syntax highlighter in diff view

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/diff.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/diff.scala.html
@@ -109,8 +109,8 @@
         } else {
           @if(diff.newContent != None || diff.oldContent != None){
             <div id="diffText-@i" class="diffText"></div>
-            <input type="hidden" id="newText-@i" data-file-name="@diff.oldPath" data-val="@diff.newContent">
-            <input type="hidden" id="oldText-@i" data-file-name="@diff.newPath" data-val="@diff.oldContent">
+            <input type="hidden" id="newText-@i" data-file-name="@diff.newPath" data-val="@diff.newContent">
+            <input type="hidden" id="oldText-@i" data-file-name="@diff.oldPath" data-val="@diff.oldContent">
           } else {
             @if(diff.newIsImage || diff.oldIsImage){
               <div class="diff-image-render diff2up">


### PR DESCRIPTION
Hi.
I made a GitBucket plugin that replaces the syntax highlighter with highlight.js. [(repo)](https://github.com/kaz-on/gitbucket-code-highlighter-plugin)
So I found that language names were not passed correctly to the syntax highlighter in diff view when adding or deleting files.
This is caused by the new file name and the old file name being swapped in HTML.
This PR will fix this.


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
