### PR TITLE
fix: make some methods call JGitUtil.getCommitLog with ObjectId

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
+++ b/src/main/scala/gitbucket/core/servlet/GitRepositoryServlet.scala
@@ -296,7 +296,7 @@ class CommitLogHook(owner: String, repository: String, pusher: String, baseUrl: 
     } else {
       command.getType match {
         case ReceiveCommand.Type.DELETE => Nil
-        case _                          => JGitUtil.getCommitLog(git, command.getOldId.name, command.getNewId.name)
+        case _                          => JGitUtil.getCommitLog(git, command.getOldId, command.getNewId)
       }
     }
   }
@@ -492,7 +492,7 @@ class WikiCommitHook(owner: String, repository: String, pusher: String, baseUrl:
           } else {
             command.getType match {
               case ReceiveCommand.Type.DELETE => None
-              case _                          => Some((command.getOldId.getName, command.getNewId.name))
+              case _                          => Some((command.getOldId, command.getNewId))
             }
           }
 


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

This is a fix for the PR #3647 .

It seems like the change with the tag resolution broke something. There are occasions where `JGit.getCommitLog(Git,String,String)` gets called with invalid names. This happens when during a push there is no old id. Then the names will be just zeros `000000...` (probably from the zero `ObjectId`). This currently cannot be resolved. 

I fixed it by using the `getCommitLog(Git,ObjectId,ObjectId)` version directly, which also makes more sense here.

I think the behavior in this case (maybe like it was before), is that the full log will be returned, since we do not have a `from` (or the from will be filtered out). I'm not so sure that this is what is intended in `GitRepositoryServlet`. I think the intention is to find only the new commits and do some processing with them (Wiki, Issues). But shouldn't this only happen for the main branch? 
