### PR TITLE
Fix: Issue assignees survive a repository rename or ownership change

### DIFF
--- a/src/main/scala/gitbucket/core/service/RepositoryService.scala
+++ b/src/main/scala/gitbucket/core/service/RepositoryService.scala
@@ -87,6 +87,7 @@ trait RepositoryService {
           val pullRequests = PullRequests.filter(_.byRepository(oldUserName, oldRepositoryName)).list
           val labels = Labels.filter(_.byRepository(oldUserName, oldRepositoryName)).list
           val priorities = Priorities.filter(_.byRepository(oldUserName, oldRepositoryName)).list
+          val issueAssignees = IssueAssignees.filter(_.byRepository(oldUserName, oldRepositoryName)).list
           val issueComments = IssueComments.filter(_.byRepository(oldUserName, oldRepositoryName)).list
           val issueLabels = IssueLabels.filter(_.byRepository(oldUserName, oldRepositoryName)).list
           val commitComments = CommitComments.filter(_.byRepository(oldUserName, oldRepositoryName)).list
@@ -149,6 +150,9 @@ trait RepositoryService {
 
           PullRequests.insertAll(
             pullRequests.map(_.copy(userName = newUserName, repositoryName = newRepositoryName))*
+          )
+          IssueAssignees.insertAll(
+            issueAssignees.map(_.copy(userName = newUserName, repositoryName = newRepositoryName))*
           )
           IssueComments.insertAll(
             issueComments.map(_.copy(userName = newUserName, repositoryName = newRepositoryName))*

--- a/src/test/scala/gitbucket/core/service/RepositoryServiceSpec.scala
+++ b/src/test/scala/gitbucket/core/service/RepositoryServiceSpec.scala
@@ -1,6 +1,8 @@
 package gitbucket.core.service
 
 import gitbucket.core.model.*
+import gitbucket.core.model.Profile.*
+import gitbucket.core.model.Profile.profile.blockingApi.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class RepositoryServiceSpec extends AnyFunSuite with ServiceSpecBase with RepositoryService with AccountService {
@@ -33,6 +35,64 @@ class RepositoryServiceSpec extends AnyFunSuite with ServiceSpecBase with Reposi
       assert(
         service.getProtectedBranchInfo("tester", "repo2", "branch") == orgPbi
           .copy(owner = "tester", repository = "repo2")
+      )
+    }
+  }
+
+  test("renameRepository preserves issue assignees") {
+    withTestDB { implicit session =>
+      generateNewAccount("tester")
+      dummyService.insertRepository("repo", "root", None, false, "main")
+
+      val issueId = dummyService.insertIssue(
+        owner = "root",
+        repository = "repo",
+        loginUser = "root",
+        title = "issue title",
+        content = None,
+        milestoneId = None,
+        priorityId = None,
+        isPullRequest = false
+      )
+
+      IssueAssignees insert IssueAssignee("root", "repo", issueId, "tester")
+
+      renameRepository("root", "repo", "root", "repo2")
+
+      assert(dummyService.getIssueAssignees("root", "repo", issueId).isEmpty)
+      assert(
+        dummyService.getIssueAssignees("root", "repo2", issueId) == List(
+          IssueAssignee("root", "repo2", issueId, "tester")
+        )
+      )
+    }
+  }
+
+  test("renameRepository preserves issue assignees when changing owners") {
+    withTestDB { implicit session =>
+      generateNewAccount("tester")
+      dummyService.insertRepository("repo", "root", None, false, "main")
+
+      val issueId = dummyService.insertIssue(
+        owner = "root",
+        repository = "repo",
+        loginUser = "root",
+        title = "issue title",
+        content = None,
+        milestoneId = None,
+        priorityId = None,
+        isPullRequest = false
+      )
+
+      IssueAssignees insert IssueAssignee("root", "repo", issueId, "tester")
+
+      renameRepository("root", "repo", "tester", "repo2")
+
+      assert(dummyService.getIssueAssignees("root", "repo", issueId).isEmpty)
+      assert(
+        dummyService.getIssueAssignees("tester", "repo2", issueId) == List(
+          IssueAssignee("tester", "repo2", issueId, "tester")
+        )
       )
     }
   }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

When a repository is renamed or its ownership changes, assignees are not preserved. Preserve them.