### PR TITLE
Remove unnecessary workaround for scala-xml version conflict

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,6 @@ resolvers ++= Seq(
   "sonatype-snapshot" at "https://oss.sonatype.org/content/repositories/snapshots/"
 )
 
-libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
-
 libraryDependencies ++= Seq(
   "org.eclipse.jgit"                % "org.eclipse.jgit.http.server" % JgitVersion,
   "org.eclipse.jgit"                % "org.eclipse.jgit.archive"     % JgitVersion,


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
