### PR TITLE
Keyword search for issues and pull requests using search box

### DIFF
--- a/src/main/scala/gitbucket/core/controller/IssuesController.scala
+++ b/src/main/scala/gitbucket/core/controller/IssuesController.scala
@@ -93,7 +93,13 @@ trait IssuesControllerBase extends ControllerBase {
       case Some(filter) if filter.contains("is:pr") =>
         redirect(s"/${repository.owner}/${repository.name}/pulls?q=${StringUtil.urlEncode(q)}")
       case Some(filter) =>
-        searchIssues(repository, IssueSearchCondition(filter), IssueSearchCondition.page(request))
+        val condition = IssueSearchCondition(filter)
+        if (condition.isEmpty) {
+          // Redirect to keyword search
+          redirect(s"/${repository.owner}/${repository.name}/search?q=${StringUtil.urlEncode(q)}&type=issues")
+        } else {
+          searchIssues(repository, condition, IssueSearchCondition.page(request))
+        }
       case None =>
         searchIssues(repository, IssueSearchCondition(request), IssueSearchCondition.page(request))
     }

--- a/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
+++ b/src/main/scala/gitbucket/core/controller/PullRequestsController.scala
@@ -106,7 +106,13 @@ trait PullRequestsControllerBase extends ControllerBase {
       case Some(filter) if filter.contains("is:issue") =>
         redirect(s"/${repository.owner}/${repository.name}/issues?q=${StringUtil.urlEncode(q)}")
       case Some(filter) =>
-        searchPullRequests(repository, IssueSearchCondition(filter), IssueSearchCondition.page(request))
+        val condition = IssueSearchCondition(filter)
+        if (condition.isEmpty) {
+          // Redirect to keyword search
+          redirect(s"/${repository.owner}/${repository.name}/search?q=${StringUtil.urlEncode(q)}&type=pulls")
+        } else {
+          searchPullRequests(repository, IssueSearchCondition(filter), IssueSearchCondition.page(request))
+        }
       case None =>
         searchPullRequests(repository, IssueSearchCondition(request), IssueSearchCondition.page(request))
     }

--- a/src/main/scala/gitbucket/core/service/IssuesService.scala
+++ b/src/main/scala/gitbucket/core/service/IssuesService.scala
@@ -975,15 +975,15 @@ object IssuesService {
     groups: Set[String] = Set.empty,
     others: Seq[CustomFieldCondition] = Nil
   ) {
-
     def isEmpty: Boolean = {
       labels.isEmpty && milestone.isEmpty && author.isEmpty && assigned.isEmpty &&
-      state == "open" && sort == "created" && direction == "desc" && visibility.isEmpty
+      state == "open" && sort == "created" && direction == "desc" && visibility.isEmpty && others.isEmpty
     }
 
     def nonEmpty: Boolean = !isEmpty
 
-    def toFilterString: String =
+    def toFilterString: String = if (isEmpty) ""
+    else {
       (
         List(
           Some(s"is:${state}"),
@@ -1025,6 +1025,7 @@ object IssuesService {
           } ++
           groups.map(group => s"group:${group}")
       ).mkString(" ")
+    }
 
     def toURL: String = {
       "?" + (Seq(


### PR DESCRIPTION
Integrate keyword search with filtering in one search box.

- The initial state of the search box is empty
- If search query is filter condition, trigger filtering
- Otherwise, trigger keyword search

Closes https://github.com/gitbucket/gitbucket/issues/3407

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
