### PR TITLE
Fix milestone count

### DIFF
--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -342,10 +342,7 @@ trait RepositoryService {
             repository.originUserName.getOrElse(repository.userName),
             repository.originRepositoryName.getOrElse(repository.repositoryName)
           ),
-          getOpenMilestones(
-            repository.originUserName.getOrElse(repository.userName),
-            repository.originRepositoryName.getOrElse(repository.repositoryName)
-          ),
+          getOpenMilestones(repository.userName, repository.repositoryName),
           getRepositoryManagers(repository.userName, repository.repositoryName)
         )
     }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

The count of milestones in the repository generated by the fork is incorrect.

Steps To Reproduce:
1. Fork `user1/repo` to `user2/repo` (username and repository name are just examples).
2. Add one milestone to `user1/repo`.
3. The number of milestones in `user2/repo` becomes 1.

This request solved the issue.