### PR TITLE
Fix layout of branch selector

### DIFF
--- a/src/main/twirl/gitbucket/core/helper/branchcontrol.scala.html
+++ b/src/main/twirl/gitbucket/core/helper/branchcontrol.scala.html
@@ -5,7 +5,6 @@
 @gitbucket.core.helper.html.dropdown(
   value  = if(branch.length == 40) branch.substring(0, 10) else branch,
   prefix = if(repository.branchList.contains(branch)) "branch" else if (repository.tags.map(_.name).contains(branch)) "tag" else "tree",
-  style = "min-width: 200px;",
   maxValueWidth = "200px"
 ) {
   <li>


### PR DESCRIPTION
Before
<img width="893" alt="Screen Shot 2023-11-12 at 22 43 02" src="https://github.com/gitbucket/gitbucket/assets/1094760/963ca8ef-80f6-4978-803d-b865547f6ca3">

After
<img width="897" alt="Screen Shot 2023-11-12 at 22 42 36" src="https://github.com/gitbucket/gitbucket/assets/1094760/307c79ba-1a55-4f22-bdec-83003f0a5c8d">

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
