### PR TITLE
Return a null User object in api responses for commit authors that are not GitBucket users

### DIFF
--- a/src/main/scala/gitbucket/core/api/ApiCommits.scala
+++ b/src/main/scala/gitbucket/core/api/ApiCommits.scala
@@ -55,8 +55,8 @@ object ApiCommits {
     repositoryName: RepositoryName,
     commitInfo: CommitInfo,
     diffs: Seq[DiffInfo],
-    author: Account,
-    committer: Account,
+    author: Option[Account],
+    committer: Option[Account],
     commentCount: Int
   ): ApiCommits = {
     val files = diffs.map { diff =>
@@ -113,8 +113,8 @@ object ApiCommits {
           sha = commitInfo.id
         )
       ),
-      author = ApiUser(author),
-      committer = ApiUser(committer),
+      author = author.map(ApiUser(_)).orNull,
+      committer = committer.map(ApiUser(_)).orNull,
       parents = commitInfo.parents.map { parent =>
         Tree(
           url = ApiPath(

--- a/src/main/scala/gitbucket/core/controller/api/ApiRepositoryCommitControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiRepositoryCommitControllerBase.scala
@@ -1,7 +1,6 @@
 package gitbucket.core.controller.api
 import gitbucket.core.api.{ApiBranchCommit, ApiBranchForHeadCommit, ApiCommits, JsonFormat}
 import gitbucket.core.controller.ControllerBase
-import gitbucket.core.model.Account
 import gitbucket.core.service.{AccountService, CommitsService, ProtectedBranchService}
 import gitbucket.core.util.Directory.getRepositoryDir
 import gitbucket.core.util.Implicits.*
@@ -77,8 +76,8 @@ trait ApiRepositoryCommitControllerBase extends ControllerBase {
             repositoryName = RepositoryName(repository),
             commitInfo = commitInfo,
             diffs = JGitUtil.getDiffs(git, commitInfo.parents.headOption, commitInfo.id, false, true),
-            author = getAccount(commitInfo.authorName, commitInfo.authorEmailAddress),
-            committer = getAccount(commitInfo.committerName, commitInfo.committerEmailAddress),
+            author = getAccountByMailAddress(commitInfo.authorEmailAddress),
+            committer = getAccountByMailAddress(commitInfo.committerEmailAddress),
             commentCount = getCommitComment(repository.owner, repository.name, commitInfo.id).size
           )
         })
@@ -107,33 +106,13 @@ trait ApiRepositoryCommitControllerBase extends ControllerBase {
           repositoryName = RepositoryName(repository),
           commitInfo = commitInfo,
           diffs = JGitUtil.getDiffs(git, commitInfo.parents.headOption, commitInfo.id, false, true),
-          author = getAccount(commitInfo.authorName, commitInfo.authorEmailAddress),
-          committer = getAccount(commitInfo.committerName, commitInfo.committerEmailAddress),
+          author = getAccountByMailAddress(commitInfo.authorEmailAddress),
+          committer = getAccountByMailAddress(commitInfo.committerEmailAddress),
           commentCount = getCommitComment(repository.owner, repository.name, sha).size
         )
       )
     }
   })
