### PR TITLE
Update sbt-dependency-graph plugin installation

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
-addSbtPlugin("org.scalameta"    % "sbt-scalafmt"         % "2.4.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl"            % "1.5.1")
-addSbtPlugin("com.eed3si9n"     % "sbt-assembly"         % "1.0.0")
-addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra"         % "1.0.4")
-addSbtPlugin("com.github.sbt"   % "sbt-pgp"              % "2.1.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-license-report"   % "1.2.0")
-addSbtPlugin("org.scoverage"    % "sbt-scoverage"        % "1.8.2")
+addSbtPlugin("org.scalameta"    % "sbt-scalafmt"       % "2.4.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl"          % "1.5.1")
+addSbtPlugin("com.eed3si9n"     % "sbt-assembly"       % "1.0.0")
+addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra"       % "1.0.4")
+addSbtPlugin("com.github.sbt"   % "sbt-pgp"            % "2.1.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
+addSbtPlugin("org.scoverage"    % "sbt-scoverage"      % "1.8.2")
 
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,6 @@ addSbtPlugin("com.eed3si9n"     % "sbt-assembly"         % "1.0.0")
 addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra"         % "1.0.4")
 addSbtPlugin("com.github.sbt"   % "sbt-pgp"              % "2.1.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report"   % "1.2.0")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("org.scoverage"    % "sbt-scoverage"        % "1.8.2")
+
+addDependencyTreePlugin


### PR DESCRIPTION
According with https://github.com/sbt/sbt-dependency-graph#usage-instructions, for sbt >= 1.4.x we should install the plugin with `addDependencyTreePlugin` instead of `addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")`

### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
