### PR TITLE
Fix typo

### DIFF
--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,6 +1,6 @@
 Debug GitBucket on IntelliJ
 ========
-Add following configuration for allowing remote debugging to `buils.sbt`:
+Add following configuration for allowing remote debugging to `build.sbt`:
 
 ```scala
 javaOptions in Jetty ++= Seq(


### PR DESCRIPTION
One-character typo fix in documentation. 

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
