### PR TITLE
make the URLs returned in tag api to point to something that exists

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiRef.scala
+++ b/src/main/scala/gitbucket/core/api/ApiRef.scala
@@ -28,7 +28,7 @@ object ApiRef {
       url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/git/${ref.getName}"),
       `object` = ApiRefCommit(
         sha = ref.getObjectId.getName,
-        url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/git/commits/${ref.getObjectId.getName}"),
+        url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/commits/${ref.getObjectId.getName}"),
         `type` = "commit"
       )
     )
@@ -40,10 +40,16 @@ object ApiRef {
     ApiRef(
       ref = s"refs/tags/${tagInfo.name}",
       url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/git/refs/tags/${tagInfo.name}"),
+      //the GH api distinguishes between "releases" and plain git tags
+      //for "releases", the api returns a reference to the release object (with type `tag`)
+      //this would be something like s"/api/v3/repos/${repositoryName.fullName}/git/tags/<hash-of-tag>"
+      //with a hash for the tag, which I do not fully understand
+      //since this is not yet implemented in GB, we always return a link to the plain `commit` object,
+      //which GH does for tags that are not annotated
       `object` = ApiRefCommit(
         sha = tagInfo.objectId,
-        url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/git/tags/${tagInfo.objectId}"), // TODO This URL is not yet available?
-        `type` = "tag"
+        url = ApiPath(s"/api/v3/repos/${repositoryName.fullName}/commits/${tagInfo.objectId}"),
+        `type` = "commit"
       )
     )
 }

--- a/src/test/scala/gitbucket/core/api/ApiIntegrationTest.scala
+++ b/src/test/scala/gitbucket/core/api/ApiIntegrationTest.scala
@@ -156,7 +156,6 @@ class ApiIntegrationTest extends AnyFunSuite {
         val ref = repo.getRef("tags/v1.0")
         assert(ref.getRef == "refs/tags/v1.0")
         assert(ref.getUrl.toString == "http://localhost:19999/api/v3/repos/root/create_status_test/git/refs/tags/v1.0")
-        assert(ref.getObject.getType == "tag")
       }
     }
   }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*

This PR changes (fixes? I do not know what is correct) what object type is returned by the api call to `<repo>/git/refs/tags`. 
The GH api distinguishes between released tags and plain git tags.

This is taken from https://api.github.com/repos/gitbucket/gitbucket/git/refs/tags:

```
[
  …,
  {
    "ref": "refs/tags/1.3",
    "node_id": "MDM6UmVmOTM1MDc0NjpyZWZzL3RhZ3MvMS4z",
    "url": "https://api.github.com/repos/gitbucket/gitbucket/git/refs/tags/1.3",
    "object": {
      "sha": "d57ec0c73dd5538697d34c56eaa39d8daec0aad0",
      "type": "tag",
      "url": "https://api.github.com/repos/gitbucket/gitbucket/git/tags/d57ec0c73dd5538697d34c56eaa39d8daec0aad0"
    }
  },
  {
    "ref": "refs/tags/1.4",
    "node_id": "MDM6UmVmOTM1MDc0NjpyZWZzL3RhZ3MvMS40",
    "url": "https://api.github.com/repos/gitbucket/gitbucket/git/refs/tags/1.4",
    "object": {
      "sha": "fd84b3f1c4f6b5d505e72d0585c035347a58dfc2",
      "type": "commit",
      "url": "https://api.github.com/repos/gitbucket/gitbucket/git/commits/fd84b3f1c4f6b5d505e72d0585c035347a58dfc2"
    }
  },
 …
]
```

Note that there are two types of `object`s returned (`tag` and `commit`). This PR changes everything to `commit`, because I think GB does not support the api under `<repo>/git/tags/<sha>`, yet.

Then the returned data is at least consistent. It also fixes the api link in case of `commit` from what is returned by GH to what is available in GB. What is correct here?

At least: With the patch Jenkins can now find and build the tags in GitBuckets.