### PR TITLE
Fix release date of GitBucket 4.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All changes to the project will be documented in this file.
 
-## 4.45.0 - 11 Jan 2026
+## 4.45.0 - 10 Jan 2026
 - Add new option to show full username on UI
 - Support render plugin in issues, pull requests, wiki and commit comments
 - Support link to other pages from Wiki page using Wiki link syntax

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Support
 
 What's New in 4.45.x
 -------------
-## 4.45.0 - 11 Jan 2026
+## 4.45.0 - 10 Jan 2026
 - Add new option to show full username on UI
 - Support render plugin in issues, pull requests, wiki and commit comments
 - Support link to other pages from Wiki page using Wiki link syntax


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
