### PR TITLE
Migrated from helpers.markdown() to helpers.renderMarkup().

### DIFF
--- a/src/main/twirl/gitbucket/core/issues/milestones/list.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/milestones/list.scala.html
@@ -78,13 +78,16 @@
               </div>
               @milestone.description.map { description =>
                 <div class="milestone-description markdown-body">
-                  @helpers.markdown(
-                    markdown         = description,
-                    repository       = repository,
+                  @helpers.renderMarkup(
+                    filePath         = List("temporary.md"),
+                    fileContent      = description,
                     branch           = repository.repository.defaultBranch,
+                    repository       = repository,
                     enableWikiLink   = false,
                     enableRefsLink   = false,
-                    enableLineBreaks = true
+                    enableAnchor     = false,
+                    enableLineBreaks = true,
+                    enableTaskList   = false
                   )
                 </div>
               }

--- a/src/main/twirl/gitbucket/core/issues/milestones/milestone.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/milestones/milestone.scala.html
@@ -64,13 +64,16 @@
             </div>
             @milestone.description.map { description =>
               <div class="milestone-description markdown-body">
-                @helpers.markdown(
-                  markdown         = description,
-                  repository       = repository,
+                @helpers.renderMarkup(
+                  filePath         = List("temporary.md"),
+                  fileContent      = description,
                   branch           = repository.repository.defaultBranch,
+                  repository       = repository,
                   enableWikiLink   = false,
                   enableRefsLink   = false,
-                  enableLineBreaks = true
+                  enableAnchor     = false,
+                  enableLineBreaks = true,
+                  enableTaskList   = false
                 )
               </div>
             }

--- a/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
+++ b/src/main/twirl/gitbucket/core/pulls/mergeguide.scala.html
@@ -43,13 +43,16 @@
           </div>
           <div>
             <hr>
-            @status.conflictMessage.map { message => @helpers.markdown(
-              markdown         = message,
-              repository       = originRepository,
+            @status.conflictMessage.map { message => @helpers.renderMarkup(
+              filePath         = List("temporary.md"),
+              fileContent      = message,
               branch           = originRepository.repository.defaultBranch,
+              repository       = originRepository,
               enableWikiLink   = false,
               enableRefsLink   = true,
-              enableLineBreaks = false
+              enableAnchor     = false,
+              enableLineBreaks = false,
+              enableTaskList   = false
             ) }
           </div>
         } else {

--- a/src/main/twirl/gitbucket/core/releases/list.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/list.scala.html
@@ -26,12 +26,14 @@
                   <p class="muted">
                     @helpers.avatarLink(release.author, 20) @helpers.user(release.author, styleClass="username") released this @gitbucket.core.helper.html.datetimeago(release.registeredDate)
                   </p>
-                  @helpers.markdown(
-                    markdown           = release.content getOrElse "No description provided.",
-                    repository         = repository,
+                  @helpers.renderMarkup(
+                    filePath           = List("temporary.md"),
+                    fileContent        = release.content getOrElse "No description provided.",
                     branch             = repository.repository.defaultBranch,
+                    repository         = repository,
                     enableWikiLink     = false,
                     enableRefsLink     = true,
+                    enableAnchor       = false,
                     enableLineBreaks   = true,
                     enableTaskList     = true,
                     hasWritePermission = hasWritePermission

--- a/src/main/twirl/gitbucket/core/releases/release.scala.html
+++ b/src/main/twirl/gitbucket/core/releases/release.scala.html
@@ -31,12 +31,14 @@
           <p class="muted">
            @helpers.avatarLink(release.author, 20) @helpers.user(release.author, styleClass="username") released this @gitbucket.core.helper.html.datetimeago(release.registeredDate)
           </p>
-          @helpers.markdown(
-            markdown           = release.content getOrElse "No description provided.",
-            repository         = repository,
+          @helpers.renderMarkup(
+            filePath           = List("temporary.md"),
+            fileContent        = release.content getOrElse "No description provided.",
             branch             = repository.repository.defaultBranch,
+            repository         = repository,
             enableWikiLink     = false,
             enableRefsLink     = true,
+            enableAnchor       = false,
             enableLineBreaks   = true,
             enableTaskList     = true,
             hasWritePermission = hasWritePermission


### PR DESCRIPTION
### Migrated from helpers.markdown() to helpers.renderMarkup().

Because method markdown in object helpers is deprecated (since 4.45.0)

This allows alternative renderers to be used in releases, milestones and merge guides.

### Warnings printed

```
[warn] path\to\gitbucket\src\main\twirl\gitbucket\core\issues\milestones\list.scala.html:81:28: method markdown in object helpers is deprecated (since 4.45.0): This doesn't apply render plugins. Should use renderMarkup() instead.
[warn]                   @helpers.markdown(
[warn]                            ^
[warn] path\to\gitbucket\src\main\twirl\gitbucket\core\issues\milestones\milestone.scala.html:67:26: method markdown in object helpers is deprecated (since 4.45.0): This doesn't apply render plugins. Should use renderMarkup() instead.
[warn]                 @helpers.markdown(
[warn]                          ^
[warn] path\to\gitbucket\src\main\twirl\gitbucket\core\pulls\mergeguide.scala.html:46:63: method markdown in object helpers is deprecated (since 4.45.0): This doesn't apply render plugins. Should use renderMarkup() instead.
[warn]             @status.conflictMessage.map { message => @helpers.markdown(
[warn]                                                               ^
[warn] path\to\gitbucket\src\main\twirl\gitbucket\core\releases\list.scala.html:29:28: method markdown in object helpers is deprecated (since 4.45.0): This doesn't apply render plugins. Should use renderMarkup() instead.
[warn]                   @helpers.markdown(
[warn]                            ^
[warn] path\to\gitbucket\src\main\twirl\gitbucket\core\releases\release.scala.html:34:20: method markdown in object helpers is deprecated (since 4.45.0): This doesn't apply render plugins. Should use renderMarkup() instead.
[warn]           @helpers.markdown(
[warn]                    ^
```

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
