### PR TITLE
Fix comment diff in Chrome 105

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/commentform.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/commentform.scala.html
@@ -55,10 +55,10 @@
       });
 
       @if(newLineNumber.isDefined){
-        var diff = getDiffData($('table[filename="@fileName"] table.diff tr:has(th.line-num.newline[line-number=@newLineNumber])'));
+        var diff = getDiffData($('table[filename="@fileName"] table.diff tr:has(th.line-num.newline[line-number="@newLineNumber"])'));
         param['diff'] = JSON.stringify(diff);
       } else if(oldLineNumber.isDefined){
-        var diff = getDiffData($('table[filename="@fileName"] table.diff tr:has(th.line-num.oldline[line-number=@oldLineNumber])'));
+        var diff = getDiffData($('table[filename="@fileName"] table.diff tr:has(th.line-num.oldline[line-number="@oldLineNumber"])'));
         param['diff'] = JSON.stringify(diff);
       }
 


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Using Chrome 105, diffs are not shown in comments.

Steps to Reproduce:
1. Create a PullRequest.
2. Open the Files page of the PullRequest.
3. Add a comment to the source code with **Chrome 105**.
4. Diffs are not shown in the comment.

I checked the payload when creating the comment and found that the `diff` parameter is empty.

![image](https://user-images.githubusercontent.com/5700824/189024078-a512b1d2-2244-4077-888f-65e44f30a638.png)

https://github.com/gitbucket/gitbucket/blob/2780fb960516dda2bde95d3f387c93970e7349d7/src/main/twirl/gitbucket/core/repo/commentform.scala.html#L58

In Chrome 104 and earlier, ` getDiffData` returns 1 or more elements.
On the other hand, Chrome 105 always returns an empty array.

This difference is due to the addition of `:has()` in Chrome 105.
In Chrome 104 and earlier, `:has()` is evaluated as a jQuery pseudo-class, but in Chrome 105 it is evaluated as a native `:has()`.

This issue is discussed in the following issues:
* https://github.com/w3c/csswg-drafts/issues/7676
* https://github.com/jquery/jquery/issues/5098

This problem will be solved by using double quotes to specify the `line-number`.
Example: `tr:has(th.line-num.newline[line-number="@newLineNumber"])`

![image](https://user-images.githubusercontent.com/5700824/189023808-e3081d5f-a037-4cfa-b615-4f40bae37819.png)

This is because `[line-number=...]` is invalid as a native selector and `[line-number="..."]` is valid.