### PR TITLE
Add an option to disable creating repository by cloning

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -776,6 +776,9 @@ trait AccountControllerBase extends AccountManagementControllerBase {
           } else if (!canCreateRepository(form.owner, loginAccount)) {
             // Permission error
             Forbidden()
+          } else if (form.initOption == "COPY" && !context.settings.basicBehavior.allowCreateRepositoryByClone) {
+            // Creating by cloning is disabled by system settings
+            BadRequest("Creating repositories by cloning is disabled.")
           } else {
             // create repository asynchronously
             createRepository(

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -40,6 +40,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
       "resetPasswordTokenExpiration" -> trim(label("Reset password token expiration", number())),
       "allowAnonymousAccess" -> trim(label("Anonymous access", boolean())),
       "isCreateRepoOptionPublic" -> trim(label("Default visibility of new repository", boolean())),
+      "allowCreateRepositoryByClone" -> trim(label("Allow creating repositories by cloning", boolean())),
       "repositoryOperation" -> mapping(
         "create" -> trim(label("Allow all users to create repository", boolean())),
         "delete" -> trim(label("Allow all users to delete repository", boolean())),

--- a/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
+++ b/src/main/scala/gitbucket/core/service/SystemSettingsService.scala
@@ -23,6 +23,7 @@ trait SystemSettingsService {
     props.setProperty(ResetPasswordTokenExpiration, settings.basicBehavior.resetPasswordTokenExpiration.toString)
     props.setProperty(AllowAnonymousAccess, settings.basicBehavior.allowAnonymousAccess.toString)
     props.setProperty(IsCreateRepoOptionPublic, settings.basicBehavior.isCreateRepoOptionPublic.toString)
+    props.setProperty(AllowCreateRepositoryByClone, settings.basicBehavior.allowCreateRepositoryByClone.toString)
     props.setProperty(RepositoryOperationCreate, settings.basicBehavior.repositoryOperation.create.toString)
     props.setProperty(RepositoryOperationDelete, settings.basicBehavior.repositoryOperation.delete.toString)
     props.setProperty(RepositoryOperationRename, settings.basicBehavior.repositoryOperation.rename.toString)
@@ -122,6 +123,7 @@ trait SystemSettingsService {
         getValue(props, ResetPasswordTokenExpiration, 10),
         getValue(props, AllowAnonymousAccess, true),
         getValue(props, IsCreateRepoOptionPublic, true),
+        getValue(props, AllowCreateRepositoryByClone, true),
         RepositoryOperation(
           create = getValue(props, RepositoryOperationCreate, true),
           delete = getValue(props, RepositoryOperationDelete, true),
@@ -282,6 +284,7 @@ object SystemSettingsService {
     resetPasswordTokenExpiration: Int,
     allowAnonymousAccess: Boolean,
     isCreateRepoOptionPublic: Boolean,
+    allowCreateRepositoryByClone: Boolean,
     repositoryOperation: RepositoryOperation,
     gravatar: Boolean,
     notification: Boolean,
@@ -412,6 +415,7 @@ object SystemSettingsService {
   private val ResetPasswordTokenExpiration = "reset_password_token_expiration"
   private val AllowAnonymousAccess = "allow_anonymous_access"
   private val IsCreateRepoOptionPublic = "is_create_repository_option_public"
+  private val AllowCreateRepositoryByClone = "allow_create_repository_by_clone"
   private val RepositoryOperationCreate = "repository_operation_create"
   private val RepositoryOperationDelete = "repository_operation_delete"
   private val RepositoryOperationRename = "repository_operation_rename"

--- a/src/main/twirl/gitbucket/core/account/newrepo.scala.html
+++ b/src/main/twirl/gitbucket/core/account/newrepo.scala.html
@@ -44,14 +44,14 @@ isCreateRepoOptionPublic: Boolean)(implicit context: gitbucket.core.controller.C
       <fieldset class="border-top">
         <label class="radio">
           <input type="radio" name="isPrivate" value="false" @if(isCreateRepoOptionPublic){checked}>
-          <span class="strong"><i class="octicon octicon-repo"></i>&nbsp;</i>&nbsp;Public</span>
+          <span class="strong"><i class="octicon octicon-repo"></i>&nbsp;Public</span>
           <div class="normal muted">
             Anyone can see this repository. You choose who can commit.
           </div>
         </label>
         <label class="radio">
           <input type="radio" name="isPrivate" value="true" @if(!isCreateRepoOptionPublic){checked}>
-          <span class="strong"><i class="octicon octicon-lock"></i>&nbsp;</i>&nbsp;Private</span>
+          <span class="strong"><i class="octicon octicon-lock"></i>&nbsp;Private</span>
           <div class="normal muted">
             You choose who can see and commit to this repository.
           </div>
@@ -79,14 +79,16 @@ isCreateRepoOptionPublic: Boolean)(implicit context: gitbucket.core.controller.C
             Create a repository and commit README.md. You can clone the repository immediately.
           </div>
         </label>
-        <label class="radio">
-          <input type="radio" name="initOption" value="COPY"/>
-          <span class="strong">Copy existing git repository</span>
-          <div class="normal muted">
-            Create a new repository by cloning an existing git repository.
-          </div>
-        </label>
-        <input type="text" class="form-control" name="sourceUrl" id="sourceUrl" disabled placeholder="Source git repository URL..." aria-label="Source URL"/>
+        @if(context.settings.basicBehavior.allowCreateRepositoryByClone){
+          <label class="radio">
+            <input type="radio" name="initOption" value="COPY"/>
+            <span class="strong">Copy existing git repository</span>
+            <div class="normal muted">
+              Create a new repository by cloning an existing git repository.
+            </div>
+          </label>
+          <input type="text" class="form-control" name="sourceUrl" id="sourceUrl" disabled placeholder="Source git repository URL..." aria-label="Source URL"/>
+        }
         <span id="error-sourceUrl" class="error"></span>
       </fieldset>
       <fieldset class="border-top form-actions">

--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -221,6 +221,17 @@
     </div>
   </div>
 </fieldset>
+<fieldset>
+  <label class="strong">Create repository by cloning</label>
+  <div class="form-group">
+    <div class="col-md-10">
+      <label class="checkbox">
+        <input type="checkbox" name="basicBehavior.allowCreateRepositoryByClone" value="true" @if(context.settings.basicBehavior.allowCreateRepositoryByClone){ checked}>
+        Allow creating new repositories by cloning an existing repository
+      </label>
+    </div>
+  </div>
+</fieldset>
 <hr>
 <label class="strong">Default visibility when creating a new repository</label>
 <fieldset>

--- a/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
+++ b/src/test/scala/gitbucket/core/service/ServiceSpecBase.scala
@@ -46,6 +46,7 @@ trait ServiceSpecBase {
         resetPasswordTokenExpiration = 10,
         allowAnonymousAccess = true,
         isCreateRepoOptionPublic = true,
+        allowCreateRepositoryByClone = true,
         repositoryOperation = RepositoryOperation(
           create = true,
           delete = true,

--- a/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
+++ b/src/test/scala/gitbucket/core/view/AvatarImageProviderSpec.scala
@@ -157,6 +157,7 @@ class AvatarImageProviderSpec extends AnyFunSpec {
         resetPasswordTokenExpiration = 10,
         allowAnonymousAccess = true,
         isCreateRepoOptionPublic = true,
+        allowCreateRepositoryByClone = true,
         repositoryOperation = RepositoryOperation(
           create = true,
           delete = true,


### PR DESCRIPTION
Ref: #4044

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
