### PR TITLE
Fix NoSuchElementException in delete issue comment API

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueCommentControllerBase.scala
@@ -85,7 +85,7 @@ trait ApiIssueCommentControllerBase extends ControllerBase {
    * iv. Delete a comment
    * https://docs.github.com/en/rest/reference/issues#delete-an-issue-comment
    */
-  delete("/api/v3/repos/:owner/:repo/issues/comments/:id")(readableUsersOnly { repository =>
+  delete("/api/v3/repos/:owner/:repository/issues/comments/:id")(readableUsersOnly { repository =>
     val maybeDeleteResponse: Option[Either[ActionResult, Option[Int]]] =
       for {
         commentId <- params("id").toIntOpt


### PR DESCRIPTION
Reported in https://gitter.im/gitbucket/gitbucket?at=63a8cb37378d512c182fb425

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
