### PR TITLE
fix: add GitUtils.findBranchesNoMergeInfo and use it when merge info …

### DIFF
--- a/src/main/scala/gitbucket/core/service/PullRequestService.scala
+++ b/src/main/scala/gitbucket/core/service/PullRequestService.scala
@@ -2,26 +2,26 @@ package gitbucket.core.service
 
 import com.github.difflib.DiffUtils
 import com.github.difflib.patch.DeltaType
-import gitbucket.core.model.{CommitComments => _, Session => _, _}
-import gitbucket.core.model.Profile._
-import gitbucket.core.model.Profile.profile.blockingApi._
-import gitbucket.core.service.RepositoryService.RepositoryInfo
 import gitbucket.core.api.JsonFormat
 import gitbucket.core.controller.Context
+import gitbucket.core.model.Profile.*
+import gitbucket.core.model.Profile.profile.blockingApi.*
 import gitbucket.core.model.activity.OpenPullRequestInfo
+import gitbucket.core.model.{CommitComments as _, Session as _, *}
 import gitbucket.core.plugin.PluginRegistry
+import gitbucket.core.service.RepositoryService.RepositoryInfo
 import gitbucket.core.service.SystemSettingsService.SystemSettings
-import gitbucket.core.util.Directory._
-import gitbucket.core.util.Implicits._
+import gitbucket.core.util.Directory.*
+import gitbucket.core.util.Implicits.*
 import gitbucket.core.util.JGitUtil
