### PR TITLE
Remove a link to the demo site from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ GitBucket is a Git web platform powered by Scala offering:
 
 ![GitBucket](https://gitbucket.github.io/img/screenshots/screenshot-repository_viewer.png)
 
-You can try an [online demo](https://gitbucket.herokuapp.com/) *(ID: root / Pass: root)* of GitBucket, and also get the latest information at [GitBucket News](https://gitbucket.github.io/gitbucket-news/).
-
 Features
 --------
 The current version of GitBucket provides many features such as:


### PR DESCRIPTION
Heroku seems to be ending the free plan (https://blog.heroku.com/next-chapter).

Recently, I was worrying about the maintenance of our demo site hosted on Heroku. It's may be a good timing to shutdown it.

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
