### PR TITLE
Fix community plugins link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ GitBucket has a plug-in system that allows extra functionality. Officially the f
 - [gitbucket-pages-plugin](https://github.com/gitbucket/gitbucket-pages-plugin)
 - [gitbucket-notifications-plugin](https://github.com/gitbucket/gitbucket-notifications-plugin)
 
-You can find more plugins made by the community at [GitBucket community plugins](https://gitbucket-plugins.github.io/).
+You can find more plugins made by the community at [GitBucket community plugins](https://github.com/gitbucket/gitbucket/wiki/Community-Plugins).
 
 Building and Development
 -----------


### PR DESCRIPTION
Updated the link to the GitBucket community plugins page.

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
