### PR TITLE
Move issue_template.yml to .github directory

### DIFF
--- a/.github/issue_template.yml
+++ b/.github/issue_template.yml
@@ -1,0 +1,41 @@
+name: Report issue
+description: Report a problem or feature request with GitBucket
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before submitting an issue to GitBucket, please ensure you have:
+        - Read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
+        - Searched for similar existing issues
+        - Read the documentation and [wiki](https://github.com/gitbucket/gitbucket/wiki)
+        - You can use [Gitter chat room](https://gitter.im/gitbucket/gitbucket) instead of GitHub Issues for casual discussion or inquiry
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I have read the contribution guidelines
+        - label: I have searched for similar issues
+        - label: I have read the documentation and wiki
+
+  - type: input
+    id: impacted_version
+    attributes:
+      label: Impacted version
+      description: Which version of GitBucket is affected?
+      placeholder: e.g. 4.37.0
+
+  - type: input
+    id: deployment_mode
+    attributes:
+      label: Deployment mode
+      description: How do you use GitBucket? (standalone app, under webcontainer, with an HTTP frontend, etc.)
+      placeholder: e.g. Standalone app, Tomcat, nginx
+
+  - type: textarea
+    id: problem_description
+    attributes:
+      label: Problem description
+      description: Be as explicit as you can. Describe the problem, its symptoms, how to reproduce, and attach any relevant information (screenshots, logs, etc.)
+      placeholder: Describe the problem and how to reproduce it


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
