### PR TITLE
Run GitBucketCoreModuleSpec Tests In Parallel; Leave Others Serial

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,12 @@ Test / testOptions += Tests.Setup(() => new java.io.File("target/gitbucket_home_
 Test / fork := true
 Test / testForkedParallel := false
 
+// Provisions the ExecutorService that suites mixing in ParallelTestExecution
+// use to run their own tests concurrently. This does not make sbt schedule
+// different suites concurrently with each other; that remains governed by
+// Test/testForkedParallel and Test/testGrouping above.
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-P8")
+
 // Packaging options
 packageOptions += Package.MainClass("JettyLauncher")
 

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ Container / javaOptions += "-Dlogback.configurationFile=/logback-dev.xml"
 Test / javaOptions += "-Dgitbucket.home=target/gitbucket_home_for_test"
 Test / testOptions += Tests.Setup(() => new java.io.File("target/gitbucket_home_for_test").mkdir())
 Test / fork := true
+Test / testForkedParallel := false
 
 // Packaging options
 packageOptions += Package.MainClass("JettyLauncher")

--- a/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
+++ b/src/main/scala/gitbucket/core/GitBucketCoreModule.scala
@@ -1,11 +1,11 @@
 package gitbucket.core
 
-import java.io.FileOutputStream
+import java.io.{File, FileOutputStream}
 import java.nio.charset.StandardCharsets
 import java.sql.Connection
 import java.util.UUID
 import gitbucket.core.model.Activity
-import gitbucket.core.util.Directory.{ActivityLog, getRepositoryDir}
+import gitbucket.core.util.Directory
 import gitbucket.core.util.{JDBCUtil, JGitUtil}
 import io.github.gitbucket.solidbase.Solidbase
 import io.github.gitbucket.solidbase.migration.{LiquibaseMigration, Migration}
@@ -19,8 +19,10 @@ import org.slf4j.LoggerFactory
 import java.util.logging.Level
 import scala.util.Using
 
-object GitBucketCoreModule
-    extends Module(
+class GitBucketCoreModule(
+  repositoryDir: (String, String) => File = Directory.getRepositoryDir,
+  activityLogFile: () => File = () => Directory.ActivityLog
+) extends Module(
       "gitbucket-core",
       new Version("4.0.0", new LiquibaseMigration("update/gitbucket-core_4.0.xml")),
       new Version("4.1.0"),
@@ -93,7 +95,7 @@ object GitBucketCoreModule
                 activityDate = rs.getTimestamp("ACTIVITY_DATE")
               )
             }
-            Using.resource(new FileOutputStream(ActivityLog, true)) { out =>
+            Using.resource(new FileOutputStream(activityLogFile(), true)) { out =>
               list.foreach { activity =>
                 out.write((write(activity) + "\n").getBytes(StandardCharsets.UTF_8))
               }
@@ -155,7 +157,7 @@ object GitBucketCoreModule
                 )
               }
               .foreach { case (owner, repository, defaultBranch) =>
-                val gitdir = getRepositoryDir(owner, repository)
+                val gitdir = repositoryDir(owner, repository)
                 if (!gitdir.exists()) {
                   logger.info(s"Create missing repository directory for ${owner}/${repository}")
                   FileUtils.forceMkdirParent(gitdir)
@@ -170,3 +172,5 @@ object GitBucketCoreModule
     ) {
   java.util.logging.Logger.getLogger("liquibase").setLevel(Level.SEVERE)
 }
+
+object GitBucketCoreModule extends GitBucketCoreModule(Directory.getRepositoryDir, () => Directory.ActivityLog)

--- a/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
+++ b/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
@@ -14,7 +14,7 @@ import org.apache.commons.io.FileUtils
 import org.junit.runner.Description
 import org.eclipse.jgit.api.Git
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.Tag
+import org.scalatest.{ParallelTestExecution, Tag}
 import org.testcontainers.mysql.MySQLContainer
 import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
@@ -24,7 +24,7 @@ import scala.util.Using
 
 object ExternalDBTest extends Tag("ExternalDBTest")
 
-class GitBucketCoreModuleSpec extends AnyFunSuite {
+class GitBucketCoreModuleSpec extends AnyFunSuite with ParallelTestExecution {
 
   private case class ColumnMetadata(name: String, sqlType: Int, size: Int, autoIncrement: Boolean)
   private case class TableSnapshot(columns: Seq[String], rows: Seq[Seq[String]])

--- a/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
+++ b/src/test/scala/gitbucket/core/GitBucketCoreModuleSpec.scala
@@ -1,9 +1,11 @@
 package gitbucket.core
 
+import java.io.File
+import java.nio.file.Files
 import java.sql.{Clob, Connection, DriverManager, Timestamp, Types}
 import java.time.Instant
 import java.util.Locale
-import gitbucket.core.util.{Directory, JGitUtil}
+import gitbucket.core.util.JGitUtil
 import io.github.gitbucket.solidbase.Solidbase
 import io.github.gitbucket.solidbase.model.Module
 import liquibase.database.Database
@@ -111,37 +113,45 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
     (missingOriginUserName, missingOriginRepositoryName),
     (missingParentUserName, missingParentRepositoryName)
   )
-  private val ownerRepositoryDir = Directory.getRepositoryDir(ownerUserName, ownerRepositoryName)
-  private val missingRepositoryDirs = Seq(
-    Directory.getRepositoryDir(missingOriginUserName, missingOriginRepositoryName),
-    Directory.getRepositoryDir(missingParentUserName, missingParentRepositoryName)
-  )
-  private val moduleBeforeOrphanRepair = new Module(
-    GitBucketCoreModule.getModuleId,
-    GitBucketCoreModule.getVersions.asScala
+
+  private def moduleBeforeOrphanRepair(module: GitBucketCoreModule) = new Module(
+    module.getModuleId,
+    module.getVersions.asScala
       .takeWhile(_.getVersion != orphanRepairStartVersion)
       .toList
       .asJava
   )
-  private val fullModule = new Module(GitBucketCoreModule.getModuleId, GitBucketCoreModule.getVersions)
 
   private def migrate(conn: Connection, db: Database, module: Module): Unit =
     new Solidbase().migrate(conn, Thread.currentThread().getContextClassLoader(), db, module)
 
-  private def withRepositoryDirCleanup[A](action: => A): A = {
-    val dirs = ownerRepositoryDir +: missingRepositoryDirs
-    dirs.foreach(FileUtils.deleteQuietly)
+  /**
+   * Gives the action a fresh, uniquely-named gitbucket home directory (deleted afterwards) and a
+   * GitBucketCoreModule bound to it, so concurrently running tests never share on-disk repository
+   * or activity-log state via the global Directory object.
+   */
+  private def withTestModule[A](action: ((String, String) => File, GitBucketCoreModule) => A): A = {
+    val home = Files.createTempDirectory("gitbucket-core-module-spec-").toFile
+    val repositoryDir: (String, String) => File = (owner, repository) =>
+      new File(home, s"repositories/$owner/$repository.git")
+    val module = new GitBucketCoreModule(
+      repositoryDir = repositoryDir,
+      activityLogFile = () => new File(home, "activity.log")
+    )
     try {
-      action
+      action(repositoryDir, module)
     } finally {
-      dirs.foreach(FileUtils.deleteQuietly)
+      FileUtils.deleteQuietly(home)
     }
   }
 
-  private def assertMissingRepositoryDirsCreated(): Unit = {
-    assert(!ownerRepositoryDir.exists())
+  private def assertMissingRepositoryDirsCreated(repositoryDir: (String, String) => File): Unit = {
+    assert(!repositoryDir(ownerUserName, ownerRepositoryName).exists())
 
-    missingRepositoryDirs.foreach { dir =>
+    Seq(
+      repositoryDir(missingOriginUserName, missingOriginRepositoryName),
+      repositoryDir(missingParentUserName, missingParentRepositoryName)
+    ).foreach { dir =>
       assert(dir.exists(), s"Expected repository directory to be created: ${dir.getAbsolutePath}")
       Using.resource(Git.open(dir)) { git =>
         assert(JGitUtil.isEmpty(git))
@@ -471,8 +481,12 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
     insertRow(conn, "RELEASE_ASSET", Map("SIZE" -> 12345L))
   }
 
-  private def assertDataPreservedBySchemaMigrations(conn: Connection, db: Database): Unit = {
-    migrate(conn, db, moduleBeforeOrphanRepair)
+  private def assertDataPreservedBySchemaMigrations(
+    conn: Connection,
+    db: Database,
+    module: GitBucketCoreModule
+  ): Unit = {
+    migrate(conn, db, moduleBeforeOrphanRepair(module))
     insertSchemaPreservationData(conn)
 
     val beforeSnapshots =
@@ -480,7 +494,7 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
     val repositoryColumnsBeforeMigration = beforeSnapshots("REPOSITORY").columns
     val accountColumnsBeforeMigration = beforeSnapshots("ACCOUNT").columns
 
-    migrate(conn, db, fullModule)
+    migrate(conn, db, module)
 
     schemaPreservationSnapshotTables.foreach { tableName =>
       val expected = beforeSnapshots(tableName)
@@ -567,10 +581,15 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
       }
     }
 
-  private def assertOrphanRepairMigration(conn: Connection, db: Database): Unit = {
-    migrate(conn, db, moduleBeforeOrphanRepair)
+  private def assertOrphanRepairMigration(
+    conn: Connection,
+    db: Database,
+    module: GitBucketCoreModule,
+    repositoryDir: (String, String) => File
+  ): Unit = {
+    migrate(conn, db, moduleBeforeOrphanRepair(module))
     insertRepositoryWithMissingOriginAndParent(conn)
-    migrate(conn, db, fullModule)
+    migrate(conn, db, module)
 
     val accounts = accountRows(conn)
     assert(accounts.map(_.userName).toSet == expectedAccountNames)
@@ -612,31 +631,38 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
         assert(repository.parentRepositoryName.isEmpty)
     }
 
-    assertMissingRepositoryDirsCreated()
+    assertMissingRepositoryDirsCreated(repositoryDir)
   }
 
   test("Migration H2") {
-    new Solidbase().migrate(
-      DriverManager.getConnection("jdbc:h2:mem:test", "sa", "sa"),
-      Thread.currentThread().getContextClassLoader(),
-      new H2Database(),
-      new Module(GitBucketCoreModule.getModuleId, GitBucketCoreModule.getVersions)
-    )
+    withTestModule { (_, module) =>
+      Using.resource(DriverManager.getConnection("jdbc:h2:mem:test", "sa", "sa")) { conn =>
+        new Solidbase().migrate(
+          conn,
+          Thread.currentThread().getContextClassLoader(),
+          new H2Database(),
+          module
+        )
+      }
+    }
   }
 
   test("Migration H2 repairs missing origin and parent repositories before adding self-referential constraints") {
-    withRepositoryDirCleanup {
+    withTestModule { (repositoryDir, module) =>
       Using.resource(DriverManager.getConnection("jdbc:h2:mem:test-orphan-repair;DB_CLOSE_DELAY=-1", "sa", "sa")) {
         conn =>
-          assertOrphanRepairMigration(conn, new H2Database())
+          assertOrphanRepairMigration(conn, new H2Database(), module, repositoryDir)
       }
     }
   }
 
   test("Migration H2 ensure data is preserved after 4.47 and 4.48 schema changes") {
-    Using.resource(DriverManager.getConnection("jdbc:h2:mem:test-schema-preservation;DB_CLOSE_DELAY=-1", "sa", "sa")) {
-      conn =>
-        assertDataPreservedBySchemaMigrations(conn, new H2Database())
+    withTestModule { (_, module) =>
+      Using.resource(
+        DriverManager.getConnection("jdbc:h2:mem:test-schema-preservation;DB_CLOSE_DELAY=-1", "sa", "sa")
+      ) { conn =>
+        assertDataPreservedBySchemaMigrations(conn, new H2Database(), module)
+      }
     }
   }
 
@@ -644,24 +670,26 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
 
   Seq("8.4", "5.7").foreach { tag =>
     test(s"Migration MySQL $tag", ExternalDBTest) {
-      val container = new MySQLContainer(s"mysql:$tag") {
-        override def getDriverClassName = "org.mariadb.jdbc.Driver"
-        override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
-      }
-      container.start()
-      try {
-        new Solidbase().migrate(
-          DriverManager.getConnection(
-            container.getJdbcUrl,
-            container.getUsername,
-            container.getPassword
-          ),
-          Thread.currentThread().getContextClassLoader(),
-          new MySQLDatabase(),
-          new Module(GitBucketCoreModule.getModuleId, GitBucketCoreModule.getVersions)
-        )
-      } finally {
-        container.stop()
+      withTestModule { (_, module) =>
+        val container = new MySQLContainer(s"mysql:$tag") {
+          override def getDriverClassName = "org.mariadb.jdbc.Driver"
+          override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
+        }
+        container.start()
+        try {
+          Using.resource(
+            DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
+          ) { conn =>
+            new Solidbase().migrate(
+              conn,
+              Thread.currentThread().getContextClassLoader(),
+              new MySQLDatabase(),
+              module
+            )
+          }
+        } finally {
+          container.stop()
+        }
       }
     }
 
@@ -669,56 +697,64 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
       s"Migration MySQL $tag repairs missing origin and parent repositories before adding self-referential constraints",
       ExternalDBTest
     ) {
-      val container = new MySQLContainer(s"mysql:$tag") {
-        override def getDriverClassName = "org.mariadb.jdbc.Driver"
-        override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
-      }
-      container.start()
-      try {
-        withRepositoryDirCleanup {
+      withTestModule { (repositoryDir, module) =>
+        val container = new MySQLContainer(s"mysql:$tag") {
+          override def getDriverClassName = "org.mariadb.jdbc.Driver"
+          override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
+        }
+        container.start()
+        try {
           Using.resource(
             DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
           ) { conn =>
-            assertOrphanRepairMigration(conn, new MySQLDatabase())
+            assertOrphanRepairMigration(conn, new MySQLDatabase(), module, repositoryDir)
           }
+        } finally {
+          container.stop()
         }
-      } finally {
-        container.stop()
       }
     }
 
     test(s"Migration MySQL $tag ensure data is preserved after 4.47 and 4.48 schema changes", ExternalDBTest) {
-      val container = new MySQLContainer(s"mysql:$tag") {
-        override def getDriverClassName = "org.mariadb.jdbc.Driver"
-        override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
-      }
-      container.start()
-      try {
-        Using.resource(
-          DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
-        ) { conn =>
-          assertDataPreservedBySchemaMigrations(conn, new MySQLDatabase())
+      withTestModule { (_, module) =>
+        val container = new MySQLContainer(s"mysql:$tag") {
+          override def getDriverClassName = "org.mariadb.jdbc.Driver"
+          override def getJdbcUrl: String = super.getJdbcUrl + "?permitMysqlScheme"
         }
-      } finally {
-        container.stop()
+        container.start()
+        try {
+          Using.resource(
+            DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
+          ) { conn =>
+            assertDataPreservedBySchemaMigrations(conn, new MySQLDatabase(), module)
+          }
+        } finally {
+          container.stop()
+        }
       }
     }
   }
 
   Seq("14", "18").foreach { tag =>
     test(s"Migration PostgreSQL $tag", ExternalDBTest) {
-      val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
+      withTestModule { (_, module) =>
+        val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
 
-      container.start()
-      try {
-        new Solidbase().migrate(
-          DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword),
-          Thread.currentThread().getContextClassLoader(),
-          new PostgresDatabase(),
-          new Module(GitBucketCoreModule.getModuleId, GitBucketCoreModule.getVersions)
-        )
-      } finally {
-        container.stop()
+        container.start()
+        try {
+          Using.resource(
+            DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
+          ) { conn =>
+            new Solidbase().migrate(
+              conn,
+              Thread.currentThread().getContextClassLoader(),
+              new PostgresDatabase(),
+              module
+            )
+          }
+        } finally {
+          container.stop()
+        }
       }
     }
 
@@ -726,19 +762,19 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
       s"Migration PostgreSQL $tag repairs missing origin and parent repositories before adding self-referential constraints",
       ExternalDBTest
     ) {
-      val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
+      withTestModule { (repositoryDir, module) =>
+        val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
 
-      container.start()
-      try {
-        withRepositoryDirCleanup {
+        container.start()
+        try {
           Using.resource(
             DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
           ) { conn =>
-            assertOrphanRepairMigration(conn, new PostgresDatabase())
+            assertOrphanRepairMigration(conn, new PostgresDatabase(), module, repositoryDir)
           }
+        } finally {
+          container.stop()
         }
-      } finally {
-        container.stop()
       }
     }
 
@@ -746,17 +782,19 @@ class GitBucketCoreModuleSpec extends AnyFunSuite {
       s"Migration PostgreSQL $tag ensure data is preserved after 4.47 and 4.48 schema changes",
       ExternalDBTest
     ) {
-      val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
+      withTestModule { (_, module) =>
+        val container = new PostgreSQLContainer(DockerImageName.parse(s"postgres:$tag"))
 
-      container.start()
-      try {
-        Using.resource(
-          DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
-        ) { conn =>
-          assertDataPreservedBySchemaMigrations(conn, new PostgresDatabase())
+        container.start()
+        try {
+          Using.resource(
+            DriverManager.getConnection(container.getJdbcUrl, container.getUsername, container.getPassword)
+          ) { conn =>
+            assertDataPreservedBySchemaMigrations(conn, new PostgresDatabase(), module)
+          }
+        } finally {
+          container.stop()
         }
-      } finally {
-        container.stop()
       }
     }
   }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

This consistently cuts down the test suite execution time by at least 90s and up to 2m (from around 4:45 to around 2:45).

Prior to this pr, each test and each test spec ran in serial - no parallelization at all. Recent new migration tests extended the runtime, and MySQL also takes a substantial amount of time to start, which is not meaningfully reduced in the latest MySQL LTS.

After this pr, all tests within `GitBucketCoreModuleSpec` will run in parallel when this spec is run, but all other specs will still run in serial relative to each other, and in other specs, tests will still run in serial.

* Refactors GitBucketCoreModule so instances can be created with base folders provided via a constructor instead of the `Directory` singleton
* Modifies `GitBucketCoreModuleSpec` tests to create unique temporary folders and provide them via the constructor
* All other tests still use the `Directory` singleton which obtains its home folder from a jvm property set in the sbt build config
* `Test / testForkedParallel` already defaults to false; added a line to the build config to make this explicit since most of the test suite still requires serial execution

Alternative to:

* https://github.com/gitbucket/gitbucket/pull/4101
* https://github.com/gitbucket/gitbucket/pull/4105

I also explored refactoring `Directory` so it is no longer a singleton, but this was unsurprisingly very invasive, and might break plugins. If it were possible, it would make parallelization substantially easier.

Also, while `MySQL` container start time is the majority contributor to the slowness, Liquibase XML migration parsing is also a substantial contributor. I explored changing `SolidBase` to make it cacheable but avoiding the singleton pattern there also is very invasive too (though not as much as refactoring `Directory`). 
