### PR TITLE
Make it possible to edit empty custom field value

### DIFF
--- a/src/main/scala/gitbucket/core/model/CustomField.scala
+++ b/src/main/scala/gitbucket/core/model/CustomField.scala
@@ -300,10 +300,22 @@ object CustomFieldBehavior {
       implicit context: Context
     ): String = {
       val sb = new StringBuilder
-      sb.append(
-        s"""<span id="custom-field-$fieldId-label" class="custom-field-label">${StringUtil
-             .escapeHtml(value)}</span>""".stripMargin
-      )
+      if (value.nonEmpty) {
+        sb.append(
+          s"""<span id="custom-field-$fieldId-label" class="custom-field-label">${StringUtil
+            .escapeHtml(value)}</span>"""
+        )
+      } else {
+        if (editable) {
+          sb.append(
+            s"""<span id="custom-field-$fieldId-label" class="custom-field-label"><i class="octicon octicon-pencil" style="cursor: pointer;"></i></span>"""
+          )
+        } else {
+          sb.append(
+            s"""<span id="custom-field-$fieldId-label" class="custom-field-label">N/A</span>"""
+          )
+        }
+      }
       if (editable) {
         sb.append(
           s"""<input type="$fieldType" id="custom-field-$fieldId-editor" class="form-control input-sm custom-field-editor" data-field-id="$fieldId" style="width: 120px; display: none;"/>"""
@@ -328,7 +340,11 @@ object CustomFieldBehavior {
             |          { value: $$this.val() },
             |          function(data){
             |            $$this.hide();
-            |            $$this.prev().text(data).show();
+            |            if (data == '') {
+            |              $$this.prev().html('<i class="octicon octicon-pencil" style="cursor: pointer;">').show();
+            |            } else {
+            |              $$this.prev().text(data).show();
+            |            }
             |          }
             |        );
             |      }


### PR DESCRIPTION
Currently, clicking the custom text field value enters the edit mode but there is no ways to enter the edit mode if the field value is empty.

Showing a pencil icon to enter the edit mode if custom text field value is empty.

<img width="917" alt="Screen Shot 2023-05-06 at 18 30 33" src="https://user-images.githubusercontent.com/1094760/236615929-36618f4e-0ee2-425d-a571-80933a5a9cfd.png">

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
