### PR TITLE
Update postgres testcontainers from 10 and 11 to 14 and 18

### DIFF
--- a/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
+++ b/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
@@ -50,7 +50,7 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
     }
   }
 
-  Seq("11", "10").foreach { tag =>
+  Seq("14", "18").foreach { tag =>
     test(s"Migration PostgreSQL $tag", ExternalDBTest) {
       val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
 


### PR DESCRIPTION
The postgres tests use versions 10 and 11, both of which are end-of-life.

Use 14 and 18 instead. 14 is the oldest version not end-of-life, and 18 is the current version.

### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

