### PR TITLE
Bump apache-sshd to 2.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons"              % "commons-email"                % "1.5",
   "commons-net"                     % "commons-net"                  % "3.8.0",
   "org.apache.httpcomponents"       % "httpclient"                   % "4.5.13",
-  "org.apache.sshd"                 % "apache-sshd"                  % "2.1.0" exclude ("org.slf4j", "slf4j-jdk14") exclude ("org.apache.sshd", "sshd-mina") exclude ("org.apache.sshd", "sshd-netty"),
+  "org.apache.sshd"                 % "apache-sshd"                  % "2.7.0" exclude ("org.slf4j", "slf4j-jdk14") exclude ("org.apache.sshd", "sshd-mina") exclude ("org.apache.sshd", "sshd-netty"),
   "org.apache.tika"                 % "tika-core"                    % "2.1.0",
   "com.github.takezoe"              %% "blocking-slick-32"           % "0.0.12" cross CrossVersion.for3Use2_13,
   "com.novell.ldap"                 % "jldap"                        % "2009-10-07",

--- a/src/main/scala/gitbucket/core/ssh/GitCommand.scala
+++ b/src/main/scala/gitbucket/core/ssh/GitCommand.scala
@@ -5,18 +5,20 @@ import gitbucket.core.plugin.{GitRepositoryRouting, PluginRegistry}
 import gitbucket.core.service.{AccountService, DeployKeyService, RepositoryService, SystemSettingsService}
 import gitbucket.core.servlet.{CommitLogHook, Database}
 import gitbucket.core.util.Directory
-import org.apache.sshd.server.{Environment, ExitCallback, SessionAware}
+import org.apache.sshd.server.{Environment, ExitCallback}
 import org.apache.sshd.server.command.{Command, CommandFactory}
-import org.apache.sshd.server.session.ServerSession
+import org.apache.sshd.server.session.{ServerSession, ServerSessionAware}
 import org.slf4j.LoggerFactory
-import java.io.{File, InputStream, OutputStream}
 
+import java.io.{File, InputStream, OutputStream}
 import org.eclipse.jgit.api.Git
 import Directory._
 import gitbucket.core.ssh.PublicKeyAuthenticator.AuthType
+import org.apache.sshd.server.channel.ChannelSession
 import org.eclipse.jgit.transport.{ReceivePack, UploadPack}
 import org.apache.sshd.server.shell.UnknownCommand
 import org.eclipse.jgit.errors.RepositoryNotFoundException
