### PR TITLE
Suppress "scanned from multiple locations" warnings in development

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -287,5 +287,6 @@ Test / testOptions ++= {
 
 Jetty / javaOptions ++= Seq(
   "-Xdebug",
-  "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000"
+  "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000",
+  "-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF"
 )


### PR DESCRIPTION
When we start GitBucket by `sbt ~jetty:start` during development, the recent version of Jetty yeilds many warning messages like below:
```
2022-11-12 19:52:35.610:WARN:oeja.AnnotationParser:qtp1851691492-17: javax.activation.ActivationDataFlavor scanned from multiple locations: jar:file:...
```
Even though these warnings are valid, they are too annoying during development. It would be nice if we can surppress them.