### PR TITLE
Remove unnecessary loading of google-code-prettify

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/preview.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/preview.scala.html
@@ -40,8 +40,6 @@
     </div>
   </div>
 </div>
-<link  href="@helpers.assets("/vendors/google-code-prettify/prettify.css")" type="text/css" rel="stylesheet"/>
-<script src="@helpers.assets("/vendors/google-code-prettify/prettify.js")"></script>
 <script>
 $(function(){
   @if(elastic){


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

### Description

GitBucket loads additional `google-code-prettify` when editing comments, but `google-code-prettify` is already loaded in [`main.scala.html`](https://github.com/gitbucket/gitbucket/blob/37accd92d6bd49ecd77ba47b4e2e776db25111cd/src/main/twirl/gitbucket/core/main.scala.html#L50).
Therefore, no additional loading is required.
This PR will remove it.
This is affecting my code-highlighter-plugin. (kaz-on/gitbucket-code-highlighter-plugin#3)