-
-  private def getAccount(userName: String, email: String): Account = {
-    getAccountByMailAddress(email).getOrElse {
-      Account(
-        userName = userName,
-        fullName = userName,
-        mailAddress = email,
-        password = "xxx",
-        isAdmin = false,
-        url = None,
-        registeredDate = new java.util.Date(),
-        updatedDate = new java.util.Date(),
-        lastLoginDate = None,
-        image = None,
-        isGroupAccount = false,
-        isRemoved = true,
-        description = None
-      )
-    }
-  }
 
   /*
    * iii. Get the SHA-1 of a commit reference

--- a/src/test/scala/gitbucket/core/api/ApiIntegrationTest.scala
+++ b/src/test/scala/gitbucket/core/api/ApiIntegrationTest.scala
@@ -4,7 +4,7 @@ import gitbucket.core.TestingGitBucketServer
 import gitbucket.core.api.ApiError
 import org.apache.commons.io.IOUtils
 import org.eclipse.jgit.api.Git
-import org.json4s.{DefaultFormats, jvalue2extractable}
+import org.json4s.{DefaultFormats, JArray, JObject, JNull, JString, jvalue2extractable}
 import org.json4s.jackson.JsonMethods.parse
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -168,6 +168,55 @@ class ApiIntegrationTest extends AnyFunSuite {
         assert(tags.size() == 1)
         assert(tags.get(0).getName == "v1.0")
       }
+    }
+  }
+
+  test("commit APIs return null account fields for an unmapped Git author") {
+    Using.resource(new TestingGitBucketServer(19999)) { server =>
+      val github = server.client("root", "root")
+      github.createRepository("unmapped_commit_author").autoInit(true).create()
+
+      val bareRepository = new File(server.getDirectory(), "repositories/root/unmapped_commit_author")
+      val workTree = new File(server.getDirectory(), "unmapped_commit_author-worktree")
+      val commitId =
+        Using.resource(Git.cloneRepository().setURI(bareRepository.toURI.toString).setDirectory(workTree).call()) {
+          git =>
+            val commit = git
+              .commit()
+              .setAllowEmpty(true)
+              .setMessage("Commit from an unmapped Git identity")
+              .setAuthor("Unmapped Author", "unmapped-author@example.invalid")
+              .setCommitter("Unmapped Committer", "unmapped-committer@example.invalid")
+              .call()
+            git.push().call()
+            commit.getName
+        }
+
+      val listResponse = server.getApi("/api/v3/repos/root/unmapped_commit_author/commits", "root", "root")
+      assert(listResponse.status == 200)
+      val listCommit = parse(listResponse.body).asInstanceOf[JArray].arr.head
+      def field(json: JObject, name: String) = json.obj.collectFirst { case (`name`, value) => value }.get
+      assert(field(listCommit.asInstanceOf[JObject], "author") == JNull)
+      assert(field(listCommit.asInstanceOf[JObject], "committer") == JNull)
+
+      val singleResponse =
+        server.getApi(s"/api/v3/repos/root/unmapped_commit_author/commits/${commitId}", "root", "root")
+      assert(singleResponse.status == 200)
+      val singleCommit = parse(singleResponse.body).asInstanceOf[JObject]
+      assert(field(singleCommit, "author") == JNull)
+      assert(field(singleCommit, "committer") == JNull)
+
+      val singleCommitInfo = field(singleCommit, "commit").asInstanceOf[JObject]
+      val singleCommitAuthor = field(singleCommitInfo, "author").asInstanceOf[JObject]
+      val singleCommitCommitter = field(singleCommitInfo, "committer").asInstanceOf[JObject]
+      assert(
+        field(singleCommitAuthor, "name") == JString("Unmapped Author") &&
+          field(singleCommitAuthor, "email") == JString("unmapped-author@example.invalid")
+      )
+      assert(
+        field(singleCommitCommitter, "name") == JString("Unmapped Committer") &&
+          field(singleCommitCommitter, "email") == JString("unmapped-committer@example.invalid")
+      )
     }
   }
 

--- a/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
+++ b/src/test/scala/gitbucket/core/api/ApiSpecModels.scala
@@ -345,8 +345,8 @@ object ApiSpecModels {
                        |\ No newline at end of file""".stripMargin)
       )
     ),
-    author = account,
-    committer = account,
+    author = Some(account),
+    committer = Some(account),
     commentCount = 2
   )
 


### PR DESCRIPTION

### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

The GitHub api returns `null` for an author or committer who is not a registered user of GitHub.

Change GitBucket to behave the same as GitHub - instead of returning a fictitious user as the committer or author, return null.

Example of this behavior on GitHub:
https://api.github.com/repos/torvalds/linux/commits/fddb5ceaf901b050ed2a1a7deeecbf97e003435a
