### PR TITLE
Set UTF-8 as the default commit charset at the online text editor

### DIFF
--- a/src/main/scala/gitbucket/core/util/StringUtil.scala
+++ b/src/main/scala/gitbucket/core/util/StringUtil.scala
@@ -98,8 +98,8 @@ object StringUtil {
     detector.handleData(content, 0, content.length)
     detector.dataEnd()
     detector.getDetectedCharset match {
-      case null => "UTF-8"
-      case e    => e
+      case null | "US-ASCII" => "UTF-8"
+      case e                 => e
     }
   }
 


### PR DESCRIPTION
Fixes #3100

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
