### PR TITLE
Fix SSH command extension point for apache-sshd 2.x

### DIFF
--- a/src/main/scala/gitbucket/core/plugin/Plugin.scala
+++ b/src/main/scala/gitbucket/core/plugin/Plugin.scala
@@ -1,14 +1,15 @@
 package gitbucket.core.plugin
 
 import javax.servlet.ServletContext
-
 import gitbucket.core.controller.{Context, ControllerBase}
 import gitbucket.core.model.{Account, Issue}
 import gitbucket.core.service.RepositoryService.RepositoryInfo
 import gitbucket.core.service.SystemSettingsService.SystemSettings
 import io.github.gitbucket.solidbase.model.Version
+import org.apache.sshd.server.channel.ChannelSession
 import org.apache.sshd.server.command.Command
 import play.twirl.api.Html
+
 import scala.util.Using
 
 /**
@@ -323,7 +324,7 @@ abstract class Plugin {
   /**
    * Override to add ssh command providers.
    */
-  val sshCommandProviders: Seq[PartialFunction[String, Command]] = Nil
+  val sshCommandProviders: Seq[PartialFunction[String, ChannelSession => Command]] = Nil
 
   /**
    * Override to add ssh command providers.
@@ -332,7 +333,7 @@ abstract class Plugin {
     registry: PluginRegistry,
     context: ServletContext,
     settings: SystemSettings
-  ): Seq[PartialFunction[String, Command]] = Nil
+  ): Seq[PartialFunction[String, ChannelSession => Command]] = Nil
 
   /**
    * This method is invoked in initialization of plugin system.

--- a/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
+++ b/src/main/scala/gitbucket/core/plugin/PluginRegistry.scala
@@ -6,7 +6,6 @@ import java.nio.file.{Files, Paths, StandardWatchEventKinds}
 import java.util.Base64
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.ConcurrentHashMap
-
 import javax.servlet.ServletContext
 import com.github.zafarkhaja.semver.Version
 import gitbucket.core.controller.{Context, ControllerBase}
@@ -21,6 +20,7 @@ import io.github.gitbucket.solidbase.Solidbase
 import io.github.gitbucket.solidbase.manager.JDBCVersionManager
 import io.github.gitbucket.solidbase.model.Module
 import org.apache.commons.io.FileUtils
+import org.apache.sshd.server.channel.ChannelSession
 import org.apache.sshd.server.command.Command
 import org.slf4j.LoggerFactory
 import play.twirl.api.Html
@@ -58,7 +58,7 @@ class PluginRegistry {
   private val suggestionProviders = new ConcurrentLinkedQueue[SuggestionProvider]
   suggestionProviders.add(new UserNameSuggestionProvider())
   suggestionProviders.add(new IssueSuggestionProvider())
-  private val sshCommandProviders = new ConcurrentLinkedQueue[PartialFunction[String, Command]]()
+  private val sshCommandProviders = new ConcurrentLinkedQueue[PartialFunction[String, ChannelSession => Command]]()
 
   def addPlugin(pluginInfo: PluginInfo): Unit = plugins.add(pluginInfo)
 
@@ -177,10 +177,11 @@ class PluginRegistry {
 
   def getSuggestionProviders: Seq[SuggestionProvider] = suggestionProviders.asScala.toSeq
 
-  def addSshCommandProvider(sshCommandProvider: PartialFunction[String, Command]): Unit =
+  def addSshCommandProvider(sshCommandProvider: PartialFunction[String, ChannelSession => Command]): Unit =
     sshCommandProviders.add(sshCommandProvider)
 
-  def getSshCommandProviders: Seq[PartialFunction[String, Command]] = sshCommandProviders.asScala.toSeq
+  def getSshCommandProviders: Seq[PartialFunction[String, ChannelSession => Command]] =
+    sshCommandProviders.asScala.toSeq
 }
 
 /**

--- a/src/main/scala/gitbucket/core/ssh/GitCommand.scala
+++ b/src/main/scala/gitbucket/core/ssh/GitCommand.scala
@@ -244,7 +244,7 @@ class GitCommandFactory(baseUrl: String, sshAddress: SshAddress) extends Command
       case f if f.isDefinedAt(command) => f(command)
     }
 
-    pluginCommand.getOrElse {
+    pluginCommand.map(_.apply(channel)).getOrElse {
       val (simpleRegex, defaultRegex) =
         if (sshAddress.isDefaultPort) {
           (SimpleCommandRegexPort22, DefaultCommandRegexPort22)


### PR DESCRIPTION
[gitbucket-maven-repository-plugin](https://github.com/takezoe/gitbucket-maven-repository-plugin) doesn't work with GitBucket 4.37.0  because `ChannelSession` is required for creating `ScpCommand` in apache-sshd 2.x. The interface of extension point needs to be revised to accept `ChannelSession`.

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
