### PR TITLE
Support custom fields in search condition

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IndexController.scala
+++ b/src/main/scala/gitbucket/core/controller/IndexController.scala
@@ -265,7 +265,7 @@ trait IndexControllerBase extends ControllerBase {
     } getOrElse ""
   })
 
-  // TODO Move to RepositoryViewrController?
+  // TODO Move to RepositoryViewerController?
   get("/:owner/:repository/search")(referrersOnly { repository =>
     val query = params.getOrElse("q", "").trim
     val target = params.getOrElse("type", "code")

--- a/src/main/twirl/gitbucket/core/issues/list.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/list.scala.html
@@ -24,9 +24,9 @@
         <a href="@condition.copy(state = "closed").toURL">Closed <span class="badge">@closedCount</span></a>
       </li>
     </ul>
-    <form method="GET" action="@helpers.url(repository)/search" id="search-filter-form" class="form-inline pull-right" autocomplete="off">
+    <form method="GET" action="@helpers.url(repository)/@target" id="search-filter-form" class="form-inline pull-right" autocomplete="off">
       <div class="input-group">
-        <input type="text" class="form-control" name="q" placeholder="Search..." aria-label="Search all issues"/>
+        <input type="text" class="form-control" name="q" placeholder="Search..." aria-label="Search all issues" value="@condition.toFilterString" style="width: 300px;"/>
         <input type="hidden" name="type" value="@target"/>
         <span class="input-group-btn">
           <button type="submit" id="search-btn" class="btn btn-default" aria-label="Search all issues"><i class="fa fa-search"></i></button>


### PR DESCRIPTION
`field_name=operator:value`

Supported operators are:

- eq
- lt
- lte
- gt
- gte

TODO:

- [x] `field_name=value` is equivalent with `field_name=eq:value`
- [x] Search box
  <img width="827" alt="Screen Shot 2023-05-29 at 3 38 39" src="https://github.com/gitbucket/gitbucket/assets/1094760/058f7f43-401c-4769-a1c7-f144eb290b3b">
- [ ] Current simple text-based search (`/<user>/<repo>/search`)
  https://github.com/gitbucket/gitbucket/blob/59d1250e360de8ce813c7af3a2a5fa87ffc097c3/src/main/scala/gitbucket/core/controller/IndexController.scala#L265-L310
- [ ] Handling operators properly depending on the field type (it may be difficult with Slick)
  ```scala
  cond.operator match {
    case "eq"  => condQuery(_ === cond.value.bind)
    case "lt"  => condQuery(_ < cond.value.bind)
    case "gt"  => condQuery(_ > cond.value.bind)
    case "lte" => condQuery(_ <= cond.value.bind)
    case "gte" => condQuery(_ >= cond.value.bind)
    case _     => throw new IllegalArgumentException("Unsupported operator")
  }
  ```

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
