### PR TITLE
Drop the use of `SyntaxSugars.defining` from codebase

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -652,22 +652,20 @@ trait AccountControllerBase extends AccountManagementControllerBase {
   })
 
   get("/:groupName/_editgroup")(managersOnly {
-    defining(params("groupName")) { groupName =>
-      getAccountByUserName(groupName, true).map { account =>
-        html.editgroup(account, getGroupMembers(groupName), flash.get("info"))
-      } getOrElse NotFound()
-    }
+    val groupName = params("groupName")
+    getAccountByUserName(groupName, true).map { account =>
+      html.editgroup(account, getGroupMembers(groupName), flash.get("info"))
+    } getOrElse NotFound()
   })
 
   get("/:groupName/_deletegroup")(managersOnly {
-    defining(params("groupName")) {
-      groupName =>
-        // Remove from GROUP_MEMBER
-        updateGroupMembers(groupName, Nil)
-        // Disable group
-        getAccountByUserName(groupName, false).foreach { account =>
-          updateGroup(groupName, account.description, account.url, true)
-        }
+    val groupName = params("groupName")
+    // Remove from GROUP_MEMBER
+    updateGroupMembers(groupName, Nil)
+    // Disable group
+    getAccountByUserName(groupName, false).foreach { account =>
+      updateGroup(groupName, account.description, account.url, true)
+    }
 //      // Remove repositories
 //      getRepositoryNamesOfUser(groupName).foreach { repositoryName =>
 //        deleteRepository(groupName, repositoryName)
@@ -675,28 +673,25 @@ trait AccountControllerBase extends AccountManagementControllerBase {
 //        FileUtils.deleteDirectory(getWikiRepositoryDir(groupName, repositoryName))
 //        FileUtils.deleteDirectory(getTemporaryDir(groupName, repositoryName))
 //      }
-    }
     redirect("/")
   })
 
   post("/:groupName/_editgroup", editGroupForm)(managersOnly { form =>
-    defining(
-      params("groupName"),
-      form.members
-        .split(",")
-        .map {
-          _.split(":") match {
-            case Array(userName, isManager) => (userName, isManager.toBoolean)
-          }
+    val groupName = params("groupName")
+    val members = form.members
+      .split(",")
+      .map {
+        _.split(":") match {
+          case Array(userName, isManager) => (userName, isManager.toBoolean)
         }
-        .toList
-    ) {
-      case (groupName, members) =>
-        getAccountByUserName(groupName, true).map { account =>
-          updateGroup(groupName, form.description, form.url, false)
+      }
+      .toList
 
-          // Update GROUP_MEMBER
-          updateGroupMembers(form.groupName, members)
+    getAccountByUserName(groupName, true).map { account =>
+      updateGroup(groupName, form.description, form.url, false)
+
+      // Update GROUP_MEMBER
+      updateGroupMembers(form.groupName, members)
 //        // Update COLLABORATOR for group repositories
 //        getRepositoryNamesOfUser(form.groupName).foreach { repositoryName =>
 //          removeCollaborators(form.groupName, repositoryName)
@@ -705,13 +700,12 @@ trait AccountControllerBase extends AccountManagementControllerBase {
 //          }
 //        }
 
-          updateImage(form.groupName, form.fileId, form.clearImage)
+      updateImage(form.groupName, form.fileId, form.clearImage)
 
-          flash.update("info", "Account information has been updated.")
-          redirect(s"/${groupName}/_editgroup")
+      flash.update("info", "Account information has been updated.")
+      redirect(s"/${groupName}/_editgroup")
 
-        } getOrElse NotFound()
-    }
+    } getOrElse NotFound()
   })
 
   /**

--- a/src/main/scala/gitbucket/core/controller/ControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/ControllerBase.scala
@@ -158,11 +158,8 @@ abstract class ControllerBase
           org.scalatra.Unauthorized(
             redirect(
               "/signin?redirect=" + StringUtil.urlEncode(
-                defining(request.getQueryString) { queryString =>
-                  request.getRequestURI.substring(request.getContextPath.length) + (if (queryString != null)
-                                                                                      "?" + queryString
-                                                                                    else "")
-                }
+                request.getRequestURI
+                  .substring(request.getContextPath.length) + Option(request.getQueryString).map("?" + _).getOrElse("")
               )
             )
           )
@@ -316,14 +313,14 @@ case class Context(
    * If object has not been cached with the specified key then retrieves by given action.
    * Cached object are available during a request.
    */
-  def cache[A](key: String)(action: => A): A =
-    defining(Keys.Request.Cache(key)) { cacheKey =>
-      Option(request.getAttribute(cacheKey).asInstanceOf[A]).getOrElse {
-        val newObject = action
-        request.setAttribute(cacheKey, newObject)
-        newObject
-      }
+  def cache[A](key: String)(action: => A): A = {
+    val cacheKey = Keys.Request.Cache(key)
+    Option(request.getAttribute(cacheKey).asInstanceOf[A]).getOrElse {
+      val newObject = action
+      request.setAttribute(cacheKey, newObject)
+      newObject
     }
+  }
 
 }
 

--- a/src/main/scala/gitbucket/core/controller/FileUploadController.scala
+++ b/src/main/scala/gitbucket/core/controller/FileUploadController.scala
@@ -6,7 +6,6 @@ import gitbucket.core.model.Account
 import gitbucket.core.service.{AccountService, ReleaseService, RepositoryService}
 import gitbucket.core.servlet.Database
 import gitbucket.core.util._
-import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.Directory._
 import gitbucket.core.util.Implicits._
 import org.eclipse.jgit.api.Git
@@ -194,12 +193,11 @@ class FileUploadController
 
   private def execute(f: (FileItem, String) => Unit, mimeTypeChcker: (String) => Boolean) =
     fileParams.get("file") match {
-      case Some(file) if (mimeTypeChcker(file.name)) =>
-        defining(FileUtil.generateFileId) { fileId =>
-          f(file, fileId)
-          contentType = "text/plain"
-          Ok(fileId)
-        }
+      case Some(file) if mimeTypeChcker(file.name) =>
+        val fileId = FileUtil.generateFileId
+        f(file, fileId)
+        contentType = "text/plain"
+        Ok(fileId)
       case _ => BadRequest()
     }
 

--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -8,7 +8,6 @@ import gitbucket.core.helper.xml
 import gitbucket.core.model.Account
 import gitbucket.core.service._
 import gitbucket.core.util.Implicits._
-import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util._
 import gitbucket.core.view.helpers._
 import org.scalatra.Ok
@@ -237,50 +236,49 @@ trait IndexControllerBase extends ControllerBase {
 
   // TODO Move to RepositoryViewrController?
   get("/:owner/:repository/search")(referrersOnly { repository =>
-    defining(params.getOrElse("q", "").trim, params.getOrElse("type", "code")) {
-      case (query, target) =>
-        val page = try {
-          val i = params.getOrElse("page", "1").toInt
-          if (i <= 0) 1 else i
-        } catch {
-          case e: NumberFormatException => 1
-        }
+    val query = params.getOrElse("q", "").trim
+    val target = params.getOrElse("type", "code")
+    val page = try {
+      val i = params.getOrElse("page", "1").toInt
+      if (i <= 0) 1 else i
+    } catch {
+      case _: NumberFormatException => 1
+    }
 
-        target.toLowerCase match {
-          case "issues" =>
-            gitbucket.core.search.html.issues(
-              if (query.nonEmpty) searchIssues(repository.owner, repository.name, query, false) else Nil,
-              false,
-              query,
-              page,
-              repository
-            )
+    target.toLowerCase match {
+      case "issues" =>
+        gitbucket.core.search.html.issues(
+          if (query.nonEmpty) searchIssues(repository.owner, repository.name, query, false) else Nil,
+          false,
+          query,
+          page,
+          repository
+        )
 
-          case "pulls" =>
-            gitbucket.core.search.html.issues(
-              if (query.nonEmpty) searchIssues(repository.owner, repository.name, query, true) else Nil,
-              true,
-              query,
-              page,
-              repository
-            )
+      case "pulls" =>
+        gitbucket.core.search.html.issues(
+          if (query.nonEmpty) searchIssues(repository.owner, repository.name, query, true) else Nil,
+          true,
+          query,
+          page,
+          repository
+        )
 
-          case "wiki" =>
-            gitbucket.core.search.html.wiki(
-              if (query.nonEmpty) searchWikiPages(repository.owner, repository.name, query) else Nil,
-              query,
-              page,
-              repository
-            )
+      case "wiki" =>
+        gitbucket.core.search.html.wiki(
+          if (query.nonEmpty) searchWikiPages(repository.owner, repository.name, query) else Nil,
+          query,
+          page,
+          repository
+        )
 
-          case _ =>
-            gitbucket.core.search.html.code(
-              if (query.nonEmpty) searchFiles(repository.owner, repository.name, query) else Nil,
-              query,
-              page,
-              repository
-            )
-        }
+      case _ =>
+        gitbucket.core.search.html.code(
+          if (query.nonEmpty) searchFiles(repository.owner, repository.name, query) else Nil,
+          query,
+          page,
+          repository
+        )
     }
   })
 

--- a/src/main/scala/gitbucket/core/controller/IssuesController.scala
+++ b/src/main/scala/gitbucket/core/controller/IssuesController.scala
@@ -4,7 +4,6 @@ import gitbucket.core.issues.html
 import gitbucket.core.model.Account
 import gitbucket.core.service.IssuesService._
 import gitbucket.core.service._
-import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.Implicits._
 import gitbucket.core.util._
 import gitbucket.core.view
@@ -323,17 +322,15 @@ trait IssuesControllerBase extends ControllerBase {
   })
 
   ajaxPost("/:owner/:repository/issues/:id/label/new")(writableUsersOnly { repository =>
-    defining(params("id").toInt) { issueId =>
-      registerIssueLabel(repository.owner, repository.name, issueId, params("labelId").toInt, true)
-      html.labellist(getIssueLabels(repository.owner, repository.name, issueId))
-    }
+    val issueId = params("id").toInt
+    registerIssueLabel(repository.owner, repository.name, issueId, params("labelId").toInt, true)
+    html.labellist(getIssueLabels(repository.owner, repository.name, issueId))
   })
 
   ajaxPost("/:owner/:repository/issues/:id/label/delete")(writableUsersOnly { repository =>
-    defining(params("id").toInt) { issueId =>
-      deleteIssueLabel(repository.owner, repository.name, issueId, params("labelId").toInt, true)
-      html.labellist(getIssueLabels(repository.owner, repository.name, issueId))
-    }
+    val issueId = params("id").toInt
+    deleteIssueLabel(repository.owner, repository.name, issueId, params("labelId").toInt, true)
+    html.labellist(getIssueLabels(repository.owner, repository.name, issueId))
   })
 
   ajaxPost("/:owner/:repository/issues/:id/assign")(writableUsersOnly { repository =>

--- a/src/main/scala/gitbucket/core/service/HandleCommentService.scala
+++ b/src/main/scala/gitbucket/core/service/HandleCommentService.scala
@@ -13,7 +13,6 @@ import gitbucket.core.model.activity.{
 }
 import gitbucket.core.plugin.{IssueHook, PluginRegistry}
 import gitbucket.core.service.RepositoryService.RepositoryInfo
-import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.Implicits._
 
 trait HandleCommentService {
@@ -34,105 +33,104 @@ trait HandleCommentService {
     actionOpt: Option[String]
   )(implicit context: Context, s: Session) = {
     context.loginAccount.flatMap { loginAccount =>
-      defining(repository.owner, repository.name) {
-        case (owner, name) =>
-          val userName = loginAccount.userName
+      val owner = repository.owner
+      val name = repository.name
+      val userName = loginAccount.userName
 
-          actionOpt.collect {
-            case "close" if !issue.closed =>
-              updateClosed(owner, name, issue.issueId, true)
-            case "reopen" if issue.closed =>
-              updateClosed(owner, name, issue.issueId, false)
-          }
-
-          val (action, _) = actionOpt
-            .collect {
-              case "close" if !issue.closed =>
-                val info = if (issue.isPullRequest) {
-                  ClosePullRequestInfo(owner, name, userName, issue.issueId, issue.title)
-                } else {
-                  CloseIssueInfo(owner, name, userName, issue.issueId, issue.title)
-                }
-                recordActivity(info)
-                Some("close") -> info
-              case "reopen" if issue.closed =>
-                val info = if (issue.isPullRequest) {
-                  ReopenPullRequestInfo(owner, name, userName, issue.issueId, issue.title)
-                } else {
-                  ReopenIssueInfo(owner, name, userName, issue.issueId, issue.title)
-                }
-                recordActivity(info)
-                Some("reopen") -> info
-            }
-            .getOrElse(None -> None)
-
-          val commentId = (content, action) match {
-            case (None, None) => None
-            case (None, Some(action)) =>
-              Some(createComment(owner, name, userName, issue.issueId, action.capitalize, action))
-            case (Some(content), _) =>
-              val id = Some(
-                createComment(
-                  owner,
-                  name,
-                  userName,
-                  issue.issueId,
-                  content,
-                  action.map(_ + "_comment").getOrElse("comment")
-                )
-              )
-
-              // record comment activity
-              val commentInfo = if (issue.isPullRequest) {
-                PullRequestCommentInfo(owner, name, userName, content, issue.issueId)
-              } else {
-                IssueCommentInfo(owner, name, userName, content, issue.issueId)
-              }
-              recordActivity(commentInfo)
-
-              // extract references and create refer comment
-              createReferComment(owner, name, issue, content, loginAccount)
-
-              id
-          }
-
-          // call web hooks
-          action match {
-            case None =>
-              commentId foreach (callIssueCommentWebHook(repository, issue, _, loginAccount, context.settings))
-            case Some(act) =>
-              val webHookAction = act match {
-                case "close"  => "closed"
-                case "reopen" => "reopened"
-              }
-              if (issue.isPullRequest)
-                callPullRequestWebHook(webHookAction, repository, issue.issueId, loginAccount, context.settings)
-              else
-                callIssuesWebHook(webHookAction, repository, issue, loginAccount, context.settings)
-          }
-
-          // call hooks
-          content foreach { x =>
-            if (issue.isPullRequest)
-              PluginRegistry().getPullRequestHooks.foreach(_.addedComment(commentId.get, x, issue, repository))
-            else
-              PluginRegistry().getIssueHooks.foreach(_.addedComment(commentId.get, x, issue, repository))
-          }
-          action foreach {
-            case "close" =>
-              if (issue.isPullRequest)
-                PluginRegistry().getPullRequestHooks.foreach(_.closed(issue, repository))
-              else
-                PluginRegistry().getIssueHooks.foreach(_.closed(issue, repository))
-            case "reopen" =>
-              if (issue.isPullRequest)
-                PluginRegistry().getPullRequestHooks.foreach(_.reopened(issue, repository))
-              else
-                PluginRegistry().getIssueHooks.foreach(_.reopened(issue, repository))
-          }
-
-          commentId.map(issue -> _)
+      actionOpt.collect {
+        case "close" if !issue.closed =>
+          updateClosed(owner, name, issue.issueId, true)
+        case "reopen" if issue.closed =>
+          updateClosed(owner, name, issue.issueId, false)
       }
+
+      val (action, _) = actionOpt
+        .collect {
+          case "close" if !issue.closed =>
+            val info = if (issue.isPullRequest) {
+              ClosePullRequestInfo(owner, name, userName, issue.issueId, issue.title)
+            } else {
+              CloseIssueInfo(owner, name, userName, issue.issueId, issue.title)
+            }
+            recordActivity(info)
+            Some("close") -> info
+          case "reopen" if issue.closed =>
+            val info = if (issue.isPullRequest) {
+              ReopenPullRequestInfo(owner, name, userName, issue.issueId, issue.title)
+            } else {
+              ReopenIssueInfo(owner, name, userName, issue.issueId, issue.title)
+            }
+            recordActivity(info)
+            Some("reopen") -> info
+        }
+        .getOrElse(None -> None)
+
+      val commentId = (content, action) match {
+        case (None, None) => None
+        case (None, Some(action)) =>
+          Some(createComment(owner, name, userName, issue.issueId, action.capitalize, action))
+        case (Some(content), _) =>
+          val id = Some(
+            createComment(
+              owner,
+              name,
+              userName,
+              issue.issueId,
+              content,
+              action.map(_ + "_comment").getOrElse("comment")
+            )
+          )
+
+          // record comment activity
+          val commentInfo = if (issue.isPullRequest) {
+            PullRequestCommentInfo(owner, name, userName, content, issue.issueId)
+          } else {
+            IssueCommentInfo(owner, name, userName, content, issue.issueId)
+          }
+          recordActivity(commentInfo)
+
+          // extract references and create refer comment
+          createReferComment(owner, name, issue, content, loginAccount)
+
+          id
+      }
+
+      // call web hooks
+      action match {
+        case None =>
+          commentId foreach (callIssueCommentWebHook(repository, issue, _, loginAccount, context.settings))
+        case Some(act) =>
+          val webHookAction = act match {
+            case "close"  => "closed"
+            case "reopen" => "reopened"
+          }
+          if (issue.isPullRequest)
+            callPullRequestWebHook(webHookAction, repository, issue.issueId, loginAccount, context.settings)
+          else
+            callIssuesWebHook(webHookAction, repository, issue, loginAccount, context.settings)
+      }
+
+      // call hooks
+      content foreach { x =>
+        if (issue.isPullRequest)
+          PluginRegistry().getPullRequestHooks.foreach(_.addedComment(commentId.get, x, issue, repository))
+        else
+          PluginRegistry().getIssueHooks.foreach(_.addedComment(commentId.get, x, issue, repository))
+      }
+      action foreach {
+        case "close" =>
+          if (issue.isPullRequest)
+            PluginRegistry().getPullRequestHooks.foreach(_.closed(issue, repository))
+          else
+            PluginRegistry().getIssueHooks.foreach(_.closed(issue, repository))
+        case "reopen" =>
+          if (issue.isPullRequest)
+            PluginRegistry().getPullRequestHooks.foreach(_.reopened(issue, repository))
+          else
+            PluginRegistry().getIssueHooks.foreach(_.reopened(issue, repository))
+      }
+
+      commentId.map(issue -> _)
     }
   }
 
@@ -161,33 +159,32 @@ trait HandleCommentService {
     content: Option[String]
   )(implicit context: Context, s: Session): Option[(Issue, Int)] = {
     context.loginAccount.flatMap { loginAccount =>
-      defining(repository.owner, repository.name) {
-        case (owner, name) =>
-          val userName = loginAccount.userName
-          content match {
-            case Some(content) =>
-              // Update comment
-              val _commentId = Some(updateComment(issue.issueId, commentId.toInt, content))
-              // Record comment activity
-              val commentInfo = if (issue.isPullRequest) {
-                PullRequestCommentInfo(owner, name, userName, content, issue.issueId)
-              } else {
-                IssueCommentInfo(owner, name, userName, content, issue.issueId)
-              }
-              recordActivity(commentInfo)
-              // extract references and create refer comment
-              createReferComment(owner, name, issue, content, loginAccount)
-              // call web hooks
-              commentId foreach (callIssueCommentWebHook(repository, issue, _, loginAccount, context.settings))
-              // call hooks
-              if (issue.isPullRequest)
-                PluginRegistry().getPullRequestHooks
-                  .foreach(_.updatedComment(commentId.toInt, content, issue, repository))
-              else
-                PluginRegistry().getIssueHooks.foreach(_.updatedComment(commentId.toInt, content, issue, repository))
-              _commentId.map(issue -> _)
-            case _ => None
+      val owner = repository.owner
+      val name = repository.name
+      val userName = loginAccount.userName
+      content match {
+        case Some(content) =>
+          // Update comment
+          val _commentId = Some(updateComment(issue.issueId, commentId.toInt, content))
+          // Record comment activity
+          val commentInfo = if (issue.isPullRequest) {
+            PullRequestCommentInfo(owner, name, userName, content, issue.issueId)
+          } else {
+            IssueCommentInfo(owner, name, userName, content, issue.issueId)
           }
+          recordActivity(commentInfo)
+          // extract references and create refer comment
+          createReferComment(owner, name, issue, content, loginAccount)
+          // call web hooks
+          commentId foreach (callIssueCommentWebHook(repository, issue, _, loginAccount, context.settings))
+          // call hooks
+          if (issue.isPullRequest)
+            PluginRegistry().getPullRequestHooks
+              .foreach(_.updatedComment(commentId.toInt, content, issue, repository))
+          else
+            PluginRegistry().getIssueHooks.foreach(_.updatedComment(commentId.toInt, content, issue, repository))
+          _commentId.map(issue -> _)
+        case _ => None
       }
     }
   }

--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -2,7 +2,6 @@ package gitbucket.core.service
 
 import gitbucket.core.controller.Context
 import gitbucket.core.util._
-import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.model.{CommitComments => _, Session => _, _}
 import gitbucket.core.model.Profile._
 import gitbucket.core.model.Profile.profile.blockingApi._
@@ -202,22 +201,19 @@ trait RepositoryService {
           )
 
           // Move git repository
-          defining(getRepositoryDir(oldUserName, oldRepositoryName)) { dir =>
-            if (dir.isDirectory) {
-              FileUtils.moveDirectory(dir, getRepositoryDir(newUserName, newRepositoryName))
-            }
+          val repoDir = getRepositoryDir(oldUserName, oldRepositoryName)
+          if (repoDir.isDirectory) {
+            FileUtils.moveDirectory(repoDir, getRepositoryDir(newUserName, newRepositoryName))
           }
           // Move wiki repository
-          defining(getWikiRepositoryDir(oldUserName, oldRepositoryName)) { dir =>
-            if (dir.isDirectory) {
-              FileUtils.moveDirectory(dir, getWikiRepositoryDir(newUserName, newRepositoryName))
-            }
+          val wikiDir = getWikiRepositoryDir(oldUserName, oldRepositoryName)
+          if (wikiDir.isDirectory) {
+            FileUtils.moveDirectory(wikiDir, getWikiRepositoryDir(newUserName, newRepositoryName))
           }
           // Move files directory
-          defining(getRepositoryFilesDir(oldUserName, oldRepositoryName)) { dir =>
-            if (dir.isDirectory) {
-              FileUtils.moveDirectory(dir, getRepositoryFilesDir(newUserName, newRepositoryName))
-            }
+          val filesDir = getRepositoryFilesDir(oldUserName, oldRepositoryName)
+          if (filesDir.isDirectory) {
+            FileUtils.moveDirectory(filesDir, getRepositoryFilesDir(newUserName, newRepositoryName))
           }
           // Delete parent directory
           FileUtil.deleteDirectoryIfEmpty(getRepositoryFilesDir(oldUserName, oldRepositoryName))

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -7,7 +7,6 @@ import com.nimbusds.oauth2.sdk.id.{ClientID, Issuer}
 import gitbucket.core.service.SystemSettingsService._
 import gitbucket.core.util.ConfigUtil._
 import gitbucket.core.util.Directory._
-import gitbucket.core.util.SyntaxSugars._
 import scala.util.Using
 
 trait SystemSettingsService {
@@ -15,175 +14,173 @@ trait SystemSettingsService {
   def baseUrl(implicit request: HttpServletRequest): String = loadSystemSettings().baseUrl(request)
 
   def saveSystemSettings(settings: SystemSettings): Unit = {
-    defining(new java.util.Properties()) { props =>
-      settings.baseUrl.foreach(x => props.setProperty(BaseURL, x.replaceFirst("/\\Z", "")))
-      settings.information.foreach(x => props.setProperty(Information, x))
-      props.setProperty(AllowAccountRegistration, settings.allowAccountRegistration.toString)
-      props.setProperty(AllowAnonymousAccess, settings.allowAnonymousAccess.toString)
-      props.setProperty(IsCreateRepoOptionPublic, settings.isCreateRepoOptionPublic.toString)
-      props.setProperty(RepositoryOperationCreate, settings.repositoryOperation.create.toString)
-      props.setProperty(RepositoryOperationDelete, settings.repositoryOperation.delete.toString)
-      props.setProperty(RepositoryOperationRename, settings.repositoryOperation.rename.toString)
-      props.setProperty(RepositoryOperationTransfer, settings.repositoryOperation.transfer.toString)
-      props.setProperty(RepositoryOperationFork, settings.repositoryOperation.fork.toString)
-      props.setProperty(Gravatar, settings.gravatar.toString)
-      props.setProperty(Notification, settings.notification.toString)
-      props.setProperty(LimitVisibleRepositories, settings.limitVisibleRepositories.toString)
-      props.setProperty(SshEnabled, settings.ssh.enabled.toString)
-      settings.ssh.sshHost.foreach(x => props.setProperty(SshHost, x.trim))
-      settings.ssh.sshPort.foreach(x => props.setProperty(SshPort, x.toString))
-      props.setProperty(UseSMTP, settings.useSMTP.toString)
-      if (settings.useSMTP) {
-        settings.smtp.foreach { smtp =>
-          props.setProperty(SmtpHost, smtp.host)
-          smtp.port.foreach(x => props.setProperty(SmtpPort, x.toString))
-          smtp.user.foreach(props.setProperty(SmtpUser, _))
-          smtp.password.foreach(props.setProperty(SmtpPassword, _))
-          smtp.ssl.foreach(x => props.setProperty(SmtpSsl, x.toString))
-          smtp.starttls.foreach(x => props.setProperty(SmtpStarttls, x.toString))
-          smtp.fromAddress.foreach(props.setProperty(SmtpFromAddress, _))
-          smtp.fromName.foreach(props.setProperty(SmtpFromName, _))
+    val props = new java.util.Properties()
+    settings.baseUrl.foreach(x => props.setProperty(BaseURL, x.replaceFirst("/\\Z", "")))
+    settings.information.foreach(x => props.setProperty(Information, x))
+    props.setProperty(AllowAccountRegistration, settings.allowAccountRegistration.toString)
+    props.setProperty(AllowAnonymousAccess, settings.allowAnonymousAccess.toString)
+    props.setProperty(IsCreateRepoOptionPublic, settings.isCreateRepoOptionPublic.toString)
+    props.setProperty(RepositoryOperationCreate, settings.repositoryOperation.create.toString)
+    props.setProperty(RepositoryOperationDelete, settings.repositoryOperation.delete.toString)
+    props.setProperty(RepositoryOperationRename, settings.repositoryOperation.rename.toString)
+    props.setProperty(RepositoryOperationTransfer, settings.repositoryOperation.transfer.toString)
+    props.setProperty(RepositoryOperationFork, settings.repositoryOperation.fork.toString)
+    props.setProperty(Gravatar, settings.gravatar.toString)
+    props.setProperty(Notification, settings.notification.toString)
+    props.setProperty(LimitVisibleRepositories, settings.limitVisibleRepositories.toString)
+    props.setProperty(SshEnabled, settings.ssh.enabled.toString)
+    settings.ssh.sshHost.foreach(x => props.setProperty(SshHost, x.trim))
+    settings.ssh.sshPort.foreach(x => props.setProperty(SshPort, x.toString))
+    props.setProperty(UseSMTP, settings.useSMTP.toString)
+    if (settings.useSMTP) {
+      settings.smtp.foreach { smtp =>
+        props.setProperty(SmtpHost, smtp.host)
+        smtp.port.foreach(x => props.setProperty(SmtpPort, x.toString))
+        smtp.user.foreach(props.setProperty(SmtpUser, _))
+        smtp.password.foreach(props.setProperty(SmtpPassword, _))
+        smtp.ssl.foreach(x => props.setProperty(SmtpSsl, x.toString))
+        smtp.starttls.foreach(x => props.setProperty(SmtpStarttls, x.toString))
+        smtp.fromAddress.foreach(props.setProperty(SmtpFromAddress, _))
+        smtp.fromName.foreach(props.setProperty(SmtpFromName, _))
+      }
+    }
+    props.setProperty(LdapAuthentication, settings.ldapAuthentication.toString)
+    if (settings.ldapAuthentication) {
+      settings.ldap.foreach { ldap =>
+        props.setProperty(LdapHost, ldap.host)
+        ldap.port.foreach(x => props.setProperty(LdapPort, x.toString))
+        ldap.bindDN.foreach(x => props.setProperty(LdapBindDN, x))
+        ldap.bindPassword.foreach(x => props.setProperty(LdapBindPassword, x))
+        props.setProperty(LdapBaseDN, ldap.baseDN)
+        props.setProperty(LdapUserNameAttribute, ldap.userNameAttribute)
+        ldap.additionalFilterCondition.foreach(x => props.setProperty(LdapAdditionalFilterCondition, x))
+        ldap.fullNameAttribute.foreach(x => props.setProperty(LdapFullNameAttribute, x))
+        ldap.mailAttribute.foreach(x => props.setProperty(LdapMailAddressAttribute, x))
+        ldap.tls.foreach(x => props.setProperty(LdapTls, x.toString))
+        ldap.ssl.foreach(x => props.setProperty(LdapSsl, x.toString))
+        ldap.keystore.foreach(x => props.setProperty(LdapKeystore, x))
+      }
+    }
+    props.setProperty(OidcAuthentication, settings.oidcAuthentication.toString)
+    if (settings.oidcAuthentication) {
+      settings.oidc.foreach { oidc =>
+        props.setProperty(OidcIssuer, oidc.issuer.getValue)
+        props.setProperty(OidcClientId, oidc.clientID.getValue)
+        props.setProperty(OidcClientSecret, oidc.clientSecret.getValue)
+        oidc.jwsAlgorithm.foreach { x =>
+          props.setProperty(OidcJwsAlgorithm, x.getName)
         }
       }
-      props.setProperty(LdapAuthentication, settings.ldapAuthentication.toString)
-      if (settings.ldapAuthentication) {
-        settings.ldap.foreach { ldap =>
-          props.setProperty(LdapHost, ldap.host)
-          ldap.port.foreach(x => props.setProperty(LdapPort, x.toString))
-          ldap.bindDN.foreach(x => props.setProperty(LdapBindDN, x))
-          ldap.bindPassword.foreach(x => props.setProperty(LdapBindPassword, x))
-          props.setProperty(LdapBaseDN, ldap.baseDN)
-          props.setProperty(LdapUserNameAttribute, ldap.userNameAttribute)
-          ldap.additionalFilterCondition.foreach(x => props.setProperty(LdapAdditionalFilterCondition, x))
-          ldap.fullNameAttribute.foreach(x => props.setProperty(LdapFullNameAttribute, x))
-          ldap.mailAttribute.foreach(x => props.setProperty(LdapMailAddressAttribute, x))
-          ldap.tls.foreach(x => props.setProperty(LdapTls, x.toString))
-          ldap.ssl.foreach(x => props.setProperty(LdapSsl, x.toString))
-          ldap.keystore.foreach(x => props.setProperty(LdapKeystore, x))
-        }
-      }
-      props.setProperty(OidcAuthentication, settings.oidcAuthentication.toString)
-      if (settings.oidcAuthentication) {
-        settings.oidc.foreach { oidc =>
-          props.setProperty(OidcIssuer, oidc.issuer.getValue)
-          props.setProperty(OidcClientId, oidc.clientID.getValue)
-          props.setProperty(OidcClientSecret, oidc.clientSecret.getValue)
-          oidc.jwsAlgorithm.foreach { x =>
-            props.setProperty(OidcJwsAlgorithm, x.getName)
-          }
-        }
-      }
-      props.setProperty(SkinName, settings.skinName.toString)
-      settings.userDefinedCss.foreach(x => props.setProperty(UserDefinedCss, x))
-      props.setProperty(ShowMailAddress, settings.showMailAddress.toString)
-      props.setProperty(WebHookBlockPrivateAddress, settings.webHook.blockPrivateAddress.toString)
-      props.setProperty(WebHookWhitelist, settings.webHook.whitelist.mkString("\n"))
-      props.setProperty(UploadMaxFileSize, settings.upload.maxFileSize.toString)
-      props.setProperty(UploadTimeout, settings.upload.timeout.toString)
-      props.setProperty(UploadLargeMaxFileSize, settings.upload.largeMaxFileSize.toString)
-      props.setProperty(UploadLargeTimeout, settings.upload.largeTimeout.toString)
-      props.setProperty(RepositoryViewerMaxFiles, settings.repositoryViewer.maxFiles.toString)
+    }
+    props.setProperty(SkinName, settings.skinName.toString)
+    settings.userDefinedCss.foreach(x => props.setProperty(UserDefinedCss, x))
+    props.setProperty(ShowMailAddress, settings.showMailAddress.toString)
+    props.setProperty(WebHookBlockPrivateAddress, settings.webHook.blockPrivateAddress.toString)
+    props.setProperty(WebHookWhitelist, settings.webHook.whitelist.mkString("\n"))
+    props.setProperty(UploadMaxFileSize, settings.upload.maxFileSize.toString)
+    props.setProperty(UploadTimeout, settings.upload.timeout.toString)
+    props.setProperty(UploadLargeMaxFileSize, settings.upload.largeMaxFileSize.toString)
+    props.setProperty(UploadLargeTimeout, settings.upload.largeTimeout.toString)
+    props.setProperty(RepositoryViewerMaxFiles, settings.repositoryViewer.maxFiles.toString)
 
-      Using.resource(new java.io.FileOutputStream(GitBucketConf)) { out =>
-        props.store(out, null)
-      }
+    Using.resource(new java.io.FileOutputStream(GitBucketConf)) { out =>
+      props.store(out, null)
     }
   }
 
   def loadSystemSettings(): SystemSettings = {
-    defining(new java.util.Properties()) { props =>
-      if (GitBucketConf.exists) {
-        Using.resource(new java.io.FileInputStream(GitBucketConf)) { in =>
-          props.load(in)
-        }
+    val props = new java.util.Properties()
+    if (GitBucketConf.exists) {
+      Using.resource(new java.io.FileInputStream(GitBucketConf)) { in =>
+        props.load(in)
       }
-      SystemSettings(
-        getOptionValue[String](props, BaseURL, None).map(x => x.replaceFirst("/\\Z", "")),
-        getOptionValue(props, Information, None),
-        getValue(props, AllowAccountRegistration, false),
-        getValue(props, AllowAnonymousAccess, true),
-        getValue(props, IsCreateRepoOptionPublic, true),
-        RepositoryOperation(
-          create = getValue(props, RepositoryOperationCreate, true),
-          delete = getValue(props, RepositoryOperationDelete, true),
-          rename = getValue(props, RepositoryOperationRename, true),
-          transfer = getValue(props, RepositoryOperationTransfer, true),
-          fork = getValue(props, RepositoryOperationFork, true)
-        ),
-        getValue(props, Gravatar, false),
-        getValue(props, Notification, false),
-        getValue(props, LimitVisibleRepositories, false),
-        Ssh(
-          getValue(props, SshEnabled, false),
-          getOptionValue[String](props, SshHost, None).map(_.trim),
-          getOptionValue(props, SshPort, Some(DefaultSshPort))
-        ),
-        getValue(
-          props,
-          UseSMTP,
-          getValue(props, Notification, false)
-        ), // handle migration scenario from only notification to useSMTP
-        if (getValue(props, UseSMTP, getValue(props, Notification, false))) {
-          Some(
-            Smtp(
-              getValue(props, SmtpHost, ""),
-              getOptionValue(props, SmtpPort, Some(DefaultSmtpPort)),
-              getOptionValue(props, SmtpUser, None),
-              getOptionValue(props, SmtpPassword, None),
-              getOptionValue[Boolean](props, SmtpSsl, None),
-              getOptionValue[Boolean](props, SmtpStarttls, None),
-              getOptionValue(props, SmtpFromAddress, None),
-              getOptionValue(props, SmtpFromName, None)
-            )
-          )
-        } else None,
-        getValue(props, LdapAuthentication, false),
-        if (getValue(props, LdapAuthentication, false)) {
-          Some(
-            Ldap(
-              getValue(props, LdapHost, ""),
-              getOptionValue(props, LdapPort, Some(DefaultLdapPort)),
-              getOptionValue(props, LdapBindDN, None),
-              getOptionValue(props, LdapBindPassword, None),
-              getValue(props, LdapBaseDN, ""),
-              getValue(props, LdapUserNameAttribute, ""),
-              getOptionValue(props, LdapAdditionalFilterCondition, None),
-              getOptionValue(props, LdapFullNameAttribute, None),
-              getOptionValue(props, LdapMailAddressAttribute, None),
-              getOptionValue[Boolean](props, LdapTls, None),
-              getOptionValue[Boolean](props, LdapSsl, None),
-              getOptionValue(props, LdapKeystore, None)
-            )
-          )
-        } else None,
-        getValue(props, OidcAuthentication, false),
-        if (getValue(props, OidcAuthentication, false)) {
-          Some(
-            OIDC(
-              getValue(props, OidcIssuer, ""),
-              getValue(props, OidcClientId, ""),
-              getValue(props, OidcClientSecret, ""),
-              getOptionValue(props, OidcJwsAlgorithm, None)
-            )
-          )
-        } else {
-          None
-        },
-        getValue(props, SkinName, "skin-blue"),
-        getOptionValue(props, UserDefinedCss, None),
-        getValue(props, ShowMailAddress, false),
-        WebHook(getValue(props, WebHookBlockPrivateAddress, false), getSeqValue(props, WebHookWhitelist, "")),
-        Upload(
-          getValue(props, UploadMaxFileSize, 3 * 1024 * 1024),
-          getValue(props, UploadTimeout, 3 * 10000),
-          getValue(props, UploadLargeMaxFileSize, 3 * 1024 * 1024),
-          getValue(props, UploadLargeTimeout, 3 * 10000)
-        ),
-        RepositoryViewerSettings(
-          getValue(props, RepositoryViewerMaxFiles, 0)
-        )
-      )
     }
+    SystemSettings(
+      getOptionValue[String](props, BaseURL, None).map(x => x.replaceFirst("/\\Z", "")),
+      getOptionValue(props, Information, None),
+      getValue(props, AllowAccountRegistration, false),
+      getValue(props, AllowAnonymousAccess, true),
+      getValue(props, IsCreateRepoOptionPublic, true),
+      RepositoryOperation(
+        create = getValue(props, RepositoryOperationCreate, true),
+        delete = getValue(props, RepositoryOperationDelete, true),
+        rename = getValue(props, RepositoryOperationRename, true),
+        transfer = getValue(props, RepositoryOperationTransfer, true),
+        fork = getValue(props, RepositoryOperationFork, true)
+      ),
+      getValue(props, Gravatar, false),
+      getValue(props, Notification, false),
+      getValue(props, LimitVisibleRepositories, false),
+      Ssh(
+        getValue(props, SshEnabled, false),
+        getOptionValue[String](props, SshHost, None).map(_.trim),
+        getOptionValue(props, SshPort, Some(DefaultSshPort))
+      ),
+      getValue(
+        props,
+        UseSMTP,
+        getValue(props, Notification, false)
+      ), // handle migration scenario from only notification to useSMTP
+      if (getValue(props, UseSMTP, getValue(props, Notification, false))) {
+        Some(
+          Smtp(
+            getValue(props, SmtpHost, ""),
+            getOptionValue(props, SmtpPort, Some(DefaultSmtpPort)),
+            getOptionValue(props, SmtpUser, None),
+            getOptionValue(props, SmtpPassword, None),
+            getOptionValue[Boolean](props, SmtpSsl, None),
+            getOptionValue[Boolean](props, SmtpStarttls, None),
+            getOptionValue(props, SmtpFromAddress, None),
+            getOptionValue(props, SmtpFromName, None)
+          )
+        )
+      } else None,
+      getValue(props, LdapAuthentication, false),
+      if (getValue(props, LdapAuthentication, false)) {
+        Some(
+          Ldap(
+            getValue(props, LdapHost, ""),
+            getOptionValue(props, LdapPort, Some(DefaultLdapPort)),
+            getOptionValue(props, LdapBindDN, None),
+            getOptionValue(props, LdapBindPassword, None),
+            getValue(props, LdapBaseDN, ""),
+            getValue(props, LdapUserNameAttribute, ""),
+            getOptionValue(props, LdapAdditionalFilterCondition, None),
+            getOptionValue(props, LdapFullNameAttribute, None),
+            getOptionValue(props, LdapMailAddressAttribute, None),
+            getOptionValue[Boolean](props, LdapTls, None),
+            getOptionValue[Boolean](props, LdapSsl, None),
+            getOptionValue(props, LdapKeystore, None)
+          )
+        )
+      } else None,
+      getValue(props, OidcAuthentication, false),
+      if (getValue(props, OidcAuthentication, false)) {
+        Some(
+          OIDC(
+            getValue(props, OidcIssuer, ""),
+            getValue(props, OidcClientId, ""),
+            getValue(props, OidcClientSecret, ""),
+            getOptionValue(props, OidcJwsAlgorithm, None)
+          )
+        )
+      } else {
+        None
+      },
+      getValue(props, SkinName, "skin-blue"),
+      getOptionValue(props, UserDefinedCss, None),
+      getValue(props, ShowMailAddress, false),
+      WebHook(getValue(props, WebHookBlockPrivateAddress, false), getSeqValue(props, WebHookWhitelist, "")),
+      Upload(
+        getValue(props, UploadMaxFileSize, 3 * 1024 * 1024),
+        getValue(props, UploadTimeout, 3 * 10000),
+        getValue(props, UploadLargeMaxFileSize, 3 * 1024 * 1024),
+        getValue(props, UploadLargeTimeout, 3 * 10000)
+      ),
+      RepositoryViewerSettings(
+        getValue(props, RepositoryViewerMaxFiles, 0)
+      )
+    )
   }
 
 }
@@ -368,12 +365,11 @@ object SystemSettingsService {
 
   private def getValue[A: ClassTag](props: java.util.Properties, key: String, default: A): A = {
     getConfigValue(key).getOrElse {
-      defining(props.getProperty(key)) { value =>
-        if (value == null || value.isEmpty) {
-          default
-        } else {
-          convertType(value).asInstanceOf[A]
-        }
+      val value = props.getProperty(key)
+      if (value == null || value.isEmpty) {
+        default
+      } else {
+        convertType(value).asInstanceOf[A]
       }
     }
   }
@@ -390,12 +386,11 @@ object SystemSettingsService {
 
   private def getOptionValue[A: ClassTag](props: java.util.Properties, key: String, default: Option[A]): Option[A] = {
     getConfigValue(key).orElse {
-      defining(props.getProperty(key)) { value =>
-        if (value == null || value.isEmpty) {
-          default
-        } else {
-          Some(convertType(value)).asInstanceOf[Option[A]]
-        }
+      val value = props.getProperty(key)
+      if (value == null || value.isEmpty) {
+        default
+      } else {
+        Some(convertType(value)).asInstanceOf[Option[A]]
       }
     }
   }

--- a/src/main/scala/gitbucket/core/service/WikiService.scala
+++ b/src/main/scala/gitbucket/core/service/WikiService.scala
@@ -5,7 +5,6 @@ import gitbucket.core.controller.Context
 import gitbucket.core.model.Account
 import gitbucket.core.service.RepositoryService.RepositoryInfo
 import gitbucket.core.util._
-import gitbucket.core.util.SyntaxSugars._
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.treewalk.CanonicalTreeParser
 import org.eclipse.jgit.lib._
@@ -54,20 +53,19 @@ trait WikiService {
 
   def createWikiRepository(loginAccount: Account, owner: String, repository: String): Unit =
     LockUtil.lock(s"${owner}/${repository}/wiki") {
-      defining(Directory.getWikiRepositoryDir(owner, repository)) { dir =>
-        if (!dir.exists) {
-          JGitUtil.initRepository(dir)
-          saveWikiPage(
-            owner,
-            repository,
-            "Home",
-            "Home",
-            s"Welcome to the ${repository} wiki!!",
-            loginAccount,
-            "Initial Commit",
-            None
-          )
-        }
+      val dir = Directory.getWikiRepositoryDir(owner, repository)
+      if (!dir.exists) {
+        JGitUtil.initRepository(dir)
+        saveWikiPage(
+          owner,
+          repository,
+          "Home",
+          "Home",
+          s"Welcome to the ${repository} wiki!!",
+          loginAccount,
+          "Initial Commit",
+          None
+        )
       }
     }
 

--- a/src/main/scala/gitbucket/core/util/ConfigUtil.scala
+++ b/src/main/scala/gitbucket/core/util/ConfigUtil.scala
@@ -1,7 +1,5 @@
 package gitbucket.core.util
 
-import gitbucket.core.util.SyntaxSugars.defining
-
 import scala.reflect.ClassTag
 
 object ConfigUtil {
@@ -30,12 +28,12 @@ object ConfigUtil {
     }
   }
 
-  def convertType[A: ClassTag](value: String): A =
-    defining(implicitly[ClassTag[A]].runtimeClass) { c =>
-      if (c == classOf[Boolean]) value.toBoolean
-      else if (c == classOf[Long]) value.toLong
-      else if (c == classOf[Int]) value.toInt
-      else value
-    }.asInstanceOf[A]
+  def convertType[A: ClassTag](value: String): A = {
+    val c = implicitly[ClassTag[A]].runtimeClass
+    if (c == classOf[Boolean]) value.toBoolean
+    else if (c == classOf[Long]) value.toLong
+    else if (c == classOf[Int]) value.toInt
+    else value
+  }.asInstanceOf[A]
 
 }

--- a/src/main/scala/gitbucket/core/util/FileUtil.scala
+++ b/src/main/scala/gitbucket/core/util/FileUtil.scala
@@ -3,26 +3,24 @@ package gitbucket.core.util
 import org.apache.commons.io.FileUtils
 import org.apache.tika.Tika
 import java.io.File
-import SyntaxSugars._
 import scala.util.Random
 
 object FileUtil {
 
-  def getMimeType(name: String): String =
-    defining(new Tika()) { tika =>
-      tika.detect(name) match {
-        case null     => "application/octet-stream"
-        case mimeType => mimeType
-      }
+  def getMimeType(name: String): String = {
+    val tika = new Tika()
+    tika.detect(name) match {
+      case null     => "application/octet-stream"
+      case mimeType => mimeType
     }
+  }
 
   def getMimeType(name: String, bytes: Array[Byte]): String = {
-    defining(getMimeType(name)) { mimeType =>
-      if (mimeType == "application/octet-stream" && isText(bytes)) {
-        "text/plain"
-      } else {
-        mimeType
-      }
+    val mimeType = getMimeType(name)
+    if (mimeType == "application/octet-stream" && isText(bytes)) {
+      "text/plain"
+    } else {
+      mimeType
     }
   }
 

--- a/src/main/scala/gitbucket/core/util/LDAPUtil.scala
+++ b/src/main/scala/gitbucket/core/util/LDAPUtil.scala
@@ -1,7 +1,6 @@
 package gitbucket.core.util
 
 import gitbucket.core.model.Account
-import SyntaxSugars._
 import gitbucket.core.service.SystemSettingsService
 import gitbucket.core.service.SystemSettingsService.Ldap
 import com.novell.ldap._
@@ -246,20 +245,18 @@ object LDAPUtil {
     userNameAttribute: String,
     userName: String,
     mailAttribute: String
-  ): Option[String] =
-    defining(
-      conn.search(
-        userDN,
-        LDAPConnection.SCOPE_BASE,
-        userNameAttribute + "=" + userName,
-        Array[String](mailAttribute),
-        false
-      )
-    ) { results =>
-      if (results.hasMore) {
-        Option(results.next.getAttribute(mailAttribute)).map(_.getStringValue)
-      } else None
-    }
+  ): Option[String] = {
+    val results = conn.search(
+      userDN,
+      LDAPConnection.SCOPE_BASE,
+      userNameAttribute + "=" + userName,
+      Array[String](mailAttribute),
+      false
+    )
+    if (results.hasMore) {
+      Option(results.next.getAttribute(mailAttribute)).map(_.getStringValue)
+    } else None
+  }
 
   private def findFullName(
     conn: LDAPConnection,
@@ -267,20 +264,18 @@ object LDAPUtil {
     userNameAttribute: String,
     userName: String,
     nameAttribute: String
-  ): Option[String] =
-    defining(
-      conn.search(
-        userDN,
-        LDAPConnection.SCOPE_BASE,
-        userNameAttribute + "=" + userName,
-        Array[String](nameAttribute),
-        false
-      )
-    ) { results =>
-      if (results.hasMore) {
-        Option(results.next.getAttribute(nameAttribute)).map(_.getStringValue)
-      } else None
-    }
+  ): Option[String] = {
+    val results = conn.search(
+      userDN,
+      LDAPConnection.SCOPE_BASE,
+      userNameAttribute + "=" + userName,
+      Array[String](nameAttribute),
+      false
+    )
+    if (results.hasMore) {
+      Option(results.next.getAttribute(nameAttribute)).map(_.getStringValue)
+    } else None
+  }
 
   case class LDAPUserInfo(userName: String, fullName: String, mailAddress: String)
 

--- a/src/main/scala/gitbucket/core/util/LockUtil.scala
+++ b/src/main/scala/gitbucket/core/util/LockUtil.scala
@@ -2,7 +2,6 @@ package gitbucket.core.util
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.{ReentrantLock, Lock}
-import SyntaxSugars._
 
 object LockUtil {
 
@@ -24,7 +23,8 @@ object LockUtil {
   /**
    * Synchronizes a given function which modifies the working copy of the wiki repository.
    */
-  def lock[T](key: String)(f: => T): T = defining(getLockObject(key)) { lock =>
+  def lock[T](key: String)(f: => T): T = {
+    val lock = getLockObject(key)
     try {
       lock.lock()
       f

--- a/src/main/scala/gitbucket/core/util/StringUtil.scala
+++ b/src/main/scala/gitbucket/core/util/StringUtil.scala
@@ -5,7 +5,6 @@ import java.security.SecureRandom
 import java.util.{Base64, UUID}
 
 import org.mozilla.universalchardet.UniversalDetector
-import SyntaxSugars._
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.PBEKeySpec
 import org.apache.commons.io.input.BOMInputStream
@@ -45,11 +44,11 @@ object StringUtil {
     s"""$$pbkdf2-sha256$$${iter}$$${base64Encode(salt)}$$${base64Encode(s.getEncoded)}"""
   }
 
-  def sha1(value: String): String =
-    defining(java.security.MessageDigest.getInstance("SHA-1")) { md =>
-      md.update(value.getBytes)
-      md.digest.map(b => "%02x".format(b)).mkString
-    }
+  def sha1(value: String): String = {
+    val md = java.security.MessageDigest.getInstance("SHA-1")
+    md.update(value.getBytes)
+    md.digest.map(b => "%02x".format(b)).mkString
+  }
 
   def md5(value: String): String = {
     val md = java.security.MessageDigest.getInstance("MD5")
@@ -89,15 +88,15 @@ object StringUtil {
   def convertFromByteArray(content: Array[Byte]): String =
     IOUtils.toString(new BOMInputStream(new java.io.ByteArrayInputStream(content)), detectEncoding(content))
 
-  def detectEncoding(content: Array[Byte]): String =
-    defining(new UniversalDetector(null)) { detector =>
-      detector.handleData(content, 0, content.length)
-      detector.dataEnd()
-      detector.getDetectedCharset match {
-        case null => "UTF-8"
-        case e    => e
-      }
+  def detectEncoding(content: Array[Byte]): String = {
+    val detector = new UniversalDetector(null)
+    detector.handleData(content, 0, content.length)
+    detector.dataEnd()
+    detector.getDetectedCharset match {
+      case null => "UTF-8"
+      case e    => e
     }
+  }
 
   /**
    * Converts line separator in the given content.

--- a/src/test/scala/gitbucket/core/view/PaginationSpec.scala
+++ b/src/test/scala/gitbucket/core/view/PaginationSpec.scala
@@ -15,11 +15,13 @@ class PaginationSpec extends AnyFunSpec {
 
   describe("omitLeft and omitRight") {
     it("should return true if pagination links at their side will be omitted") {
-      defining(Pagination(1, 100, 10, 6)) { pagination =>
+      {
+        val pagination = Pagination(1, 100, 10, 6)
         assert(pagination.omitLeft == false)
         assert(pagination.omitRight == true)
       }
-      defining(Pagination(9, 100, 10, 6)) { pagination =>
+      {
+        val pagination = Pagination(9, 100, 10, 6)
         assert(pagination.omitLeft == true)
         assert(pagination.omitRight == false)
       }
@@ -28,7 +30,8 @@ class PaginationSpec extends AnyFunSpec {
 
   describe("visibleFor") {
     it("should return true for visible pagination links") {
-      defining(Pagination(1, 100, 10, 6)) { pagination =>
+      {
+        val pagination = Pagination(1, 100, 10, 6)
         assert(pagination.visibleFor(1) == true)
         assert(pagination.visibleFor(2) == true)
         assert(pagination.visibleFor(3) == true)
@@ -40,7 +43,8 @@ class PaginationSpec extends AnyFunSpec {
         assert(pagination.visibleFor(9) == false)
         assert(pagination.visibleFor(10) == true)
       }
-      defining(Pagination(5, 100, 10, 6)) { pagination =>
+      {
+        val pagination = Pagination(5, 100, 10, 6)
         assert(pagination.visibleFor(1) == true)
         assert(pagination.visibleFor(2) == false)
         assert(pagination.visibleFor(3) == false)
@@ -52,7 +56,8 @@ class PaginationSpec extends AnyFunSpec {
         assert(pagination.visibleFor(9) == false)
         assert(pagination.visibleFor(10) == true)
       }
-      defining(Pagination(8, 100, 10, 6)) { pagination =>
+      {
+        val pagination = Pagination(8, 100, 10, 6)
         assert(pagination.visibleFor(1) == true)
         assert(pagination.visibleFor(2) == false)
         assert(pagination.visibleFor(3) == false)


### PR DESCRIPTION
Drop the use of `SyntaxSugars.defining` from codebase to reduce warnings

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
