### PR TITLE
Closes #2818 - Supporting custom SSH URL's when hosting behind a proxy

### DIFF
--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -12,6 +12,7 @@ import gitbucket.core.util.JGitUtil.FileInfo
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.{Repository => _}
+
 import scala.util.Using
 
 trait RepositoryService {
@@ -835,12 +836,10 @@ object RepositoryService {
 
   def httpUrl(owner: String, name: String)(implicit context: Context): String =
     s"${context.baseUrl}/git/${owner}/${name}.git"
+
   def sshUrl(owner: String, name: String)(implicit context: Context): Option[String] =
-    if (context.settings.ssh.enabled) {
-      context.settings.sshAddress.map { x =>
-        s"ssh://${x.genericUser}@${x.host}:${x.port}/${owner}/${name}.git"
-      }
-    } else None
+    context.settings.sshUrl(owner, name)
+
   def openRepoUrl(openUrl: String)(implicit context: Context): String =
     s"github-${context.platform}://openRepo/${openUrl}"
 

--- a/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
@@ -3,7 +3,6 @@ package gitbucket.core.servlet
 import java.io.File
 import java.util
 import java.util.Date
-
 import scala.util.Using
 import gitbucket.core.api
 import gitbucket.core.api.JsonFormat.Context
@@ -209,9 +208,7 @@ class GitBucketReceivePackFactory extends ReceivePackFactory[HttpServletRequest]
 
       val settings = loadSystemSettings()
       val baseUrl = settings.baseUrl(request)
-      val sshUrl = settings.sshAddress.map { x =>
-        s"${x.genericUser}@${x.host}:${x.port}"
-      }
+      val sshUrl = settings.sshUrl(owner, repository)
 
       if (!repository.endsWith(".wiki")) {
         val hook = new CommitLogHook(owner, repository, pusher, baseUrl, sshUrl)

--- a/src/main/scala/gitbucket/core/ssh/GitCommand.scala
+++ b/src/main/scala/gitbucket/core/ssh/GitCommand.scala
@@ -9,19 +9,23 @@ import org.apache.sshd.server.{Environment, ExitCallback, SessionAware}
 import org.apache.sshd.server.command.{Command, CommandFactory}
 import org.apache.sshd.server.session.ServerSession
 import org.slf4j.LoggerFactory
-import java.io.{File, InputStream, OutputStream}
 
+import java.io.{File, InputStream, OutputStream}
 import org.eclipse.jgit.api.Git
 import Directory._
+import gitbucket.core.service.SystemSettingsService.SshAddress
 import gitbucket.core.ssh.PublicKeyAuthenticator.AuthType
 import org.eclipse.jgit.transport.{ReceivePack, UploadPack}
 import org.apache.sshd.server.shell.UnknownCommand
 import org.eclipse.jgit.errors.RepositoryNotFoundException
+
 import scala.util.Using
 
 object GitCommand {
   val DefaultCommandRegex = """\Agit-(upload|receive)-pack '/([a-zA-Z0-9\-_.]+)/([a-zA-Z0-9\-\+_.]+).git'\Z""".r
   val SimpleCommandRegex = """\Agit-(upload|receive)-pack '/(.+\.git)'\Z""".r
+  val DefaultCommandRegexPort22 = """\Agit-(upload|receive)-pack '/?([a-zA-Z0-9\-_.]+)/([a-zA-Z0-9\-\+_.]+).git'\Z""".r
+  val SimpleCommandRegexPort22 = """\Agit-(upload|receive)-pack '/?(.+\.git)'\Z""".r
 }
 
 abstract class GitCommand extends Command with SessionAware {
@@ -159,7 +163,7 @@ class DefaultGitUploadPack(owner: String, repoName: String)
   }
 }
 
-class DefaultGitReceivePack(owner: String, repoName: String, baseUrl: String, sshUrl: Option[String])
+class DefaultGitReceivePack(owner: String, repoName: String, baseUrl: String, sshAddress: SshAddress)
     extends DefaultGitCommand(owner, repoName)
     with RepositoryService
     with AccountService
@@ -177,7 +181,8 @@ class DefaultGitReceivePack(owner: String, repoName: String, baseUrl: String, ss
         val repository = git.getRepository
         val receive = new ReceivePack(repository)
         if (!repoName.endsWith(".wiki")) {
-          val hook = new CommitLogHook(owner, repoName, userName(authType), baseUrl, sshUrl)
+          val hook =
+            new CommitLogHook(owner, repoName, userName(authType), baseUrl, Some(sshAddress.getUrl(owner, repoName)))
           receive.setPreReceiveHook(hook)
           receive.setPostReceiveHook(hook)
         }
@@ -227,7 +232,7 @@ class PluginGitReceivePack(repoName: String, routing: GitRepositoryRouting)
   }
 }
 
-class GitCommandFactory(baseUrl: String, sshUrl: Option[String]) extends CommandFactory {
+class GitCommandFactory(baseUrl: String, sshAddress: SshAddress) extends CommandFactory {
   private val logger = LoggerFactory.getLogger(classOf[GitCommandFactory])
 
   override def createCommand(command: String): Command = {
@@ -238,19 +243,24 @@ class GitCommandFactory(baseUrl: String, sshUrl: Option[String]) extends Command
       case f if f.isDefinedAt(command) => f(command)
     }
 
-    pluginCommand match {
-      case Some(x) => x
-      case None =>
-        command match {
-          case SimpleCommandRegex("upload", repoName) if (pluginRepository(repoName)) =>
-            new PluginGitUploadPack(repoName, routing(repoName))
-          case SimpleCommandRegex("receive", repoName) if (pluginRepository(repoName)) =>
-            new PluginGitReceivePack(repoName, routing(repoName))
-          case DefaultCommandRegex("upload", owner, repoName) => new DefaultGitUploadPack(owner, repoName)
-          case DefaultCommandRegex("receive", owner, repoName) =>
-            new DefaultGitReceivePack(owner, repoName, baseUrl, sshUrl)
-          case _ => new UnknownCommand(command)
+    pluginCommand.getOrElse {
+      val (simpleRegex, defaultRegex) =
+        if (sshAddress.isDefaultPort) {
+          (SimpleCommandRegexPort22, DefaultCommandRegexPort22)
+        } else {
+          (SimpleCommandRegex, DefaultCommandRegex)
         }
+      command match {
+        case simpleRegex("upload", repoName) if pluginRepository(repoName) =>
+          new PluginGitUploadPack(repoName, routing(repoName))
+        case simpleRegex("receive", repoName) if pluginRepository(repoName) =>
+          new PluginGitReceivePack(repoName, routing(repoName))
+        case defaultRegex("upload", owner, repoName) =>
+          new DefaultGitUploadPack(owner, repoName)
+        case defaultRegex("receive", owner, repoName) =>
+          new DefaultGitReceivePack(owner, repoName, baseUrl, sshAddress)
+        case _ => new UnknownCommand(command)
+      }
     }
   }
 

--- a/src/main/scala/gitbucket/core/ssh/NoShell.scala
+++ b/src/main/scala/gitbucket/core/ssh/NoShell.scala
@@ -15,6 +15,7 @@ class NoShell(sshAddress: SshAddress) extends Factory[Command] {
     private var callback: ExitCallback = null
 
     override def start(env: Environment): Unit = {
+      val placeholderAddress = sshAddress.getUrl("OWNER", "REPOSITORY_NAME")
       val message =
         """
           | Welcome to
@@ -30,8 +31,8 @@ class NoShell(sshAddress: SshAddress) extends Factory[Command] {
           |
           | Please use:
           |
-          | git clone ssh://%s@%s:%d/OWNER/REPOSITORY_NAME.git
-        """.stripMargin.format(sshAddress.genericUser, sshAddress.host, sshAddress.port).replace("\n", "\r\n") + "\r\n"
+          | git clone %s
+        """.stripMargin.format(placeholderAddress).replace("\n", "\r\n") + "\r\n"
       err.write(Constants.encode(message))
       err.flush()
       in.close()

--- a/src/main/scala/gitbucket/core/util/Implicits.scala
+++ b/src/main/scala/gitbucket/core/util/Implicits.scala
@@ -22,9 +22,7 @@ object Implicits {
   implicit def request2Session(implicit request: HttpServletRequest): JdbcBackend#Session = Database.getSession(request)
 
   implicit def context2ApiJsonFormatContext(implicit context: Context): JsonFormat.Context =
-    JsonFormat.Context(context.baseUrl, context.settings.sshAddress.map { x =>
-      s"${x.genericUser}@${x.host}:${x.port}"
-    })
+    JsonFormat.Context(context.baseUrl, context.settings.sshUrl)
 
   implicit class RichSeq[A](private val seq: Seq[A]) extends AnyVal {
 

--- a/src/main/twirl/gitbucket/core/admin/settings_integrations.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_integrations.scala.html
@@ -19,22 +19,40 @@
   <label class="checkbox">
     <input type="checkbox" id="sshEnabled" name="ssh.enabled"@if(context.settings.ssh.enabled){ checked}/>
     Enable SSH access to git repository
-    <span class="muted normal">(Both SSH host and Base URL are required if SSH access is enabled)</span>
+    <span class="muted normal">(Both SSH bind host and Base URL are required if SSH access is enabled)</span>
   </label>
 </fieldset>
 <div class="ssh">
-  <div class="form-group">
-    <label class="control-label col-md-2" for="sshHost">SSH host</label>
-    <div class="col-md-10">
-      <input type="text" id="sshHost" name="ssh.host" class="form-control" value="@context.settings.ssh.sshHost"/>
-      <span id="error-ssh_host" class="error"></span>
+  <div class="bindAddress">
+    <div class="form-group">
+      <label class="control-label col-md-2" for="sshBindHost">SSH bind host</label>
+      <div class="col-md-10">
+        <input type="text" id="sshBindHost" name="ssh.bindAddress.host" class="form-control" value="@context.settings.ssh.bindAddress.map(_.host)"/>
+        <span id="error-ssh_bindAddress_host" class="error"></span>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="control-label col-md-2" for="sshBindPort">SSH bind port</label>
+      <div class="col-md-10">
+        <input type="text" id="sshBindPort" name="ssh.bindAddress.port" class="form-control" value="@context.settings.ssh.bindAddress.map(_.port)"/>
+        <span id="error-ssh_bindAddress_port" class="error"></span>
+      </div>
     </div>
   </div>
-  <div class="form-group">
-    <label class="control-label col-md-2" for="sshPort">SSH port</label>
-    <div class="col-md-10">
-      <input type="text" id="sshPort" name="ssh.port" class="form-control" value="@context.settings.ssh.sshPort"/>
-      <span id="error-ssh_port" class="error"></span>
+  <div class="publicAddress">
+    <div class="form-group">
+      <label class="control-label col-md-2" for="sshPublicHost">SSH public host</label>
+      <div class="col-md-10">
+        <input type="text" id="sshPublicHost" name="ssh.publicAddress.host" class="form-control" value="@context.settings.ssh.publicAddress.map(_.host)"/>
+        <span id="error-ssh_publicAddress_host" class="error"></span>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="control-label col-md-2" for="sshPublicPort">SSH public port</label>
+      <div class="col-md-10">
+        <input type="text" id="sshPublicPort" name="ssh.publicAddress.port" class="form-control" value="@context.settings.ssh.publicAddress.map(_.port)"/>
+        <span id="error-ssh_publicAddress_port" class="error"></span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
+++ b/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
@@ -47,8 +47,8 @@ trait ServiceSpecBase {
       limitVisibleRepositories = false,
       ssh = Ssh(
         enabled = false,
-        sshHost = None,
-        sshPort = None
+        bindAddress = None,
+        publicAddress = None
       ),
       useSMTP = false,
       smtp = None,

--- a/src/test/scala/gitbucket/core/service/SystemSettingsServiceSpec.scala
+++ b/src/test/scala/gitbucket/core/service/SystemSettingsServiceSpec.scala
@@ -1,0 +1,113 @@
+package gitbucket.core.service
+
+import gitbucket.core.service.SystemSettingsService.SshAddress
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.util.Properties
+
+class SystemSettingsServiceSpec extends AnyWordSpecLike with Matchers {
+
+  "loadSystemSettings" should {
+    "read old-style ssh configuration" in new SystemSettingsService {
+      val props = new Properties()
+      props.setProperty("ssh", "true")
+      props.setProperty("ssh.host", "127.0.0.1")
+      props.setProperty("ssh.port", "8022")
+
+      val settings = loadSystemSettings(props)
+      settings.ssh.enabled shouldBe true
+      settings.ssh.bindAddress shouldBe Some(SshAddress("127.0.0.1", 8022, "git"))
+      settings.ssh.publicAddress shouldBe settings.ssh.bindAddress
+    }
+    "read new-style ssh configuration" in new SystemSettingsService {
+      val props = new Properties()
+      props.setProperty("ssh", "true")
+      props.setProperty("ssh.bindAddress.host", "127.0.0.1")
+      props.setProperty("ssh.bindAddress.port", "8022")
+      props.setProperty("ssh.publicAddress.host", "code.these.solutions")
+      props.setProperty("ssh.publicAddress.port", "22")
+
+      val settings = loadSystemSettings(props)
+      settings.ssh.enabled shouldBe true
+      settings.ssh.bindAddress shouldBe Some(SshAddress("127.0.0.1", 8022, "git"))
+      settings.ssh.publicAddress shouldBe Some(SshAddress("code.these.solutions", 22, "git"))
+    }
+    "default the ssh port if not specified" in new SystemSettingsService {
+      val props = new Properties()
+      props.setProperty("ssh", "true")
+      props.setProperty("ssh.bindAddress.host", "127.0.0.1")
+      props.setProperty("ssh.publicAddress.host", "code.these.solutions")
+
+      val settings = loadSystemSettings(props)
+      settings.ssh.enabled shouldBe true
+      settings.ssh.bindAddress shouldBe Some(SshAddress("127.0.0.1", 29418, "git"))
+      settings.ssh.publicAddress shouldBe Some(SshAddress("code.these.solutions", 22, "git"))
+    }
+    "default the public address if not specified" in new SystemSettingsService {
+      val props = new Properties()
+      props.setProperty("ssh", "true")
+      props.setProperty("ssh.bindAddress.host", "127.0.0.1")
+      props.setProperty("ssh.bindAddress.port", "8022")
+
+      val settings = loadSystemSettings(props)
+      settings.ssh.enabled shouldBe true
+      settings.ssh.bindAddress shouldBe Some(SshAddress("127.0.0.1", 8022, "git"))
+      settings.ssh.publicAddress shouldBe settings.ssh.bindAddress
+    }
+    "return addresses even if ssh is not enabled" in new SystemSettingsService {
+      val props = new Properties()
+      props.setProperty("ssh", "false")
+      props.setProperty("ssh.bindAddress.host", "127.0.0.1")
+      props.setProperty("ssh.bindAddress.port", "8022")
+      props.setProperty("ssh.publicAddress.host", "code.these.solutions")
+      props.setProperty("ssh.publicAddress.port", "22")
+
+      val settings = loadSystemSettings(props)
+      settings.ssh.enabled shouldBe false
+      settings.ssh.bindAddress shouldNot be(empty)
+      settings.ssh.publicAddress shouldNot be(empty)
+    }
+  }
+
+  "SshAddress" can {
+    trait MockContext {
+      val host = "code.these.solutions"
+      val port = 1337
+      val user = "git"
+      lazy val sshAddress = SshAddress(host, port, user)
+    }
+    "isDefaultPort" which {
+      "returns true if using port 22" in new MockContext {
+        override val port = 22
+        sshAddress.isDefaultPort shouldBe true
+      }
+      "returns false if using a different port" in new MockContext {
+        override val port = 8022
+        sshAddress.isDefaultPort shouldBe false
+      }
+    }
+    "getUrl" which {
+      "returns the port number when not using port 22" in new MockContext {
+        override val port = 8022
+        sshAddress.getUrl shouldBe "git@code.these.solutions:8022"
+      }
+      "leaves off the port number when using port 22" in new MockContext {
+        override val port = 22
+        sshAddress.getUrl shouldBe "git@code.these.solutions"
+      }
+    }
+    "getUrl for owner and repo" which {
+      "returns an ssh-protocol url when not using port 22" in new MockContext {
+        override val port = 8022
+        sshAddress.getUrl("np-hard", "quantum-crypto-cracker") shouldBe
+          "ssh://git@code.these.solutions:8022/np-hard/quantum-crypto-cracker.git"
+      }
+      "returns a bare-protocol url when using port 22" in new MockContext {
+        override val port = 22
+        sshAddress.getUrl("syntactic", "brace-stretcher") shouldBe
+          "git@code.these.solutions:syntactic/brace-stretcher.git"
+      }
+    }
+  }
+}

--- a/src/test/scala/gitbucket/core/ssh/GitCommandSpec.scala
+++ b/src/test/scala/gitbucket/core/ssh/GitCommandSpec.scala
@@ -1,38 +1,84 @@
 package gitbucket.core.ssh
 
+import gitbucket.core.service.SystemSettingsService.SshAddress
 import org.apache.sshd.server.shell.UnknownCommand
-import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GitCommandFactorySpec extends AnyFunSpec {
+class GitCommandFactorySpec extends AnyWordSpec with Matchers {
 
-  val factory = new GitCommandFactory("http://localhost:8080", None)
-
-  describe("createCommand") {
-    it("should return GitReceivePack when command is git-receive-pack") {
-      assert(factory.createCommand("git-receive-pack '/owner/repo.git'").isInstanceOf[DefaultGitReceivePack] == true)
-      assert(
-        factory.createCommand("git-receive-pack '/owner/repo.wiki.git'").isInstanceOf[DefaultGitReceivePack] == true
-      )
-    }
-    it("should return GitUploadPack when command is git-upload-pack") {
-      assert(factory.createCommand("git-upload-pack '/owner/repo.git'").isInstanceOf[DefaultGitUploadPack] == true)
-      assert(factory.createCommand("git-upload-pack '/owner/repo.wiki.git'").isInstanceOf[DefaultGitUploadPack] == true)
-    }
-    it("should return UnknownCommand when command is not git-(upload|receive)-pack") {
-      assert(factory.createCommand("git- '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-a-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-up-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("\ngit-upload-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-    }
-    it("should return UnknownCommand when git command has no valid arguments") {
-      // must be: git-upload-pack '/owner/repository_name.git'
-      assert(factory.createCommand("git-upload-pack").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-upload-pack /owner/repo.git").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-upload-pack 'owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-upload-pack '/ownerrepo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-upload-pack '/owner/repo.wiki'").isInstanceOf[UnknownCommand] == true)
-    }
+  trait MockContext {
+    val baseUrl = "https://some.example.tech:8080/code-context"
+    val sshHost = "localhost"
+    val sshPort = 2222
+    lazy val factory = new GitCommandFactory(baseUrl, SshAddress(sshHost, sshPort, "git"))
   }
 
+  "createCommand" when {
+    "receiving a git-receive-pack command" should {
+      "return DefaultGitReceivePack" when {
+        "the path matches owner/repo" in new MockContext {
+          assert(factory.createCommand("git-receive-pack '/owner/repo.git'").isInstanceOf[DefaultGitReceivePack])
+          assert(factory.createCommand("git-receive-pack '/owner/repo.wiki.git'").isInstanceOf[DefaultGitReceivePack])
+        }
+        "the leading slash is left off and running on port 22" in new MockContext {
+          override val sshPort: Int = 22
+          assert(factory.createCommand("git-receive-pack 'owner/repo.git'").isInstanceOf[DefaultGitReceivePack])
+          assert(factory.createCommand("git-receive-pack 'owner/repo.wiki.git'").isInstanceOf[DefaultGitReceivePack])
+        }
+      }
+      "return UnknownCommand" when {
+        "the ssh port is not 22 and the leading slash is missing" in new MockContext {
+          override val sshPort: Int = 1337
+          assert(factory.createCommand("git-receive-pack 'owner/repo.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-receive-pack 'owner/repo.wiki.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-receive-pack 'oranges.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-receive-pack 'apples.git'").isInstanceOf[UnknownCommand])
+        }
+        "the path is malformed" in new MockContext {
+          assert(factory.createCommand("git-receive-pack '/owner/repo/wrong.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-receive-pack '/owner:repo.wiki.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-receive-pack '/oranges'").isInstanceOf[UnknownCommand])
+        }
+      }
+    }
+    "receiving a git-upload-pack command" should {
+      "return DefaultGitUploadPack" when {
+        "the path matches owner/repo" in new MockContext {
+          assert(factory.createCommand("git-upload-pack '/owner/repo.git'").isInstanceOf[DefaultGitUploadPack])
+          assert(factory.createCommand("git-upload-pack '/owner/repo.wiki.git'").isInstanceOf[DefaultGitUploadPack])
+        }
+        "the leading slash is left off and running on port 22" in new MockContext {
+          override val sshPort = 22
+          assert(factory.createCommand("git-upload-pack 'owner/repo.git'").isInstanceOf[DefaultGitUploadPack])
+          assert(factory.createCommand("git-upload-pack 'owner/repo.wiki.git'").isInstanceOf[DefaultGitUploadPack])
+        }
+      }
+      "return UnknownCommand" when {
+        "the ssh port is not 22 and the leading slash is missing" in new MockContext {
+          override val sshPort = 1337
+          assert(factory.createCommand("git-upload-pack 'owner/repo.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-upload-pack 'owner/repo.wiki.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-upload-pack 'oranges.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-upload-pack 'apples.git'").isInstanceOf[UnknownCommand])
+        }
+        "the path is malformed" in new MockContext {
+          assert(factory.createCommand("git-upload-pack '/owner/repo'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-upload-pack '/owner:repo.wiki.git'").isInstanceOf[UnknownCommand])
+          assert(factory.createCommand("git-upload-pack '/oranges'").isInstanceOf[UnknownCommand])
+        }
+      }
+    }
+    "receiving any command not matching git-(receive|upload)-pack" should {
+      "return UnknownCommand" in new MockContext {
+        assert(factory.createCommand("git-destroy-pack '/owner/repo.git'").isInstanceOf[UnknownCommand])
+        assert(factory.createCommand("git-irrigate-pack '/apples.git'").isInstanceOf[UnknownCommand])
+        assert(factory.createCommand("git-force-push '/stolen/nuke.git'").isInstanceOf[UnknownCommand])
+        assert(factory.createCommand("git-delete '/backups.git'").isInstanceOf[UnknownCommand])
+        assert(factory.createCommand("git-pack '/your/bags.git'").isInstanceOf[UnknownCommand])
+        assert(factory.createCommand("git- '/bananas.git'").isInstanceOf[UnknownCommand])
+        assert(factory.createCommand("99 tickets of bugs on the wall").isInstanceOf[UnknownCommand])
+      }
+    }
+  }
 }

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -166,8 +166,8 @@ class AvatarImageProviderSpec extends AnyFunSpec {
       limitVisibleRepositories = false,
       ssh = Ssh(
         enabled = false,
-        sshHost = None,
-        sshPort = None
+        bindAddress = None,
+        publicAddress = None
       ),
       useSMTP = false,
       smtp = None,


### PR DESCRIPTION
I've made changes to support hosting GitBucket behind a proxy. The public SSH host and port can now be configured independently of the locally-bound SSH host and port. When the public port is 22, the SSH url's leave off "ssh://" and the port number: they look like what everyone's used to on GitHub.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
