### PR TITLE
Fix executable war for Jetty 10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,8 +159,7 @@ executableKey := {
   val jettyJars = Keys.update.value select configurationFilter(name = ExecutableConfig.name)
   jettyJars foreach { jar =>
     IO unzip (jar, temp, (name: String) =>
-      (name startsWith "javax/") ||
-        (name startsWith "org/"))
+      (name startsWith "javax/") || (name startsWith "org/") || (name startsWith "META-INF/services/"))
   }
 
   // include original war file


### PR DESCRIPTION
Jetty 10 internally uses ServiceLoader: https://github.com/jetty/jetty.project/blob/jetty-10.0.x/jetty-webapp/src/main/resources/META-INF/services/org.eclipse.jetty.webapp.Configuration

Need to include this service configuration file in the executable war file.

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
