### PR TITLE
Fix setting for default visibility of new repository

### DIFF
--- a/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
+++ b/src/main/twirl/gitbucket/core/admin/settings_system.scala.html
@@ -231,6 +231,11 @@
     </div>
   </div>
 </fieldset>
+<!--====================================================================-->
+<!-- Defalut visibility of new repository -->
+<!--====================================================================-->
+<hr>
+<label class="strong">Default visibility when creating a new repository</label>
 <fieldset>
   <label class="radio">
     <input type="radio" name="basicBehavior.isCreateRepoOptionPublic" value="true"@if(context.settings.basicBehavior.isCreateRepoOptionPublic){ checked}>


### PR DESCRIPTION
The label has been wrongly removed in https://github.com/gitbucket/gitbucket/pull/4056

### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
