### PR TITLE
Fix line highlighting in dark syntax highlighter themes

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/blob.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/blob.scala.html
@@ -244,7 +244,7 @@ function updateHighlighting() {
   const isDark = @{highlighterTheme.contains("dark").toString};
   if (hash.match(/#L\d+(-L\d+)?/)) {
     if (isDark) {
-      $('li.highlight').removeClass('highlight-dark');
+      $('li.highlight-dark').removeClass('highlight-dark');
     } else {
       $('li.highlight').removeClass('highlight');
     }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

### Description

If you select a **dark** syntax highlighter theme in your account settings, clicking on another line in the repository file viewer will not remove the highlight.
This PR fixes this.