### PR TITLE
Restore pagination in commit history

### DIFF
--- a/src/main/scala/gitbucket/core/util/JGitUtil.scala
+++ b/src/main/scala/gitbucket/core/util/JGitUtil.scala
@@ -631,7 +631,7 @@ object JGitUtil {
       count: Int,
       logs: List[CommitInfo]
     ): (List[CommitInfo], Boolean) =
-      if (i.hasNext) {
+      if (i.hasNext && limit <= 0 || logs.size < limit) {
         val commit = i.next
         getCommitLog(
           i,


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
