### PR TITLE
Improve GitBucketCoreModuleSpec test suite runtime by starting all containers at once

### DIFF
--- a/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
+++ b/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
@@ -12,17 +12,23 @@ import org.apache.commons.io.FileUtils
 import org.junit.runner.Description
 import org.eclipse.jgit.api.Git
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.Tag
+import org.scalatest.{BeforeAndAfterAll, Tag}
+import org.testcontainers.lifecycle.Startable
 import org.testcontainers.mysql.MySQLContainer
 import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.*
+import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters.*
 import scala.util.Using
+import scala.util.control.NonFatal
 
 object ExternalDBTest extends Tag("ExternalDBTest")
 
-class GitBucketCoreModuleSpec extends AnyFunSuite {
+class GitBucketCoreModuleSpec extends AnyFunSuite with BeforeAndAfterAll {
 
   private case class ColumnMetadata(name: String, sqlType: Int, size: Int, autoIncrement: Boolean)
   private case class TableSnapshot(columns: Seq[String], rows: Seq[Seq[String]])
@@ -633,13 +639,41 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
 
   implicit private val suiteDescription: Description = Description.createSuiteDescription(getClass)
 
+  // Kick off container start while tests are registering. This results in containers starting in
+  // parallel, substantially reducing test suite execution time.
+  //
+  // Due to the Directory singleton, the tests themselves cannot run in parallel.
+  //
+  // Every container is tracked so afterAll can stop it even if that container's own test never
+  // ran (e.g. via an sbt test filter) instead of leaving it running until Ryuk reaps it.
+  private val containersToStop = ArrayBuffer.empty[Future[Startable]]
+
+  private def newMySQLContainer(tag: String): Future[MySQLContainer] = {
+    val container = new MySQLContainer(s"mysql:$tag") {
+      override def getDriverClassName = "org.mariadb.jdbc.Driver"
+      override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
+    }
+    val started = Future(container.start()).map(_ => container)
+    containersToStop += started
+    started
+  }
+
+  private def newPostgreSQLContainer(tag: String): Future[PostgreSQLContainer] = {
+    val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
+    val started = Future(container.start()).map(_ => container)
+    containersToStop += started
+    started
+  }
+
+  override def afterAll(): Unit = {
+    val stopped = containersToStop.map(_.map(_.stop()).recover { case NonFatal(_) => () })
+    Await.result(Future.sequence(stopped), 5.minutes)
+  }
+
   Seq("8.4", "5.7").foreach { tag =>
+    val plainContainerStarted = newMySQLContainer(tag)
     test(s"Migration MySQL $tag", ExternalDBTest) {
-      val container = new MySQLContainer(s"mysql:$tag") {
-        override def getDriverClassName = "org.mariadb.jdbc.Driver"
-        override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
-      }
-      container.start()
+      val container = Await.result(plainContainerStarted, 5.minutes)
       try {
         new Solidbase().migrate(
           DriverManager.getConnection(
@@ -656,19 +690,17 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
       }
     }
 
+    val repairsContainerStarted = newMySQLContainer(tag)
     test(
       s"Migration MySQL $tag repairs missing origin and parent repositories before adding self-referential constraints",
       ExternalDBTest
     ) {
-      val container = new MySQLContainer(s"mysql:$tag") {
-        override def getDriverClassName = "org.mariadb.jdbc.Driver"
-        override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
-      }
-      container.start()
+      val container = Await.result(repairsContainerStarted, 5.minutes)
       try {
         withRepositoryDirCleanup {
           Using.resource(
-            DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
+            DriverManager
+              .getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
           ) { conn =>
             assertOrphanRepairMigration(conn, new MySQLDatabase())
           }
@@ -678,15 +710,16 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
       }
     }
 
+    val preservedContainerStarted = newMySQLContainer(tag)
     test(s"Migration MySQL $tag ensure repository data is preserved after 4.47 schema changes", ExternalDBTest) {
-      val container = new MySQLContainer(s"mysql:$tag") {
-        override def getDriverClassName = "org.mariadb.jdbc.Driver"
-        override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
-      }
-      container.start()
+      val container = Await.result(preservedContainerStarted, 5.minutes)
       try {
         Using.resource(
-          DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
+          DriverManager.getConnection(
+            container.getJdbcUrl,
+            container.getUsername,
+            container.getPassword
+          )
         ) { conn =>
           assertRepositoryDataPreservedBy447Migrations(conn, new MySQLDatabase())
         }
@@ -697,13 +730,13 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
   }
 
   Seq("14", "18").foreach { tag =>
+    val plainContainerStarted = newPostgreSQLContainer(tag)
     test(s"Migration PostgreSQL $tag", ExternalDBTest) {
-      val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
-
-      container.start()
+      val container = Await.result(plainContainerStarted, 5.minutes)
       try {
         new Solidbase().migrate(
-          DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword),
+          DriverManager
+            .getConnection(container.getJdbcUrl, container.getUsername, container.getPassword),
           Thread.currentThread().getContextClassLoader(),
           new PostgresDatabase(),
           new Module(GitBucketCoreModule.getModuleId, GitBucketCoreModule.getVersions)
@@ -713,17 +746,17 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
       }
     }
 
+    val repairsContainerStarted = newPostgreSQLContainer(tag)
     test(
       s"Migration PostgreSQL $tag repairs missing origin and parent repositories before adding self-referential constraints",
       ExternalDBTest
     ) {
-      val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
-
-      container.start()
+      val container = Await.result(repairsContainerStarted, 5.minutes)
       try {
         withRepositoryDirCleanup {
           Using.resource(
-            DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
+            DriverManager
+              .getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
           ) { conn =>
             assertOrphanRepairMigration(conn, new PostgresDatabase())
           }
@@ -733,16 +766,19 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
       }
     }
 
+    val preservedContainerStarted = newPostgreSQLContainer(tag)
     test(
       s"Migration PostgreSQL $tag ensure repository data is preserved after 4.47 schema changes",
       ExternalDBTest
     ) {
-      val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
-
-      container.start()
+      val container = Await.result(preservedContainerStarted, 5.minutes)
       try {
         Using.resource(
-          DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
+          DriverManager.getConnection(
+            container.getJdbcUrl,
+            container.getUsername,
+            container.getPassword
+          )
         ) { conn =>
           assertRepositoryDataPreservedBy447Migrations(conn, new PostgresDatabase())
         }


### PR DESCRIPTION

### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

Reduces total test suite time (ie sbt test) by about 50 seconds. While the postgres containers start quickly, the MySQL containers take 20-30s to start.

This change starts all of the containers as the tests are registering, and each test awaits its own container when it starts executing. Containers start in parallel; test still execute in serial. The h2 tests execute first in parallel with MySQL containers starting.

A downside of this change is that a targeted/filtered sbt test run (eg for only h2 tests) still starts all of those containers and waits for them all to shut down, which increases the runtime of an h2-only run from 2s to 20s. This could be reduced back to single digit seconds if it is acceptable to rely on Ryuk to cleanup containers for tests that did not run.

An alternative strategy would be to split GitBucketCoreModuleSpec into separate specs for h2, postgres, and MySQL - that would make targeting better, though such a refactor would still benefit from the start-at-test-registration container strategy here.