### PR TITLE
Fix GitHub API compatibility routes that should return json to do so

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiOrganizationControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiOrganizationControllerBase.scala
@@ -4,6 +4,7 @@ import gitbucket.core.controller.ControllerBase
 import gitbucket.core.service.{AccountService, RepositoryService}
 import gitbucket.core.util.Implicits._
 import gitbucket.core.util.{AdminAuthenticator, UsersAuthenticator}
+import org.scalatra.BadRequest
 
 trait ApiOrganizationControllerBase extends ControllerBase {
   self: RepositoryService & AccountService & AdminAuthenticator & UsersAuthenticator =>
@@ -52,9 +53,7 @@ trait ApiOrganizationControllerBase extends ControllerBase {
    * https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#create-an-organization
    */
   post("/api/v3/admin/organizations")(adminOnly {
-    for {
-      data <- extractFromJsonBody[CreateAGroup]
-    } yield {
+    extractFromJsonBody[CreateAGroup].map { data =>
       val group = createGroup(
         data.login,
         data.profile_name,
@@ -62,7 +61,7 @@ trait ApiOrganizationControllerBase extends ControllerBase {
       )
       updateGroupMembers(data.login, List(data.admin -> true))
       JsonFormat(ApiGroup(group))
-    }
+    } getOrElse BadRequest()
   })
 
   /*

--- a/src/main/scala/gitbucket/core/controller/api/ApiPullRequestControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiPullRequestControllerBase.scala
@@ -10,7 +10,7 @@ import gitbucket.core.util.Implicits._
 import gitbucket.core.util.JGitUtil.CommitInfo
 import gitbucket.core.util._
 import org.eclipse.jgit.api.Git
-import org.scalatra.{Conflict, MethodNotAllowed, NoContent, Ok}
+import org.scalatra.{BadRequest, Conflict, MethodNotAllowed, NoContent, Ok}
 import scala.util.Using
 
 import scala.jdk.CollectionConverters._
@@ -75,9 +75,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
    * requested #1843
    */
   post("/api/v3/repos/:owner/:repository/pulls")(readableUsersOnly { repository =>
-    (for {
-      data <- extractFromJsonBody[Either[CreateAPullRequest, CreateAPullRequestAlt]]
-    } yield {
+    extractFromJsonBody[Either[CreateAPullRequest, CreateAPullRequestAlt]].map { data =>
       data match {
         case Left(createPullReq) =>
           val (reqOwner, reqBranch) = parseCompareIdentifier(createPullReq.head, repository.owner)
@@ -146,7 +144,7 @@ trait ApiPullRequestControllerBase extends ControllerBase {
               NotFound()
             }
       }
-    })
+    } getOrElse BadRequest()
   })
 
   /*

--- a/src/main/scala/gitbucket/core/controller/api/ApiReleaseControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiReleaseControllerBase.scala
@@ -8,7 +8,7 @@ import gitbucket.core.util.Directory.getReleaseFilesDir
 import gitbucket.core.util.{FileUtil, ReferrerAuthenticator, RepositoryName, WritableUsersAuthenticator}
 import gitbucket.core.util.Implicits._
 import org.apache.commons.io.FileUtils
-import org.scalatra.NoContent
+import org.scalatra.{BadRequest, NoContent}
 
 trait ApiReleaseControllerBase extends ControllerBase {
   self: AccountService & ReleaseService & ReferrerAuthenticator & WritableUsersAuthenticator =>
@@ -66,9 +66,7 @@ trait ApiReleaseControllerBase extends ControllerBase {
    * https://developer.github.com/v3/repos/releases/#create-a-release
    */
   post("/api/v3/repos/:owner/:repository/releases")(writableUsersOnly { repository =>
-    (for {
-      data <- extractFromJsonBody[CreateARelease]
-    } yield {
+    extractFromJsonBody[CreateARelease].map { data =>
       createRelease(
         repository.owner,
         repository.name,
@@ -80,7 +78,7 @@ trait ApiReleaseControllerBase extends ControllerBase {
       val release = getRelease(repository.owner, repository.name, data.tag_name).get
       val assets = getReleaseAssets(repository.owner, repository.name, data.tag_name)
       JsonFormat(ApiRelease(release, assets, context.loginAccount.get, RepositoryName(repository)))
-    })
+    } getOrElse BadRequest()
   })
 
   /**
@@ -89,15 +87,13 @@ trait ApiReleaseControllerBase extends ControllerBase {
    * Incompatibility info: GitHub API requires :release_id, but GitBucket API requires :tag_name
    */
   patch("/api/v3/repos/:owner/:repository/releases/:tag")(writableUsersOnly { repository =>
-    (for {
-      data <- extractFromJsonBody[CreateARelease]
-    } yield {
+    extractFromJsonBody[CreateARelease].map { data =>
       val tag = params("tag")
       updateRelease(repository.owner, repository.name, tag, data.name.getOrElse(data.tag_name), data.body)
       val release = getRelease(repository.owner, repository.name, data.tag_name).get
       val assets = getReleaseAssets(repository.owner, repository.name, data.tag_name)
       JsonFormat(ApiRelease(release, assets, context.loginAccount.get, RepositoryName(repository)))
-    })
+    } getOrElse BadRequest()
   })
 
   /**

--- a/src/main/scala/gitbucket/core/controller/api/ApiUserControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiUserControllerBase.scala
@@ -5,7 +5,7 @@ import gitbucket.core.service.{AccountService, RepositoryService}
 import gitbucket.core.util.{AdminAuthenticator, UsersAuthenticator}
 import gitbucket.core.util.Implicits._
 import gitbucket.core.util.StringUtil._
-import org.scalatra.NoContent
+import org.scalatra.{BadRequest, NoContent}
 
 trait ApiUserControllerBase extends ControllerBase {
   self: RepositoryService & AccountService & AdminAuthenticator & UsersAuthenticator =>
@@ -45,7 +45,7 @@ trait ApiUserControllerBase extends ControllerBase {
       )
       updateAccount(updatedAccount)
       JsonFormat(ApiUser(updatedAccount))
-    })
+    }) getOrElse BadRequest()
   })
 
   /*
@@ -66,7 +66,7 @@ trait ApiUserControllerBase extends ControllerBase {
    * https://developer.github.com/enterprise/2.14/v3/enterprise-admin/users/#create-a-new-user
    */
   post("/api/v3/admin/users")(adminOnly {
-    for {
+    (for {
       data <- extractFromJsonBody[CreateAUser]
     } yield {
       val user = createAccount(
@@ -79,7 +79,7 @@ trait ApiUserControllerBase extends ControllerBase {
         data.url
       )
       JsonFormat(ApiUser(user))
-    }
+    }) getOrElse BadRequest()
   })
 
   /*

--- a/src/test/scala/gitbucket/core/TestingGitBucketServer.scala
+++ b/src/test/scala/gitbucket/core/TestingGitBucketServer.scala
@@ -6,7 +6,7 @@ import java.io.File
 
 import gitbucket.core.util.{FileUtil, HttpClientUtil}
 import org.apache.http.client.entity.UrlEncodedFormEntity
-import org.apache.http.client.methods.{HttpGet, HttpPost}
+import org.apache.http.client.methods.{HttpGet, HttpPatch, HttpPost}
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.{BasicCookieStore, CloseableHttpClient, HttpClients}
 import org.apache.http.message.BasicNameValuePair
@@ -170,6 +170,34 @@ class TestingGitBucketServer(val port: Int = 19999) extends AutoCloseable {
       val credentials = Base64.getEncoder.encodeToString(s"$login:$password".getBytes("UTF-8"))
       get.setHeader("Authorization", s"Basic $credentials")
       val response = httpClient.execute(get)
+      val responseBody = Option(response.getEntity).map(EntityUtils.toString(_, "UTF-8")).getOrElse("")
+      ApiResponse(response.getStatusLine.getStatusCode, responseBody)
+    }
+  }
+
+  /** Perform an authenticated POST request with a JSON body and return the status code and response body. */
+  def postApi(path: String, body: String, login: String, password: String): ApiResponse = {
+    HttpClientUtil.withHttpClient(None) { httpClient =>
+      val post = new HttpPost(s"http://localhost:$port$path")
+      val credentials = Base64.getEncoder.encodeToString(s"$login:$password".getBytes("UTF-8"))
+      post.setHeader("Authorization", s"Basic $credentials")
+      post.setHeader("Content-Type", "application/json")
+      post.setEntity(new StringEntity(body, "UTF-8"))
+      val response = httpClient.execute(post)
+      val responseBody = Option(response.getEntity).map(EntityUtils.toString(_, "UTF-8")).getOrElse("")
+      ApiResponse(response.getStatusLine.getStatusCode, responseBody)
+    }
+  }
+
+  /** Perform an authenticated PATCH request with a JSON body and return the status code and response body. */
+  def patchApi(path: String, body: String, login: String, password: String): ApiResponse = {
+    HttpClientUtil.withHttpClient(None) { httpClient =>
+      val patch = new HttpPatch(s"http://localhost:$port$path")
+      val credentials = Base64.getEncoder.encodeToString(s"$login:$password".getBytes("UTF-8"))
+      patch.setHeader("Authorization", s"Basic $credentials")
+      patch.setHeader("Content-Type", "application/json")
+      patch.setEntity(new StringEntity(body, "UTF-8"))
+      val response = httpClient.execute(patch)
       val responseBody = Option(response.getEntity).map(EntityUtils.toString(_, "UTF-8")).getOrElse("")
       ApiResponse(response.getStatusLine.getStatusCode, responseBody)
     }

--- a/src/test/scala/gitbucket/core/api/ApiIntegrationTest.scala
+++ b/src/test/scala/gitbucket/core/api/ApiIntegrationTest.scala
@@ -640,4 +640,196 @@ class ApiIntegrationTest extends AnyFunSuite {
       assert(fork.getId != base.getId)
     }
   }
+
+  test("POST /admin/organizations creates an organization with the given profile") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val response = server.postApi(
+        "/api/v3/admin/organizations",
+        """{"login":"json-response-org","admin":"root","profile_name":"JSON Response Org"}""",
+        "root",
+        "root"
+      )
+      assert(response.status == 200, s"Expected 200 but got ${response.status}")
+
+      val organization = parse(response.body).extract[Map[String, Any]]
+      assert(organization("login") == "json-response-org")
+      assert(organization("description") == "JSON Response Org")
+    }
+  }
+
+  test("POST /admin/organizations with an unparsable request body returns 400") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val response = server.postApi("/api/v3/admin/organizations", "{", "root", "root")
+      assert(response.status == 400, s"Expected 400 but got ${response.status}")
+    }
+  }
+
+  test("POST /admin/users creates a user with the given login and email") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val response = server.postApi(
+        "/api/v3/admin/users",
+        """{"login":"json-response-user","password":"json-response-pass","email":"json-response-user@example.invalid"}""",
+        "root",
+        "root"
+      )
+      assert(response.status == 200, s"Expected 200 but got ${response.status}")
+
+      val user = parse(response.body).extract[Map[String, Any]]
+      assert(user("login") == "json-response-user")
+      assert(user("email") == "json-response-user@example.invalid")
+      assert(user("type") == "User")
+      assert(user("site_admin") == false)
+    }
+  }
+
+  test("POST /admin/users with an unparsable request body returns 400") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val response = server.postApi("/api/v3/admin/users", "{", "root", "root")
+      assert(response.status == 400, s"Expected 400 but got ${response.status}")
+    }
+  }
+
+  test("PATCH /user updates the authenticated user's profile") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      server.createUser("patch-user-test", "patch-user-pass", "patch-user-test@example.invalid", "root", "root")
+
+      val response = server.patchApi(
+        "/api/v3/user",
+        """{"email":"patch-user-test-updated@example.invalid"}""",
+        "patch-user-test",
+        "patch-user-pass"
+      )
+      assert(response.status == 200, s"Expected 200 but got ${response.status}")
+
+      val user = parse(response.body).extract[Map[String, Any]]
+      assert(user("login") == "patch-user-test")
+      assert(user("email") == "patch-user-test-updated@example.invalid")
+    }
+  }
+
+  test("PATCH /user with an unparsable request body returns 400") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      server.createUser("patch-user-bad-body", "patch-user-bad-pass", "patch-user-bad@example.invalid", "root", "root")
+
+      val response = server.patchApi("/api/v3/user", "{", "patch-user-bad-body", "patch-user-bad-pass")
+      assert(response.status == 400, s"Expected 400 but got ${response.status}")
+    }
+  }
+
+  test("POST /repos/:owner/:repo/pulls creates a pull request with the given title and body") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val github = server.client("root", "root")
+      val repo = github.createRepository("pulls_response_test").autoInit(true).create()
+      val sha1 = repo.getBranch("main").getSHA1
+      repo.createRef("refs/heads/feature", sha1)
+      repo
+        .createContent()
+        .content("feature content")
+        .path("feature.txt")
+        .message("Add feature file")
+        .branch("feature")
+        .commit()
+
+      val response = server.postApi(
+        "/api/v3/repos/root/pulls_response_test/pulls",
+        """{"title":"Add feature","head":"feature","base":"main","body":"feature description"}""",
+        "root",
+        "root"
+      )
+      assert(response.status == 200, s"Expected 200 but got ${response.status}")
+
+      val pullRequest = parse(response.body).extract[Map[String, Any]]
+      assert(pullRequest("title") == "Add feature")
+      assert(pullRequest("body") == "feature description")
+      assert(pullRequest("state") == "open")
+      assert(pullRequest("head").asInstanceOf[Map[String, Any]]("ref") == "feature")
+      assert(pullRequest("base").asInstanceOf[Map[String, Any]]("ref") == "main")
+    }
+  }
+
+  test("POST /repos/:owner/:repo/pulls with an unparsable request body returns 400") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val github = server.client("root", "root")
+      github.createRepository("pulls_bad_body_test").autoInit(true).create()
+
+      val response = server.postApi("/api/v3/repos/root/pulls_bad_body_test/pulls", "{", "root", "root")
+      assert(response.status == 400, s"Expected 400 but got ${response.status}")
+    }
+  }
+
+  test("POST /repos/:owner/:repo/releases creates a release with the given tag and body") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val github = server.client("root", "root")
+      github.createRepository("releases_response_test").autoInit(true).create()
+
+      val response = server.postApi(
+        "/api/v3/repos/root/releases_response_test/releases",
+        """{"tag_name":"v1.0.0","name":"Version 1.0.0","body":"initial release"}""",
+        "root",
+        "root"
+      )
+      assert(response.status == 200, s"Expected 200 but got ${response.status}")
+
+      val release = parse(response.body).extract[Map[String, Any]]
+      assert(release("tag_name") == "v1.0.0")
+      assert(release("name") == "Version 1.0.0")
+      assert(release("body") == "initial release")
+    }
+  }
+
+  test("POST /repos/:owner/:repo/releases with an unparsable request body returns 400") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val github = server.client("root", "root")
+      github.createRepository("releases_bad_body_test").autoInit(true).create()
+
+      val response = server.postApi("/api/v3/repos/root/releases_bad_body_test/releases", "{", "root", "root")
+      assert(response.status == 400, s"Expected 400 but got ${response.status}")
+    }
+  }
+
+  test("PATCH /repos/:owner/:repo/releases/:tag updates the release name and body") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val github = server.client("root", "root")
+      github.createRepository("release_patch_test").autoInit(true).create()
+
+      val createResponse = server.postApi(
+        "/api/v3/repos/root/release_patch_test/releases",
+        """{"tag_name":"v1.0.0","name":"Version 1.0.0","body":"initial release"}""",
+        "root",
+        "root"
+      )
+      assert(createResponse.status == 200, s"Expected 200 but got ${createResponse.status}")
+
+      val response = server.patchApi(
+        "/api/v3/repos/root/release_patch_test/releases/v1.0.0",
+        """{"tag_name":"v1.0.0","name":"Version 1.0.0 - updated","body":"updated release notes"}""",
+        "root",
+        "root"
+      )
+      assert(response.status == 200, s"Expected 200 but got ${response.status}")
+
+      val release = parse(response.body).extract[Map[String, Any]]
+      assert(release("tag_name") == "v1.0.0")
+      assert(release("name") == "Version 1.0.0 - updated")
+      assert(release("body") == "updated release notes")
+    }
+  }
+
+  test("PATCH /repos/:owner/:repo/releases/:tag with an unparsable request body returns 400") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val github = server.client("root", "root")
+      github.createRepository("release_patch_bad_body_test").autoInit(true).create()
+
+      server.postApi(
+        "/api/v3/repos/root/release_patch_bad_body_test/releases",
+        """{"tag_name":"v1.0.0","name":"Version 1.0.0","body":"initial release"}""",
+        "root",
+        "root"
+      )
+
+      val response =
+        server.patchApi("/api/v3/repos/root/release_patch_bad_body_test/releases/v1.0.0", "{", "root", "root")
+      assert(response.status == 400, s"Expected 400 but got ${response.status}")
+    }
+  }
 }


### PR DESCRIPTION
…instead of a string.

### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Several GitHub API compatibility routes are returning a json value wrapped in a json string, rather than simply returning the json value, so they are broken from a compatibility standpoint.

Make two fixes to these routes:

* Response value is not wrapped in a string
* Unparseable requests are responded to with 400 Bad Request

Impacted routes:

* `POST /api/v3/admin/organizations`
* `POST /api/v3/repos/:owner/:repository/pulls`
* `POST /api/v3/repos/:owner/:repository/releases`
* `PATCH /api/v3/repos/:owner/:repository/releases/:tag`
* `PATCH /api/v3/user`
* `POST /api/v3/admin/users`