### PR TITLE
Fixed inconsistencies in branch names on the Wiki

### DIFF
--- a/src/main/scala/gitbucket/core/controller/WikiController.scala
+++ b/src/main/scala/gitbucket/core/controller/WikiController.scala
@@ -67,7 +67,8 @@ trait WikiControllerBase extends ControllerBase {
         repository,
         isEditable(repository),
         getWikiPage(repository.owner, repository.name, "_Sidebar", branch),
-        getWikiPage(repository.owner, repository.name, "_Footer", branch)
+        getWikiPage(repository.owner, repository.name, "_Footer", branch),
+        branch
       )
     } getOrElse redirect(s"/${repository.owner}/${repository.name}/wiki/Home/_edit")
   })
@@ -84,7 +85,8 @@ trait WikiControllerBase extends ControllerBase {
         repository,
         isEditable(repository),
         getWikiPage(repository.owner, repository.name, "_Sidebar", branch),
-        getWikiPage(repository.owner, repository.name, "_Footer", branch)
+        getWikiPage(repository.owner, repository.name, "_Footer", branch),
+        branch
       )
     } getOrElse redirect(s"/${repository.owner}/${repository.name}/wiki/${StringUtil.urlEncode(pageName)}/_edit")
   })

--- a/src/main/twirl/gitbucket/core/wiki/page.scala.html
+++ b/src/main/twirl/gitbucket/core/wiki/page.scala.html
@@ -4,7 +4,8 @@
   repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
   isEditable: Boolean,
   sidebar: Option[gitbucket.core.service.WikiService.WikiPageInfo],
-  footer: Option[gitbucket.core.service.WikiService.WikiPageInfo])(implicit context: gitbucket.core.controller.Context)
+  footer: Option[gitbucket.core.service.WikiService.WikiPageInfo],
+  branch: String)(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers
 @import gitbucket.core.service.WikiService
 @gitbucket.core.html.main(s"${pageName} - ${repository.owner}/${repository.name}", Some(repository)){
@@ -62,7 +63,7 @@
           @helpers.renderMarkup(
             filePath = sidebarPage.name.split("/").toList,
             fileContent = sidebarPage.content,
-            branch = "main",
+            branch = branch,
             repository = repository,
             enableWikiLink = true,
             enableRefsLink = false,
@@ -95,7 +96,7 @@
         @helpers.renderMarkup(
           filePath = page.name.split("/").toList,
           fileContent = page.content,
-          branch = "main",
+          branch = branch,
           repository = repository,
           enableWikiLink = true,
           enableRefsLink = false,
@@ -112,7 +113,7 @@
           @helpers.renderMarkup(
             filePath = footerPage.name.split("/").toList,
             fileContent = footerPage.content,
-            branch = "main",
+            branch = branch,
             repository = repository,
             enableWikiLink = true,
             enableRefsLink = false,


### PR DESCRIPTION
Certain states of the Wiki repository can trigger a java.lang.NullPointerException, resulting in an "Internal Server Error" when viewing Wiki pages.

~~Although it is not a fundamental fix, we are bypassing the issue by catching the exception in WikiService.getWikiPage and returning None if an error occurs.~~

The exception no longer occurs when the branch name in pages.scala.html is changed from master to main.

### Example of a repository where the issue occurs

[test.wiki.git.zip](https://github.com/user-attachments/files/24795301/test.wiki.git.zip)

### Traceback

```
java.lang.NullPointerException: Cannot invoke "org.eclipse.jgit.lib.AnyObjectId.hashCode()" because "id" is null
        at org.eclipse.jgit.internal.storage.file.UnpackedObjectCache$Table.index(UnpackedObjectCache.java:115)
        at org.eclipse.jgit.internal.storage.file.UnpackedObjectCache$Table.contains(UnpackedObjectCache.java:76)
        at org.eclipse.jgit.internal.storage.file.UnpackedObjectCache.isUnpacked(UnpackedObjectCache.java:31)
        at org.eclipse.jgit.internal.storage.file.LooseObjects.hasCached(LooseObjects.java:99)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openObjectWithoutRestoring(ObjectDirectory.java:359)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openObject(ObjectDirectory.java:350)
        at org.eclipse.jgit.internal.storage.file.WindowCursor.open(WindowCursor.java:133)
        at org.eclipse.jgit.lib.ObjectReader.open(ObjectReader.java:216)
        at org.eclipse.jgit.revwalk.RevWalk.parseAny(RevWalk.java:1184)
        at gitbucket.core.util.JGitUtil$.getRevCommitFromId(JGitUtil.scala:287)
        at gitbucket.core.util.JGitUtil$.getLatestCommitFromPaths(JGitUtil.scala:734)
        at gitbucket.core.util.JGitUtil$.getLatestCommitFromPath(JGitUtil.scala:723)
        at gitbucket.core.service.WikiService.$anonfun$getWikiPage$1(WikiService.scala:79)
        at scala.util.Using$.resource(Using.scala:296)
        at gitbucket.core.service.WikiService.getWikiPage(WikiService.scala:76)
        at gitbucket.core.service.WikiService.getWikiPage$(WikiService.scala:75)
        at gitbucket.core.view.Markdown$GitBucketMarkedRenderer.getWikiPage(Markdown.scala:66)
        at gitbucket.core.view.Markdown$GitBucketMarkedRenderer.fixUrl(Markdown.scala:202)
        at gitbucket.core.view.Markdown$GitBucketMarkedRenderer.link(Markdown.scala:140)
```

The following omitted

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
