### PR TITLE
Check existence of Wiki page for Wiki links

### DIFF
--- a/src/main/scala/gitbucket/core/view/Markdown.scala
+++ b/src/main/scala/gitbucket/core/view/Markdown.scala
@@ -76,7 +76,7 @@ object Markdown {
   )(implicit val context: Context)
       extends Renderer(options)
       with LinkConverter
-      with RequestCache 
+      with RequestCache
       with WikiService {
 
     override def heading(text: String, level: Int, raw: String): String = {


### PR DESCRIPTION
Fully addressing #3883 and #2456.

Is it acceptable for GitBucketMarkedRenderer to inherit from WikiService?

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
