### PR TITLE
Make the reset password token expiration period configurable

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -625,7 +625,8 @@ trait AccountControllerBase extends AccountManagementControllerBase {
   post("/reset", resetPasswordEmailForm) { form =>
     if (context.settings.basicBehavior.allowResetPassword) {
       getAccountByMailAddress(form.mailAddress).foreach { account =>
-        val token = generateResetPasswordToken(form.mailAddress)
+        val expirationMillis = context.settings.basicBehavior.resetPasswordTokenExpiration * 60L * 1000L
+        val token = generateResetPasswordToken(form.mailAddress, expirationMillis)
         val mailer = new Mailer(context.settings)
         mailer.send(
           form.mailAddress,

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -37,6 +37,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
     "basicBehavior" -> mapping(
       "allowAccountRegistration" -> trim(label("Account registration", boolean())),
       "allowResetPassword" -> trim(label("Reset password", boolean())),
+      "resetPasswordTokenExpiration" -> trim(label("Reset password token expiration", number())),
       "allowAnonymousAccess" -> trim(label("Anonymous access", boolean())),
       "isCreateRepoOptionPublic" -> trim(label("Default visibility of new repository", boolean())),
       "repositoryOperation" -> mapping(

--- a/src/main/scala/gitbucket/core/service/AccountService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountService.scala
@@ -340,9 +340,14 @@ trait AccountService {
   }
 
   def generateResetPasswordToken(mailAddress: String): String = {
+    // default to 10 minutes for backward compatibility
+    generateResetPasswordToken(mailAddress, 10 * 60 * 1000L)
+  }
+
+  def generateResetPasswordToken(mailAddress: String, expirationMillis: Long): String = {
     val claimsSet = new JWTClaimsSet.Builder()
       .claim("mailAddress", mailAddress)
-      .expirationTime(new java.util.Date(System.currentTimeMillis() + 10 * 60 * 1000)) // 10 min
+      .expirationTime(new java.util.Date(System.currentTimeMillis() + expirationMillis))
       .build()
 
     val signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claimsSet)

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -20,6 +20,7 @@ trait SystemSettingsService {
     settings.information.foreach(x => props.setProperty(Information, x))
     props.setProperty(AllowAccountRegistration, settings.basicBehavior.allowAccountRegistration.toString)
     props.setProperty(AllowResetPassword, settings.basicBehavior.allowResetPassword.toString)
+    props.setProperty(ResetPasswordTokenExpiration, settings.basicBehavior.resetPasswordTokenExpiration.toString)
     props.setProperty(AllowAnonymousAccess, settings.basicBehavior.allowAnonymousAccess.toString)
     props.setProperty(IsCreateRepoOptionPublic, settings.basicBehavior.isCreateRepoOptionPublic.toString)
     props.setProperty(RepositoryOperationCreate, settings.basicBehavior.repositoryOperation.create.toString)
@@ -118,6 +119,7 @@ trait SystemSettingsService {
       BasicBehavior(
         getValue(props, AllowAccountRegistration, false),
         getValue(props, AllowResetPassword, false),
+        getValue(props, ResetPasswordTokenExpiration, 10),
         getValue(props, AllowAnonymousAccess, true),
         getValue(props, IsCreateRepoOptionPublic, true),
         RepositoryOperation(
@@ -277,6 +279,7 @@ object SystemSettingsService {
   case class BasicBehavior(
     allowAccountRegistration: Boolean,
     allowResetPassword: Boolean,
+    resetPasswordTokenExpiration: Int,
     allowAnonymousAccess: Boolean,
     isCreateRepoOptionPublic: Boolean,
     repositoryOperation: RepositoryOperation,
@@ -406,6 +409,7 @@ object SystemSettingsService {
   private val Information = "information"
   private val AllowAccountRegistration = "allow_account_registration"
   private val AllowResetPassword = "allow_reset_password"
+  private val ResetPasswordTokenExpiration = "reset_password_token_expiration"
   private val AllowAnonymousAccess = "allow_anonymous_access"
   private val IsCreateRepoOptionPublic = "is_create_repository_option_public"
   private val RepositoryOperationCreate = "repository_operation_create"

--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -140,6 +140,15 @@
     <span class="strong">Deny</span> <span class="normal">- Doesn't allow users to reset password.</span>
   </label>
 </fieldset>
+<div class="form-group">
+  <label class="control-label col-md-2" for="resetPasswordTokenExpiration">Expiration (min)</label>
+  <div class="col-md-10">
+    <div class="controls">
+      <input type="text" id="resetPasswordTokenExpiration" name="basicBehavior.resetPasswordTokenExpiration" class="form-control" value="@context.settings.basicBehavior.resetPasswordTokenExpiration"/>
+      <p class="muted">How long a password reset link remains valid.</p>
+    </div>
+  </div>
+</div>
 <!--====================================================================-->
 <!-- Repository operations -->
 <!--====================================================================-->

--- a/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
+++ b/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
@@ -43,6 +43,7 @@ trait ServiceSpecBase {
       basicBehavior = BasicBehavior(
         allowAccountRegistration = false,
         allowResetPassword = false,
+        resetPasswordTokenExpiration = 10,
         allowAnonymousAccess = true,
         isCreateRepoOptionPublic = true,
         repositoryOperation = RepositoryOperation(

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -154,6 +154,7 @@ class AvatarImageProviderSpec extends AnyFunSpec {
       basicBehavior = BasicBehavior(
         allowAccountRegistration = false,
         allowResetPassword = false,
+        resetPasswordTokenExpiration = 10,
         allowAnonymousAccess = true,
         isCreateRepoOptionPublic = true,
         repositoryOperation = RepositoryOperation(


### PR DESCRIPTION
Follow-up to #4018, originally reported in #4015

<img width="1067" height="241" alt="Screenshot 2026-04-29 at 21 18 05" src="https://github.com/user-attachments/assets/a9c3782e-aa26-49e8-8091-d393df6a59a9" />

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
