### PR TITLE
Fix bug that #3894 doesn't work with context path

### DIFF
--- a/src/main/twirl/gitbucket/core/repo/editor.scala.html
+++ b/src/main/twirl/gitbucket/core/repo/editor.scala.html
@@ -208,7 +208,7 @@ $(function(){
     $('#preview').show();
     $('#btn-code').removeClass('active');
 
-    $.get("/_is_renderable?filename=" + encodeURIComponent($('#newFileName').val()), function(data) {
+    $.get("@context.baseUrl/_is_renderable?filename=" + encodeURIComponent($('#newFileName').val()), function(data) {
       if (data === 'true') {
         // update preview
         $('#preview').html('<img src="@helpers.assets("/common/images/indicator.gif")"> Previewing...');


### PR DESCRIPTION
This is a follow up to #3894, fixes #3905.

in src\main\twirl\gitbucket\core\repo\editor.scala.html

```scala
$.get("/_is_renderable?filename=" + encodeURIComponent($('#newFileName').val()), function(data) {
```

If you are deploying to Apache Tomcat, you will get a 404 Not Found.

I add `@context.baseUrl` as below.

```scala
$.get("@context.baseUrl/_is_renderable?filename=" + encodeURIComponent($('#newFileName').val()), function(data) {
```

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
