### PR TITLE
Drop unused syntax sugars

### DIFF
--- a/src/main/scala/gitbucket/core/util/SyntaxSugars.scala
+++ b/src/main/scala/gitbucket/core/util/SyntaxSugars.scala
@@ -1,7 +1,5 @@
 package gitbucket.core.util
 
-import org.eclipse.jgit.api.Git
-import scala.util.control.Exception._
 import scala.language.reflectiveCalls
 
 /**
@@ -11,46 +9,7 @@ object SyntaxSugars {
 
   def defining[A, B](value: A)(f: A => B): B = f(value)
 
-  @deprecated("Use scala.util.Using.resource instead", "4.32.0")
-  def using[A <: { def close(): Unit }, B](resource: A)(f: A => B): B =
-    try f(resource)
-    finally {
-      if (resource != null) {
-        ignoring(classOf[Throwable]) {
-          resource.close()
-        }
-      }
-    }
-
-  @deprecated("Use scala.util.Using.resources instead", "4.32.0")
-  def using[A <: { def close(): Unit }, B <: { def close(): Unit }, C](resource1: A, resource2: B)(f: (A, B) => C): C =
-    try f(resource1, resource2)
-    finally {
-      if (resource1 != null) {
-        ignoring(classOf[Throwable]) {
-          resource1.close()
-        }
-      }
-      if (resource2 != null) {
-        ignoring(classOf[Throwable]) {
-          resource2.close()
-        }
-      }
-    }
-
-  @deprecated("Use scala.util.Using.resource instead", "4.32.0")
-  def using[T](git: Git)(f: Git => T): T =
-    try f(git)
-    finally git.getRepository.close()
-
-  @deprecated("Use scala.util.Using.resources instead", "4.32.0")
-  def using[T](git1: Git, git2: Git)(f: (Git, Git) => T): T =
-    try f(git1, git2)
-    finally {
-      git1.getRepository.close()
-      git2.getRepository.close()
-    }
-
+  @deprecated("Use scala.util.Try instead", "4.36.0")
   def ignore[T](f: => Unit): Unit =
     try {
       f


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
