### PR TITLE
Suppress JGitUtil's debug logs in test

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,6 +16,7 @@
   -->
 
   <logger name="gitbucket" level="DEBUG"/>
+  <logger name="gitbucket.core.util.JGitUtil" level="WARN"/>
   <root level="WARN">
     <appender-ref ref="STDOUT" />
   </root>


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
