### PR TITLE
Tentative fix for issue #2456

### DIFF
--- a/src/main/scala/gitbucket/core/view/Markdown.scala
+++ b/src/main/scala/gitbucket/core/view/Markdown.scala
@@ -192,6 +192,8 @@ object Markdown {
               .stripSuffix(".git") + "/blob/" + branch + "/" + urlWithRawParam
           }
         } else {
+          // URL is being modified to link to the image file on the repository, but users may want to link to the page if the page name is a link.
+          // As a interim solution, if the link contains a ., it will use the current conversion, otherwise it will perform the conversion the user wants.
           if (url.lastIndexOf(".") > 0) {
             repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/_blob/" + url
           } else {


### PR DESCRIPTION
### Overview

Tentative fix for issue #2456.

- Currently, I understand that the URL is being modified to link to the image file on the repository.
- Users will likely want to switch pages if the page name is a link.
- In the interim, if the link contains a ., it will use the current conversion, otherwise it will perform the conversion the user wants.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

and

- [x] `sbt "testOnly * -- -l ExternalDBTest"`
- [x] `sbt scalafmtAll` 
