### PR TITLE
Fix IllegalStateException when returning unknown avatar image

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -1,7 +1,6 @@
 package gitbucket.core.controller
 
 import java.io.File
-
 import gitbucket.core.account.html
 import gitbucket.core.helper
 import gitbucket.core.model._
@@ -13,10 +12,13 @@ import gitbucket.core.util.Directory._
 import gitbucket.core.util.Implicits._
 import gitbucket.core.util.StringUtil._
 import gitbucket.core.util._
+import org.apache.commons.io.IOUtils
 import org.scalatra.i18n.Messages
 import org.scalatra.BadRequest
 import org.scalatra.forms._
 import org.scalatra.Forbidden
+
+import scala.util.Using
 
 class AccountController
     extends AccountControllerBase
@@ -332,7 +334,9 @@ trait AccountControllerBase extends AccountManagementControllerBase {
       }
       .getOrElse {
         response.setHeader("Cache-Control", "max-age=3600")
-        Thread.currentThread.getContextClassLoader.getResourceAsStream("noimage.png")
+        Using.resource(Thread.currentThread.getContextClassLoader.getResourceAsStream("noimage.png")) { in =>
+          IOUtils.toByteArray(in)
+        }
       }
   }
 


### PR DESCRIPTION
```
2022-10-08 10:29:16.561:WARN:oejs.HttpChannel:qtp83954662-47: /_unknown/_avatar
java.lang.IllegalStateException: STREAM
        at org.eclipse.jetty.server.Response.getWriter(Response.java:737)
        at org.scalatra.ScalatraBase.renderUncaughtException(ScalatraBase.scala:224)
        at org.scalatra.ScalatraBase.renderUncaughtException$(ScalatraBase.scala:218)
        at gitbucket.core.controller.ControllerBase.renderUncaughtException(ControllerBase.scala:36)
        at org.scalatra.ScalatraBase.renderResponseBody(ScalatraBase.scala:418)
        at org.scalatra.ScalatraBase.renderResponseBody$(ScalatraBase.scala:406)
        at gitbucket.core.controller.ControllerBase.renderResponseBody(ControllerBase.scala:36)
        at org.scalatra.ScalatraBase.renderResponse(ScalatraBase.scala:377)
        at org.scalatra.ScalatraBase.renderResponse$(ScalatraBase.scala:371)
        at gitbucket.core.controller.ControllerBase.renderResponse(ControllerBase.scala:36)
        at org.scalatra.ScalatraBase.executeRoutes(ScalatraBase.scala:196)
        at org.scalatra.ScalatraBase.executeRoutes$(ScalatraBase.scala:150)
        at gitbucket.core.controller.ControllerBase.executeRoutes(ControllerBase.scala:36)
        at org.scalatra.ScalatraBase.$anonfun$handle$1(ScalatraBase.scala:123)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at org.scalatra.DynamicScope.withResponse(DynamicScope.scala:75)
        at org.scalatra.DynamicScope.withResponse$(DynamicScope.scala:73)
        at gitbucket.core.controller.ControllerBase.withResponse(ControllerBase.scala:36)
        at org.scalatra.DynamicScope.$anonfun$withRequestResponse$1(DynamicScope.scala:55)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at org.scalatra.DynamicScope.withRequest(DynamicScope.scala:66)
        at org.scalatra.DynamicScope.withRequest$(DynamicScope.scala:64)
        at gitbucket.core.controller.ControllerBase.withRequest(ControllerBase.scala:36)
        at org.scalatra.DynamicScope.withRequestResponse(DynamicScope.scala:54)
        at org.scalatra.DynamicScope.withRequestResponse$(DynamicScope.scala:52)
        at gitbucket.core.controller.ControllerBase.withRequestResponse(ControllerBase.scala:36)
        at org.scalatra.ScalatraBase.handle(ScalatraBase.scala:123)
        at org.scalatra.ScalatraBase.handle$(ScalatraBase.scala:119)
        at gitbucket.core.controller.ControllerBase.org$scalatra$servlet$ServletBase$$super$handle(ControllerBase.scala:36)
        at org.scalatra.servlet.ServletBase.handle(ServletBase.scala:43)
        at org.scalatra.servlet.ServletBase.handle$(ServletBase.scala:36)
        at gitbucket.core.controller.ControllerBase.org$scalatra$FlashMapSupport$$super$handle(ControllerBase.scala:36)
        at org.scalatra.FlashMapSupport.$anonfun$handle$1(FlashMap.scala:177)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at org.scalatra.DynamicScope.withRequest(DynamicScope.scala:66)
        at org.scalatra.DynamicScope.withRequest$(DynamicScope.scala:64)
        at gitbucket.core.controller.ControllerBase.withRequest(ControllerBase.scala:36)
        at org.scalatra.FlashMapSupport.handle(FlashMap.scala:152)
        at org.scalatra.FlashMapSupport.handle$(FlashMap.scala:151)
        at gitbucket.core.controller.ControllerBase.handle(ControllerBase.scala:36)
        at org.scalatra.ScalatraFilter.$anonfun$doFilter$1(ScalatraFilter.scala:41)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at org.scalatra.ScalatraFilter.doFilter(ScalatraFilter.scala:41)
        at org.scalatra.ScalatraFilter.doFilter$(ScalatraFilter.scala:36)
        at gitbucket.core.controller.ControllerBase.doFilter(ControllerBase.scala:74)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1591)
        at gitbucket.core.servlet.TransactionFilter.$anonfun$doFilter$1(TransactionFilter.scala:39)
        at gitbucket.core.servlet.TransactionFilter.$anonfun$doFilter$1$adapted(TransactionFilter.scala:30)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.$anonfun$withTransaction$2(BlockingProfile.scala:207)
        at slick.JdbcProfileBlockingSession$BlockingSession.withTransaction(TransactionalJdbcBackend.scala:26)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.$anonfun$withTransaction$1(BlockingProfile.scala:207)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.withSession(BlockingProfile.scala:200)
        at com.github.takezoe.slick.blocking.BlockingJdbcProfile$BlockingAPI$BlockingDatabase.withTransaction(BlockingProfile.scala:207)
        at gitbucket.core.servlet.TransactionFilter.doFilter(TransactionFilter.scala:30)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1583)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:542)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:536)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1581)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1307)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:482)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1549)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1204)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:221)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.Server.handle(Server.java:494)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:374)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:268)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:367)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:782)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:918)
        at java.base/java.lang.Thread.run(Thread.java:833)
```


### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
