### PR TITLE
Disable scalafmt on compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ name := Name
 version := GitBucketVersion
 scalaVersion := "2.13.10"
 
-scalafmtOnCompile := true
+// scalafmtOnCompile := true
 
 coverageExcludedPackages := ".*\\.html\\..*"
 


### PR DESCRIPTION
For rapid development with auto reloading of xsbt-web-plugin

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
