### PR TITLE
Fix Repository Contents API issues

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiContents.scala
+++ b/src/main/scala/gitbucket/core/api/ApiContents.scala
@@ -28,7 +28,7 @@ object ApiContents {
               "file",
               fileInfo.name,
               fileInfo.path,
-              fileInfo.commitId,
+              fileInfo.id.getName,
               Some(Base64.getEncoder.encodeToString(arr)),
               Some("base64")
             )(repositoryName)

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
@@ -35,7 +35,7 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
 
   /**
    * ii. Get contents
-   * https://developer.github.com/v3/repos/contents/#get-contents
+   * https://docs.github.com/en/rest/reference/repos#get-repository-content
    */
   get("/api/v3/repos/:owner/:repository/contents")(referrersOnly { repository =>
     getContents(repository, ".", params.getOrElse("ref", repository.repository.defaultBranch))
@@ -43,7 +43,7 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
 
   /**
    * ii. Get contents
-   * https://developer.github.com/v3/repos/contents/#get-contents
+   * https://docs.github.com/en/rest/reference/repos#get-repository-content
    */
   get("/api/v3/repos/:owner/:repository/contents/*")(referrersOnly { repository =>
     getContents(repository, multiParams("splat").head, params.getOrElse("ref", repository.repository.defaultBranch))
@@ -126,14 +126,13 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
       }
     }
   }
-  /*
+
+  /**
    * iii. Create a file or iv. Update a file
-   * https://developer.github.com/v3/repos/contents/#create-a-file
-   * https://developer.github.com/v3/repos/contents/#update-a-file
+   * https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents
    * if sha is presented, update a file else create a file.
    * requested #2112
    */
-
   put("/api/v3/repos/:owner/:repository/contents/*")(writableUsersOnly { repository =>
     context.withLoginAccount {
       loginAccount =>
@@ -147,10 +146,11 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
           }
           val paths = multiParams("splat").head.split("/")
           val path = paths.take(paths.size - 1).toList.mkString("/")
+
           if (data.sha.isDefined && data.sha.get != commit) {
             ApiError(
               "The blob SHA is not matched.",
-              Some("https://developer.github.com/v3/repos/contents/#update-a-file")
+              Some("https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents")
             )
           } else {
             val objectId = commitFile(
@@ -175,13 +175,14 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
 
   /*
    * v. Delete a file
-   * https://developer.github.com/v3/repos/contents/#delete-a-file
+   * https://docs.github.com/en/rest/reference/repos#delete-a-file
    * should be implemented
    */
 
   /*
- * vi. Get archive link
- * https://developer.github.com/v3/repos/contents/#get-archive-link
- */
+   * vi. Download a repository archive (tar/zip)
+   * https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-tar
+   * https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-zip
+   */
 
 }

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
@@ -183,9 +183,9 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
    */
 
   /*
-   * vi. Download a repository archive (tar/zip)
-   * https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-tar
-   * https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-zip
-   */
+ * vi. Download a repository archive (tar/zip)
+ * https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-tar
+ * https://docs.github.com/en/rest/reference/repos#download-a-repository-archive-zip
+ */
 
 }

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryContentsControllerBase.scala
@@ -69,11 +69,12 @@ trait ApiRepositoryContentsControllerBase extends ControllerBase {
     repository: RepositoryService.RepositoryInfo,
     path: String,
     refStr: String,
+    ignoreCase: Boolean = false
   ) = {
     Using.resource(Git.open(getRepositoryDir(params("owner"), params("repository")))) { git =>
       val fileList = getFileList(git, refStr, path, maxFiles = context.settings.repositoryViewer.maxFiles)
       if (fileList.isEmpty) { // file or NotFound
-        getFileInfo(git, refStr, path, false)
+        getFileInfo(git, refStr, path, ignoreCase)
           .flatMap { f =>
             val largeFile = params.get("large_file").exists(s => s.equals("true"))
             val content = getContentFromId(git, f.id, largeFile)

--- a/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
@@ -23,23 +23,25 @@ trait RepositoryCommitFileService {
     with PullRequestService
     with WebHookPullRequestService
     with RepositoryService =>
-  import RepositoryCommitFileService._
 
+  // Create multiple files by callback function
+  // Returns commitId
   def commitFiles(
     repository: RepositoryService.RepositoryInfo,
-    files: Seq[CommitFile],
     branch: String,
-    path: String,
     message: String,
     loginAccount: Account,
     settings: SystemSettings
   )(
     f: (Git, ObjectId, DirCacheBuilder, ObjectInserter) => Unit
-  )(implicit s: Session, c: JsonFormat.Context) = {
-    // prepend path to the filename
-    _commitFile(repository, branch, message, loginAccount, loginAccount.fullName, loginAccount.mailAddress, settings)(f)
+  )(implicit s: Session, c: JsonFormat.Context): ObjectId = {
+    _createFiles(repository, branch, message, loginAccount, loginAccount.fullName, loginAccount.mailAddress, settings)(
+      f
+    )._1
   }
 
+  // Create a file from string content
+  // Returns commitId + blobId
   def commitFile(
     repository: RepositoryService.RepositoryInfo,
     branch: String,
@@ -52,7 +54,7 @@ trait RepositoryCommitFileService {
     commit: String,
     loginAccount: Account,
     settings: SystemSettings
-  )(implicit s: Session, c: JsonFormat.Context): ObjectId = {
+  )(implicit s: Session, c: JsonFormat.Context): (ObjectId, Option[ObjectId]) = {
     commitFile(
       repository,
       branch,
@@ -69,6 +71,8 @@ trait RepositoryCommitFileService {
     )
   }
 
+  // Create a file from byte array content
+  // Returns commitId + blobId
   def commitFile(
     repository: RepositoryService.RepositoryInfo,
     branch: String,
@@ -82,7 +86,7 @@ trait RepositoryCommitFileService {
     committerName: String,
     committerMailAddress: String,
     settings: SystemSettings
-  )(implicit s: Session, c: JsonFormat.Context): ObjectId = {
+  )(implicit s: Session, c: JsonFormat.Context): (ObjectId, Option[ObjectId]) = {
 
     val newPath = newFileName.map { newFileName =>
       if (path.length == 0) newFileName else s"${path}/${newFileName}"
@@ -91,7 +95,7 @@ trait RepositoryCommitFileService {
       if (path.length == 0) oldFileName else s"${path}/${oldFileName}"
     }
 
-    _commitFile(repository, branch, message, pusherAccount, committerName, committerMailAddress, settings) {
+    _createFiles(repository, branch, message, pusherAccount, committerName, committerMailAddress, settings) {
       case (git, headTip, builder, inserter) =>
         if (headTip.getName == commit) {
           val permission = JGitUtil
@@ -105,18 +109,23 @@ trait RepositoryCommitFileService {
             }
             .flatten
             .headOption
-
-          newPath.foreach { newPath =>
-            builder.add(JGitUtil.createDirCacheEntry(newPath, permission.map { bits =>
+            .map { bits =>
               FileMode.fromBits(bits)
-            } getOrElse FileMode.REGULAR_FILE, inserter.insert(Constants.OBJ_BLOB, content)))
+            }
+            .getOrElse(FileMode.REGULAR_FILE)
+
+          val objectId = newPath.map { newPath =>
+            val objectId = inserter.insert(Constants.OBJ_BLOB, content)
+            builder.add(JGitUtil.createDirCacheEntry(newPath, permission, objectId))
+            objectId
           }
           builder.finish()
-        }
+          objectId
+        } else None
     }
   }
 
-  private def _commitFile(
+  private def _createFiles[R](
     repository: RepositoryService.RepositoryInfo,
     branch: String,
     message: String,
@@ -125,8 +134,8 @@ trait RepositoryCommitFileService {
     committerMailAddress: String,
     settings: SystemSettings
   )(
-    f: (Git, ObjectId, DirCacheBuilder, ObjectInserter) => Unit
-  )(implicit s: Session, c: JsonFormat.Context): ObjectId = {
+    f: (Git, ObjectId, DirCacheBuilder, ObjectInserter) => R
+  )(implicit s: Session, c: JsonFormat.Context): (ObjectId, R) = {
 
     LockUtil.lock(s"${repository.owner}/${repository.name}") {
       Using.resource(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
@@ -135,7 +144,7 @@ trait RepositoryCommitFileService {
         val headName = s"refs/heads/${branch}"
         val headTip = git.getRepository.resolve(headName)
 
-        f(git, headTip, builder, inserter)
+        val result = f(git, headTip, builder, inserter)
 
         val commitId = JGitUtil.createNewCommit(
           git,
@@ -228,7 +237,7 @@ trait RepositoryCommitFileService {
               }
             }
         }
-        commitId
+        (commitId, result)
       }
     }
   }

--- a/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryCommitFileService.scala
@@ -24,8 +24,10 @@ trait RepositoryCommitFileService {
     with WebHookPullRequestService
     with RepositoryService =>
 
-  // Create multiple files by callback function
-  // Returns commitId
+  /**
+   * Create multiple files by callback function.
+   * Returns commitId.
+   */
   def commitFiles(
     repository: RepositoryService.RepositoryInfo,
     branch: String,
@@ -40,8 +42,10 @@ trait RepositoryCommitFileService {
     )._1
   }
 
-  // Create a file from string content
-  // Returns commitId + blobId
+  /**
+   * Create a file from string content.
+   * Returns commitId + blobId.
+   */
   def commitFile(
     repository: RepositoryService.RepositoryInfo,
     branch: String,
@@ -71,8 +75,10 @@ trait RepositoryCommitFileService {
     )
   }
 
-  // Create a file from byte array content
-  // Returns commitId + blobId
+  /**
+   * Create a file from byte array content.
+   * Returns commitId + blobId.
+   */
   def commitFile(
     repository: RepositoryService.RepositoryInfo,
     branch: String,

--- a/src/main/scala/gitbucket/core/service/WebHookService.scala
+++ b/src/main/scala/gitbucket/core/service/WebHookService.scala
@@ -20,7 +20,6 @@ import gitbucket.core.model.Profile._
 import gitbucket.core.model.Profile.profile.blockingApi._
 import org.apache.http.client.utils.URLEncodedUtils
 import gitbucket.core.util.JGitUtil.CommitInfo
-import gitbucket.core.util.Implicits._
 import gitbucket.core.util.{HttpClientUtil, RepositoryName, StringUtil}
 import gitbucket.core.service.RepositoryService.RepositoryInfo
 import org.apache.http.NameValuePair


### PR DESCRIPTION
This pull request will fix several issues in Repository Contents API.

- Fix `sha` in Get Contents API response to the blob SHA from the commit id
- Fix the response schema of Create / Update Contents API
- Fix SHA check in Create / Update Contents API (closes #2761)

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
