### PR TITLE
Revert "Fix IllegalStateException when returning unknown avatar image (#3158)"

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -1,6 +1,7 @@
 package gitbucket.core.controller
 
 import java.io.File
+
 import gitbucket.core.account.html
 import gitbucket.core.helper
 import gitbucket.core.model._
@@ -12,13 +13,10 @@ import gitbucket.core.util.Directory._
 import gitbucket.core.util.Implicits._
 import gitbucket.core.util.StringUtil._
 import gitbucket.core.util._
-import org.apache.commons.io.IOUtils
 import org.scalatra.i18n.Messages
 import org.scalatra.BadRequest
 import org.scalatra.forms._
 import org.scalatra.Forbidden
-
-import scala.util.Using
 
 class AccountController
     extends AccountControllerBase


### PR DESCRIPTION
This reverts commit a0be02ce2f7b714d92df9dc69a75a65f54aa217 because the issue has been fixed in Scalatra 2.8.4: https://github.com/scalatra/scalatra/pull/1438

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
