### PR TITLE
Recommended use of BOMInputStream

### DIFF
--- a/src/main/scala/gitbucket/core/util/StringUtil.scala
+++ b/src/main/scala/gitbucket/core/util/StringUtil.scala
@@ -91,7 +91,10 @@ object StringUtil {
    * And if given bytes contains UTF-8 BOM, it's removed from returned string.
    */
   def convertFromByteArray(content: Array[Byte]): String =
-    IOUtils.toString(new BOMInputStream(new java.io.ByteArrayInputStream(content)), detectEncoding(content))
+    IOUtils.toString(
+      BOMInputStream.builder().setInputStream(new java.io.ByteArrayInputStream(content)).setInclude(true).get(),
+      detectEncoding(content)
+    )
 
   def detectEncoding(content: Array[Byte]): String = {
     val detector = new UniversalDetector(null)


### PR DESCRIPTION
The following warnings that appear during compilation have been addressed:

```
[warn] \path\to\gitbucket\src\main\scala\gitbucket\core\util\StringUtil.scala:94:22: constructor BOMInputStream in class BOMInputStream is deprecated
[warn]     IOUtils.toString(new BOMInputStream(new java.io.ByteArrayInputStream(content)), detectEncoding(content))
[warn]                      ^
```

See: https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/input/BOMInputStream.html

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
