### PR TITLE
Use account name as pusher for commits by WebUI

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
@@ -135,36 +135,42 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
    */
 
   put("/api/v3/repos/:owner/:repository/contents/*")(writableUsersOnly { repository =>
-    JsonFormat(for {
-      data <- extractFromJsonBody[CreateAFile]
-    } yield {
-      val branch = data.branch.getOrElse(repository.repository.defaultBranch)
-      val commit = Using.resource(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
-        val revCommit = JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(branch))
-        revCommit.name
-      }
-      val paths = multiParams("splat").head.split("/")
-      val path = paths.take(paths.size - 1).toList.mkString("/")
-      if (data.sha.isDefined && data.sha.get != commit) {
-        ApiError("The blob SHA is not matched.", Some("https://developer.github.com/v3/repos/contents/#update-a-file"))
-      } else {
-        val objectId = commitFile(
-          repository,
-          branch,
-          path,
-          Some(paths.last),
-          data.sha.map(_ => paths.last),
-          StringUtil.base64Decode(data.content),
-          data.message,
-          commit,
-          context.loginAccount.get,
-          data.committer.map(_.name).getOrElse(context.loginAccount.get.fullName),
-          data.committer.map(_.email).getOrElse(context.loginAccount.get.mailAddress),
-          context.settings
-        )
-        ApiContents("file", paths.last, path, objectId.name, None, None)(RepositoryName(repository))
-      }
-    })
+    context.withLoginAccount {
+      loginAccount =>
+        JsonFormat(for {
+          data <- extractFromJsonBody[CreateAFile]
+        } yield {
+          val branch = data.branch.getOrElse(repository.repository.defaultBranch)
+          val commit = Using.resource(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
+            val revCommit = JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(branch))
+            revCommit.name
+          }
+          val paths = multiParams("splat").head.split("/")
+          val path = paths.take(paths.size - 1).toList.mkString("/")
+          if (data.sha.isDefined && data.sha.get != commit) {
+            ApiError(
+              "The blob SHA is not matched.",
+              Some("https://developer.github.com/v3/repos/contents/#update-a-file")
+            )
+          } else {
+            val objectId = commitFile(
+              repository,
+              branch,
+              path,
+              Some(paths.last),
+              data.sha.map(_ => paths.last),
+              StringUtil.base64Decode(data.content),
+              data.message,
+              commit,
+              loginAccount,
+              data.committer.map(_.name).getOrElse(loginAccount.fullName),
+              data.committer.map(_.email).getOrElse(loginAccount.mailAddress),
+              context.settings
+            )
+            ApiContents("file", paths.last, path, objectId.name, None, None)(RepositoryName(repository))
+          }
+        })
+    }
   })
 
   /*

--- a/src/main/scala/gitbucket/core/service/PullRequestService.scala
+++ b/src/main/scala/gitbucket/core/service/PullRequestService.scala
@@ -244,7 +244,7 @@ trait PullRequestService {
     owner: String,
     repository: String,
     branch: String,
-    loginAccount: Account,
+    pusherAccount: Account,
     action: String,
     settings: SystemSettings
   )(
@@ -296,7 +296,7 @@ trait PullRequestService {
           action,
           getRepository(owner, repository).get,
           pullreq.requestBranch,
-          loginAccount,
+          pusherAccount,
           settings
         )
       }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
