### PR TITLE
Calculate diffs between commits based on common ancestor; works …

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ReleasesController.scala
+++ b/src/main/scala/gitbucket/core/controller/ReleasesController.scala
@@ -130,11 +130,10 @@ trait ReleaseControllerBase extends ControllerBase {
   })
 
   get("/:owner/:repository/changelog/*...*")(writableUsersOnly { repository =>
-    val Seq(previousTag, currentTag) = multiParams("splat")
-    val previousTagId = repository.tags.collectFirst { case x if x.name == previousTag => x.commitId }.getOrElse("")
-
     val commitLog = Using.resource(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
-      val commits = JGitUtil.getCommitLog(git, previousTagId, currentTag).reverse
+      val Seq(previousTag, currentTag) = multiParams("splat")
+
+      val commits = JGitUtil.getCommitLog(git, previousTag, currentTag).reverse
       commits
         .map { commit =>
           s"- ${commit.shortMessage} ${commit.id}"


### PR DESCRIPTION
…for force push

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

I've rewritten `JGitUtil.getCommitLog` to properly handle merge bases. It probably also is faster in general, since it uses the proper JGit tools. 
The previous code returned all previous commits in cases of force push (since the old id is gone). The new code now uses JGit to find the merge base with the old id.

**This changes behavior**
I am totally not sure how this method should behave at all. We've been running this code for some months on our instance and it worked.

I've added a test so the new code gets executed. But it's just a comparison with old method for a simple case. Since the behavior differs I cannot compare for a more complex case. Also I don't know the intended contract of `getCommitLog`, so I can't write a proper test.
