### PR TITLE
Bump gist plugin to 4.23.0 to support GitBucket 4.40.0

### DIFF
--- a/src/main/resources/bundle-plugins.txt
+++ b/src/main/resources/bundle-plugins.txt
@@ -1,4 +1,4 @@
 notifications:1.11.0
-gist:4.22.0
+gist:4.23.0
 emoji:4.6.0
 pages:1.10.0


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