-import gitbucket.core.util.StringUtil._
-import gitbucket.core.util.JGitUtil.{CommitInfo, DiffInfo, getBranches}
+import gitbucket.core.util.JGitUtil.{CommitInfo, DiffInfo, getBranchesNoMergeInfo}
+import gitbucket.core.util.StringUtil.*
 import gitbucket.core.view
 import gitbucket.core.view.helpers
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.ObjectId
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Using
 
 trait PullRequestService {
@@ -32,7 +32,7 @@ trait PullRequestService {
     with RepositoryService
     with MergeService
     with ActivityService =>
-  import PullRequestService._
+  import PullRequestService.*
 
   def getPullRequest(owner: String, repository: String, issueId: Int)(implicit
     s: Session
@@ -318,7 +318,7 @@ trait PullRequestService {
         base.foreach { _base =>
           if (pr.branch != _base) {
             Using.resource(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
-              getBranches(git, repository.repository.defaultBranch, origin = true)
+              getBranchesNoMergeInfo(git, repository.repository.defaultBranch)
                 .find(_.name == _base)
                 .foreach(br => updateBaseBranch(repository.owner, repository.name, issueId, br.name, br.commitId))
             }

--- a/src/main/scala/gitbucket/core/servlet/GitAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitAuthenticationFilter.scala
@@ -23,9 +23,9 @@ class GitAuthenticationFilter extends Filter with RepositoryService with Account
 
   private val logger = LoggerFactory.getLogger(classOf[GitAuthenticationFilter])
 
-  def init(config: FilterConfig) = {}
+  override def init(config: FilterConfig) = {}
 
-  def destroy(): Unit = {}
+  override def destroy(): Unit = {}
 
   def doFilter(req: ServletRequest, res: ServletResponse, chain: FilterChain): Unit = {
     val request = req.asInstanceOf[HttpServletRequest]

--- a/src/main/scala/gitbucket/core/servlet/SessionCleanupListener.scala
+++ b/src/main/scala/gitbucket/core/servlet/SessionCleanupListener.scala
@@ -1,17 +1,18 @@
 package gitbucket.core.servlet
 
-import javax.servlet.http.{HttpSessionEvent, HttpSessionListener}
-import gitbucket.core.util.Directory
+import gitbucket.core.util.Directory.*
 import org.apache.commons.io.FileUtils
-import Directory._
+
+import javax.servlet.http.{HttpSessionEvent, HttpSessionListener}
 
 /**
  * Removes session associated temporary files when session is destroyed.
  */
 class SessionCleanupListener extends HttpSessionListener {
 
-  def sessionCreated(se: HttpSessionEvent): Unit = {}
+  override def sessionCreated(se: HttpSessionEvent): Unit = {}
 
-  def sessionDestroyed(se: HttpSessionEvent): Unit = FileUtils.deleteDirectory(getTemporaryDir(se.getSession.getId))
+  override def sessionDestroyed(se: HttpSessionEvent): Unit =
+    FileUtils.deleteDirectory(getTemporaryDir(se.getSession.getId))
 
 }

--- a/src/main/scala/gitbucket/core/servlet/TransactionFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/TransactionFilter.scala
@@ -17,9 +17,9 @@ class TransactionFilter extends Filter {
 
   private val logger = LoggerFactory.getLogger(classOf[TransactionFilter])
 
-  def init(config: FilterConfig) = {}
+  override def init(config: FilterConfig): Unit = {}
 
-  def destroy(): Unit = {}
+  override def destroy(): Unit = {}
 
   def doFilter(req: ServletRequest, res: ServletResponse, chain: FilterChain): Unit = {
     val servletPath = req.asInstanceOf[HttpServletRequest].getServletPath()

--- a/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
+++ b/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
@@ -1,12 +1,13 @@
 package gitbucket.core.util
 
-import GitSpecUtil._
+import GitSpecUtil.*
+import gitbucket.core.util.JGitUtil.BranchInfoSimple
 import org.apache.commons.io.IOUtils
 import org.eclipse.jgit.diff.DiffEntry.ChangeType
 import org.eclipse.jgit.lib.Constants
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class JGitUtilSpec extends AnyFunSuite {
 
@@ -170,6 +171,23 @@ class JGitUtilSpec extends AnyFunSuite {
 
       assert(branches(0).commitId != branches(1).commitId)
       assert(branches(0).commitId == branches(2).commitId)
+    }
+  }
+
+
+  test("getBranchesNoMergeInfo") {
+    withTestRepository { git =>
+      createFile(git, Constants.HEAD, "README.md", "body1", message = "commit1")
+      JGitUtil.createBranch(git, "main", "test1")
+
+      createFile(git, Constants.HEAD, "README.md", "body2", message = "commit2")
+      JGitUtil.createBranch(git, "main", "test2")
+
+      // getBranches
+      val branchesNMI = JGitUtil.getBranchesNoMergeInfo(git, "main")
+      val branches= JGitUtil.getBranches(git, "main", true)
+
+      assert(branches.map(bi => BranchInfoSimple(bi.name, bi.committerName, bi.commitTime, bi.committerEmailAddress, bi.commitId)) == branchesNMI)
     }
   }
 

--- a/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
+++ b/src/test/scala/gitbucket/core/util/JGitUtilSpec.scala
@@ -1,6 +1,6 @@
 package gitbucket.core.util
 
-import GitSpecUtil.*
+import gitbucket.core.util.GitSpecUtil.*
 import gitbucket.core.util.JGitUtil.BranchInfoSimple
 import org.apache.commons.io.IOUtils
 import org.eclipse.jgit.diff.DiffEntry.ChangeType
@@ -174,7 +174,6 @@ class JGitUtilSpec extends AnyFunSuite {
     }
   }
 
-
   test("getBranchesNoMergeInfo") {
     withTestRepository { git =>
       createFile(git, Constants.HEAD, "README.md", "body1", message = "commit1")
@@ -185,9 +184,13 @@ class JGitUtilSpec extends AnyFunSuite {
 
       // getBranches
       val branchesNMI = JGitUtil.getBranchesNoMergeInfo(git, "main")
-      val branches= JGitUtil.getBranches(git, "main", true)
+      val branches = JGitUtil.getBranches(git, "main", true)
 
-      assert(branches.map(bi => BranchInfoSimple(bi.name, bi.committerName, bi.commitTime, bi.committerEmailAddress, bi.commitId)) == branchesNMI)
+      assert(
+        branches.map(bi =>
+          BranchInfoSimple(bi.name, bi.committerName, bi.commitTime, bi.committerEmailAddress, bi.commitId)
+        ) == branchesNMI
+      )
     }
   }
 


### PR DESCRIPTION
Creates a new method `JGitUtil.getBranchesNoMergeInfo` that does not perform the expensive repo walks. Then use this method in API requests to list branches.

This is a partial fix for #3434 which improves performance for the API requests. Rendering of the branches page of the repo is still slow.

Maybe renaming the existing method `getBranches` to `getBranchesWithMergeInfo` instead would be a better approach, since the new method should be used whenever possible.
