### PR TITLE
UI: Fix bottom margin of branch deletion box in pull request

### DIFF
--- a/src/main/twirl/gitbucket/core/pulls/conversation.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/conversation.scala.html
@@ -37,8 +37,8 @@
         </div>
       }
       @if(isManageableForkedRepository && issue.closed && merged &&
-        forkedRepository.map(r => (r.branchList.contains(pullreq.requestBranch) && r.repository.defaultBranch != pullreq.requestBranch)).getOrElse(false)){
-        <div class="issue-comment-box" style="background-color: #d0eeff;">
+        forkedRepository.exists(r => r.branchList.contains(pullreq.requestBranch) && r.repository.defaultBranch != pullreq.requestBranch)){
+        <div class="issue-comment-box" style="background-color: #d0eeff; margin-bottom: 20px;">
           <div class="box-content" style="border: 1px solid #87a8c9; padding: 10px;">
             <a href="@helpers.url(repository)/pull/@issue.issueId/delete_branch" class="btn btn-info pull-right delete-branch" data-name="@pullreq.requestBranch">Delete branch</a>
             <div>


### PR DESCRIPTION
Before:
<img width="829" alt="Screenshot 2025-06-21 at 17 21 36" src="https://github.com/user-attachments/assets/a0e41ce5-c2b1-41b9-80e2-017a8586b7ef" />

After:
<img width="822" alt="Screenshot 2025-06-21 at 17 22 01" src="https://github.com/user-attachments/assets/06a7e647-33e8-4663-84cd-ce46b8c82008" />

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
