### PR TITLE
Fix system menu of plugins.

### DIFF
--- a/src/main/twirl/gitbucket/core/admin/menu.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/menu.scala.html
@@ -33,7 +33,7 @@
       </li>
       @gitbucket.core.plugin.PluginRegistry().getSystemSettingMenus.map { menu =>
         @menu(context).map { link =>
-          <li@if(active==link.id){ class="active"}>
+          <li class="menu-item-hover @if(active==link.id){active}">
             <a href="@context.path/@link.path">
               <i class="menu-icon octicon octicon-@link.icon.getOrElse("plug")"></i>
               <span>@link.label</span>


### PR DESCRIPTION
In the system settings, the menu-item-hover class has been added to the plugin menu.

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