+
 import scala.util.Using
 
 object GitCommand {
@@ -24,7 +26,7 @@ object GitCommand {
   val SimpleCommandRegex = """\Agit-(upload|receive)-pack '/(.+\.git)'\Z""".r
 }
 
-abstract class GitCommand extends Command with SessionAware {
+abstract class GitCommand extends Command with ServerSessionAware {
 
   private val logger = LoggerFactory.getLogger(classOf[GitCommand])
 
@@ -57,12 +59,12 @@ abstract class GitCommand extends Command with SessionAware {
     }
   }
 
-  final override def start(env: Environment): Unit = {
+  final override def start(channel: ChannelSession, env: Environment): Unit = {
     val thread = new Thread(newTask())
     thread.start()
   }
 
-  override def destroy(): Unit = {}
+  override def destroy(channel: ChannelSession): Unit = {}
 
   override def setExitCallback(callback: ExitCallback): Unit = {
     this.callback = callback
@@ -230,7 +232,7 @@ class PluginGitReceivePack(repoName: String, routing: GitRepositoryRouting)
 class GitCommandFactory(baseUrl: String, sshUrl: Option[String]) extends CommandFactory {
   private val logger = LoggerFactory.getLogger(classOf[GitCommandFactory])
 
-  override def createCommand(command: String): Command = {
+  override def createCommand(channel: ChannelSession, command: String): Command = {
     import GitCommand._
     logger.debug(s"command: $command")
 

--- a/src/main/scala/gitbucket/core/ssh/NoShell.scala
+++ b/src/main/scala/gitbucket/core/ssh/NoShell.scala
@@ -1,20 +1,22 @@
 package gitbucket.core.ssh
 
 import gitbucket.core.service.SystemSettingsService.SshAddress
-import org.apache.sshd.common.Factory
+import org.apache.sshd.server.channel.ChannelSession
 import org.apache.sshd.server.{Environment, ExitCallback}
 import org.apache.sshd.server.command.Command
-import java.io.{OutputStream, InputStream}
+import org.apache.sshd.server.shell.ShellFactory
+
+import java.io.{InputStream, OutputStream}
 import org.eclipse.jgit.lib.Constants
 
-class NoShell(sshAddress: SshAddress) extends Factory[Command] {
-  override def create(): Command = new Command() {
+class NoShell(sshAddress: SshAddress) extends ShellFactory {
+  override def createShell(channel: ChannelSession): Command = new Command() {
     private var in: InputStream = null
     private var out: OutputStream = null
     private var err: OutputStream = null
     private var callback: ExitCallback = null
 
-    override def start(env: Environment): Unit = {
+    override def start(channel: ChannelSession, env: Environment): Unit = {
       val message =
         """
           | Welcome to
@@ -40,7 +42,7 @@ class NoShell(sshAddress: SshAddress) extends Factory[Command] {
       callback.onExit(127)
     }
 
-    override def destroy(): Unit = {}
+    override def destroy(channel: ChannelSession): Unit = {}
 
     override def setInputStream(in: InputStream): Unit = {
       this.in = in

--- a/src/main/scala/gitbucket/core/ssh/PublicKeyAuthenticator.scala
+++ b/src/main/scala/gitbucket/core/ssh/PublicKeyAuthenticator.scala
@@ -8,13 +8,13 @@ import gitbucket.core.model.Profile.profile.blockingApi._
 import gitbucket.core.ssh.PublicKeyAuthenticator.AuthType
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator
 import org.apache.sshd.server.session.ServerSession
-import org.apache.sshd.common.AttributeStore
+import org.apache.sshd.common.AttributeRepository
 import org.slf4j.LoggerFactory
 
 object PublicKeyAuthenticator {
 
   // put in the ServerSession here to be read by GitCommand later
-  private val authTypeSessionKey = new AttributeStore.AttributeKey[AuthType]
+  private val authTypeSessionKey = new AttributeRepository.AttributeKey[AuthType]
 
   def putAuthType(serverSession: ServerSession, authType: AuthType): Unit =
     serverSession.setAttribute(authTypeSessionKey, authType)

--- a/src/test/scala/gitbucket/core/ssh/GitCommandSpec.scala
+++ b/src/test/scala/gitbucket/core/ssh/GitCommandSpec.scala
@@ -1,5 +1,6 @@
 package gitbucket.core.ssh
 
+import org.apache.sshd.server.channel.ChannelSession
 import org.apache.sshd.server.shell.UnknownCommand
 import org.scalatest.funspec.AnyFunSpec
 
@@ -8,30 +9,41 @@ class GitCommandFactorySpec extends AnyFunSpec {
   val factory = new GitCommandFactory("http://localhost:8080", None)
 
   describe("createCommand") {
+    val channel = new ChannelSession()
     it("should return GitReceivePack when command is git-receive-pack") {
-      assert(factory.createCommand("git-receive-pack '/owner/repo.git'").isInstanceOf[DefaultGitReceivePack] == true)
       assert(
-        factory.createCommand("git-receive-pack '/owner/repo.wiki.git'").isInstanceOf[DefaultGitReceivePack] == true
+        factory.createCommand(channel, "git-receive-pack '/owner/repo.git'").isInstanceOf[DefaultGitReceivePack] == true
+      )
+      assert(
+        factory
+          .createCommand(channel, "git-receive-pack '/owner/repo.wiki.git'")
+          .isInstanceOf[DefaultGitReceivePack] == true
       )
     }
     it("should return GitUploadPack when command is git-upload-pack") {
-      assert(factory.createCommand("git-upload-pack '/owner/repo.git'").isInstanceOf[DefaultGitUploadPack] == true)
-      assert(factory.createCommand("git-upload-pack '/owner/repo.wiki.git'").isInstanceOf[DefaultGitUploadPack] == true)
+      assert(
+        factory.createCommand(channel, "git-upload-pack '/owner/repo.git'").isInstanceOf[DefaultGitUploadPack] == true
+      )
+      assert(
+        factory
+          .createCommand(channel, "git-upload-pack '/owner/repo.wiki.git'")
+          .isInstanceOf[DefaultGitUploadPack] == true
+      )
     }
     it("should return UnknownCommand when command is not git-(upload|receive)-pack") {
-      assert(factory.createCommand("git- '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-a-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-up-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("\ngit-upload-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git- '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git-a-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git-up-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "\ngit-upload-pack '/owner/repo.git'").isInstanceOf[UnknownCommand] == true)
     }
     it("should return UnknownCommand when git command has no valid arguments") {
       // must be: git-upload-pack '/owner/repository_name.git'
-      assert(factory.createCommand("git-upload-pack").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-upload-pack /owner/repo.git").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-upload-pack 'owner/repo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-upload-pack '/ownerrepo.git'").isInstanceOf[UnknownCommand] == true)
-      assert(factory.createCommand("git-upload-pack '/owner/repo.wiki'").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git-upload-pack").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git-upload-pack /owner/repo.git").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git-upload-pack 'owner/repo.git'").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git-upload-pack '/ownerrepo.git'").isInstanceOf[UnknownCommand] == true)
+      assert(factory.createCommand(channel, "git-upload-pack '/owner/repo.wiki'").isInstanceOf[UnknownCommand] == true)
     }
   }
 


### PR DESCRIPTION
Closes #2926

> EDDSA support was added to bc-java in bcgit/bc-java#636 and seemed to be released in 1.65 (bcgit/bc-java@ab48c91). However, apache-sshd has a dependency on bc-java 1.60 which doesn't have EDDSA support. Looks like the minimum version of apache-sshd that supports EDDSA is 2.6.0 (apache/mina-sshd@c3d8d57).

Closes #2495

> GitBucket uses [bouncycastle-java](https://github.com/bcgit/bc-java) for verifying signed commits, but JGit's dependency on the latest version of bc-java (1.69) seems to be overridden by apache-sshd 2.1.0's one (1.60) and this old version of bc-java doesn't support EDDSA. Probably, this is the root cause of this error. We have to use newer version of bc-java (>= 1.65) to support EDDSA.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
