### PR TITLE
Include path in filePath param for preview in the online editor

### DIFF
--- a/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
+++ b/src/main/scala/gitbucket/core/controller/RepositoryViewerController.scala
@@ -174,7 +174,7 @@ trait RepositoryViewerControllerBase extends ControllerBase {
     filename match {
       case Some(f) =>
         helpers.renderMarkup(
-          filePath = List(f),
+          filePath = f.split("/").toList,
           fileContent = params("content"),
           branch = repository.repository.defaultBranch,
           repository = repository,

--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -215,7 +215,7 @@ $(function(){
         $.post('@helpers.url(repository)/_preview', {
           content          : editor.getValue(),
           enableWikiLink   : false,
-          filename         : $('#newFileName').val(),
+          filename         : $('path').val() + '/' + $('#newFileName').val(),
           enableRefsLink   : false,
           enableLineBreaks : false,
           enableTaskList   : false


### PR DESCRIPTION
Fixes #3887

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
