### PR TITLE
Fix potential error in Markdown preview introduced in #3907

### DIFF
--- a/src/main/scala/gitbucket/core/controller/WikiController.scala
+++ b/src/main/scala/gitbucket/core/controller/WikiController.scala
@@ -103,12 +103,6 @@ trait WikiControllerBase extends ControllerBase {
     }
   })
 
-  private def getWikiBranch(owner: String, repository: String): String = {
-    Using.resource(Git.open(Directory.getWikiRepositoryDir(owner, repository))) { git =>
-      git.getRepository.getBranch
-    }
-  }
-
   get("/:owner/:repository/wiki/:page/_compare/:commitId")(referrersOnly { repository =>
     val pageName = StringUtil.urlDecode(params("page"))
     val Array(from, to) = params("commitId").split("\\.\\.\\.")

--- a/src/main/scala/gitbucket/core/service/WikiService.scala
+++ b/src/main/scala/gitbucket/core/service/WikiService.scala
@@ -341,4 +341,18 @@ trait WikiService {
     }
   }
 
+  /**
+    * Get the branch name from the HEAD of the Wiki repository.
+    * 
+    * from gitbucket.core.controller.WikiController
+    *
+    * @param owner Wiki owner
+    * @param repository Wiki repository
+    * @return Branch name
+    */
+  def getWikiBranch(owner: String, repository: String): String = {
+    Using.resource(Git.open(Directory.getWikiRepositoryDir(owner, repository))) { git =>
+      git.getRepository.getBranch
+    }
+  }
 }

--- a/src/main/scala/gitbucket/core/view/Markdown.scala
+++ b/src/main/scala/gitbucket/core/view/Markdown.scala
@@ -199,7 +199,7 @@ object Markdown {
           val pathElems = context.currentPath.split("/")
           val owner = pathElems(1)
           val repos = pathElems(2)
-          if (getWikiPage(owner, repos, url, branch) == None) {
+          if (getWikiPage(owner, repos, url, getWikiBranch(owner, repos)) == None) {
             repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/_blob/" + url
           } else {
             repository.httpUrl.replaceFirst("/git/", "/").stripSuffix(".git") + "/wiki/" + url


### PR DESCRIPTION
### Fix #3907 bug

An error in preview if the main repository and wiki repository have different branch.

Defining getWikiBranch in WikiService and passing the branch obtained there to getWikiPage in Markdown.scala

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [x] verified that project is compiling
- [x] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
