### PR TITLE
Bug Fix - Prevent Deleting Or Downgrading Last Administrator User

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -359,7 +359,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
 
     getAccountByUserName(userName, includeRemoved = true).map { account =>
       if (isLastAdministrator(account)) {
-        flash.update("error", "Account can't be removed because this is last one administrator.")
+        flash.update("error", "Account can't be removed because this one is the last administrator.")
         redirect(s"/$userName/_danger_zone")
       } else {
 //      // Remove repositories

--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -345,13 +345,22 @@ trait AccountControllerBase extends AccountManagementControllerBase {
     } getOrElse NotFound()
   })
 
+  get("/:userName/_danger_zone")(
+    oneselfOnly {
+      val userName = params("userName")
+      getAccountByUserName(userName).map { x =>
+        html.danger(x, flash.get("info"), flash.get("error"))
+      } getOrElse NotFound()
+    }
+  )
+
   get("/:userName/_delete")(oneselfOnly {
     val userName = params("userName")
 
     getAccountByUserName(userName, includeRemoved = true).map { account =>
       if (isLastAdministrator(account)) {
         flash.update("error", "Account can't be removed because this is last one administrator.")
-        redirect(s"/$userName/_edit")
+        redirect(s"/$userName/_danger_zone")
       } else {
 //      // Remove repositories
 //      getRepositoryNamesOfUser(userName).foreach { repositoryName =>

--- a/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
+++ b/src/main/scala/gitbucket/core/controller/SystemSettingsController.scala
@@ -431,7 +431,7 @@ trait SystemSettingsControllerBase extends AccountManagementControllerBase {
     val userName = params("userName")
     getAccountByUserName(userName, includeRemoved = true).map { account =>
       if (account.isAdmin && (form.isRemoved || !form.isAdmin) && isLastAdministrator(account)) {
-        flash.update("error", "Account can't be turned off because this is last one administrator.")
+        flash.update("error", "Account can't be downgraded or turned off because this one is the last administrator.")
         redirect(s"/admin/users/${userName}/_edituser")
       } else {
         if (form.isRemoved) {

--- a/src/main/scala/gitbucket/core/service/AccountService.scala
+++ b/src/main/scala/gitbucket/core/service/AccountService.scala
@@ -160,7 +160,7 @@ trait AccountService {
 
   def isLastAdministrator(account: Account)(implicit s: Session): Boolean = {
     if (account.isAdmin) {
-      (Accounts filter (_.removed === false.bind) filter (_.isAdmin === true.bind) map (_.userName.length)).first == 1
+      Query(Accounts.filter(_.removed === false.bind).filter(_.isAdmin === true.bind).length).first == 1
     } else false
   }
 

--- a/src/main/twirl/gitbucket/core/account/danger.scala.html
+++ b/src/main/twirl/gitbucket/core/account/danger.scala.html
@@ -1,0 +1,29 @@
+@(account: gitbucket.core.model.Account, info: Option[Any], error: Option[Any])(implicit context: gitbucket.core.controller.Context)
+@import gitbucket.core.view.helpers
+@gitbucket.core.html.main("Danger Zone"){
+  @gitbucket.core.account.html.menu("profile", context.loginAccount.get.userName, false){
+    @gitbucket.core.account.html.profilemenu("danger", account.userName){
+      @gitbucket.core.helper.html.information(info)
+      @gitbucket.core.helper.html.error(error)
+      <div class="panel panel-default">
+        <div class="panel-heading strong">Danger Zone</div>
+        <div class="panel-body">
+          <fieldset class="form-group">
+            <label class="strong">Delete account</label>
+            <div>
+              Permanently delete this account. This cannot be undone.
+              <a href="@helpers.url(account.userName)/_delete" class="btn btn-danger pull-right" id="delete">Delete account</a>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    }
+  }
+}
+<script>
+$(function(){
+  $('#delete').click(function(){
+    return confirm('Once you delete your account, there is no going back.\nAre you sure?');
+  });
+});
+</script>

--- a/src/main/twirl/gitbucket/core/account/edit.scala.html
+++ b/src/main/twirl/gitbucket/core/account/edit.scala.html
@@ -3,68 +3,67 @@
 @import gitbucket.core.view.helpers
 @gitbucket.core.html.main("Edit your profile"){
   @gitbucket.core.account.html.menu("profile", context.loginAccount.get.userName, false){
-    @gitbucket.core.helper.html.information(info)
-    @gitbucket.core.helper.html.error(error)
-    @if(LDAPUtil.isDummyMailAddress(account)){<div class="alert alert-danger">Please register your mail address.</div>}
-    <form action="@helpers.url(account.userName)/_edit" method="POST" validate="true" autocomplete="off">
-      <div class="panel panel-default">
-        <div class="panel-heading strong">Profile</div>
-        <div class="panel-body">
-          <div class="row">
-            <div class="col-md-6">
-              @if(account.password.nonEmpty){
-                <fieldset class="form-group">
-                  <label for="password" class="strong">
-                    Password (input to change password):
-                  </label>
-                  <input type="password" name="password" id="password" class="form-control" value="" autocomplete="off"/>
-                  <span id="error-password" class="error"></span>
-                </fieldset>
-              }
-              <fieldset class="form-group">
-                <label for="fullName" class="strong">Full Name:</label>
-                <input type="text" name="fullName" id="fullName" class="form-control" value="@account.fullName"/>
-                <span id="error-fullName" class="error"></span>
-              </fieldset>
-              <fieldset class="form-group">
-                <label for="mailAddress" class="strong">Mail Address:</label>
-                <input type="text" name="mailAddress" id="mailAddress" class="form-control" value="@if(!LDAPUtil.isDummyMailAddress(account)){@account.mailAddress}"/>
-                <span id="error-mailAddress" class="error"></span>
-              </fieldset>
-              <fieldset class="form-group" id="extraMailAddresses">
-                <span class="strong">Additional Mail Address:</span>
-                @extraMailAddresses.zipWithIndex.map { case (mail, idx) =>
-                  <input type="text" name="extraMailAddresses[@idx]" id="extraMailAddresses[@idx]" class="form-control extraMailAddress" value="@mail" aria-label="Additional mail address"/>
-                  <span id="error-extraMailAddresses_@idx" class="error"></span>
+    @gitbucket.core.account.html.profilemenu("general", account.userName){
+      @gitbucket.core.helper.html.information(info)
+      @gitbucket.core.helper.html.error(error)
+      @if(LDAPUtil.isDummyMailAddress(account)){<div class="alert alert-danger">Please register your mail address.</div>}
+      <form action="@helpers.url(account.userName)/_edit" method="POST" validate="true" autocomplete="off">
+        <div class="panel panel-default">
+          <div class="panel-heading strong">Profile</div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+                @if(account.password.nonEmpty){
+                  <fieldset class="form-group">
+                    <label for="password" class="strong">
+                      Password (input to change password):
+                    </label>
+                    <input type="password" name="password" id="password" class="form-control" value="" autocomplete="off"/>
+                    <span id="error-password" class="error"></span>
+                  </fieldset>
                 }
-              </fieldset>
-              <fieldset class="form-group">
-                <label for="url" class="strong">URL (optional):</label>
-                <input type="text" name="url" id="url" class="form-control" value="@account.url"/>
-                <span id="error-url" class="error"></span>
-              </fieldset>
-              <fieldset class="form-group">
-                <label for="description" class="strong">Bio (optional):</label>
-                <textarea name="description" id="description" class="form-control">@account.description</textarea>
-                <span id="error-description" class="error"></span>
-              </fieldset>
-            </div>
-            <div class="col-md-6">
-              <fieldset class="form-group">
-                <label for="avatar" class="strong">Image (optional):</label>
-                @gitbucket.core.helper.html.uploadavatar(Some(account))
-              </fieldset>
+                <fieldset class="form-group">
+                  <label for="fullName" class="strong">Full Name:</label>
+                  <input type="text" name="fullName" id="fullName" class="form-control" value="@account.fullName"/>
+                  <span id="error-fullName" class="error"></span>
+                </fieldset>
+                <fieldset class="form-group">
+                  <label for="mailAddress" class="strong">Mail Address:</label>
+                  <input type="text" name="mailAddress" id="mailAddress" class="form-control" value="@if(!LDAPUtil.isDummyMailAddress(account)){@account.mailAddress}"/>
+                  <span id="error-mailAddress" class="error"></span>
+                </fieldset>
+                <fieldset class="form-group" id="extraMailAddresses">
+                  <span class="strong">Additional Mail Address:</span>
+                  @extraMailAddresses.zipWithIndex.map { case (mail, idx) =>
+                    <input type="text" name="extraMailAddresses[@idx]" id="extraMailAddresses[@idx]" class="form-control extraMailAddress" value="@mail" aria-label="Additional mail address"/>
+                    <span id="error-extraMailAddresses_@idx" class="error"></span>
+                  }
+                </fieldset>
+                <fieldset class="form-group">
+                  <label for="url" class="strong">URL (optional):</label>
+                  <input type="text" name="url" id="url" class="form-control" value="@account.url"/>
+                  <span id="error-url" class="error"></span>
+                </fieldset>
+                <fieldset class="form-group">
+                  <label for="description" class="strong">Bio (optional):</label>
+                  <textarea name="description" id="description" class="form-control">@account.description</textarea>
+                  <span id="error-description" class="error"></span>
+                </fieldset>
+              </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label for="avatar" class="strong">Image (optional):</label>
+                  @gitbucket.core.helper.html.uploadavatar(Some(account))
+                </fieldset>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div>
-        <div class="pull-right">
-          <a href="@context.path/@account.userName/_delete" class="btn btn-danger" id="delete">Delete account</a>
+        <div>
+          <input type="submit" class="btn btn-success" value="Save" id="save"/>
         </div>
-        <input type="submit" class="btn btn-success" value="Save" id="save"/>
-      </div>
-    </form>
+      </form>
+    }
   }
 }
 <script>
@@ -78,10 +77,6 @@ $(function(){
     } else {
       return true;
     }
-  });
-
-  $('#delete').click(function(){
-    return confirm('Once you delete your account, there is no going back.\nAre you sure?');
   });
 });
 </script>

--- a/src/main/twirl/gitbucket/core/account/profilemenu.scala.html
+++ b/src/main/twirl/gitbucket/core/account/profilemenu.scala.html
@@ -1,0 +1,11 @@
+@(active: String, userName: String)(body: Html)(implicit context: gitbucket.core.controller.Context)
+@import gitbucket.core.view.helpers
+<ul class="nav nav-tabs" style="margin-bottom: 20px;">
+  <li@if(active=="general"){ class="active"}>
+    <a href="@helpers.url(userName)/_edit">General</a>
+  </li>
+  <li@if(active=="danger"){ class="active"}>
+    <a href="@helpers.url(userName)/_danger_zone">Danger Zone</a>
+  </li>
+</ul>
+@body

--- a/src/test/scala/gitbucket/core/controller/AccountDangerZoneControllerSpec.scala
+++ b/src/test/scala/gitbucket/core/controller/AccountDangerZoneControllerSpec.scala
@@ -1,0 +1,55 @@
+package gitbucket.core.controller
+
+import gitbucket.core.TestingGitBucketServer
+import org.apache.http.client.entity.UrlEncodedFormEntity
+import org.apache.http.client.methods.{HttpGet, HttpPost}
+import org.apache.http.impl.client.{BasicCookieStore, HttpClients}
+import org.apache.http.message.BasicNameValuePair
+import org.apache.http.util.EntityUtils
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.{Arrays => JArrays}
+import scala.util.Using
+
+/**
+ * Need to run `sbt package` before running this test.
+ */
+class AccountDangerZoneControllerSpec extends AnyFunSuite {
+
+  /** Perform a GET request through a signed-in web session (cookie-based) and return the HTTP status code. */
+  private def getWeb(server: TestingGitBucketServer, path: String, login: String, password: String): Int = {
+    Using.resource(HttpClients.custom().setDefaultCookieStore(new BasicCookieStore()).build()) { httpClient =>
+      val signin = new HttpPost(s"http://localhost:${server.port}/signin")
+      signin.setEntity(
+        new UrlEncodedFormEntity(
+          JArrays.asList(
+            new BasicNameValuePair("userName", login),
+            new BasicNameValuePair("password", password)
+          )
+        )
+      )
+      val signinResponse = httpClient.execute(signin)
+      EntityUtils.consume(signinResponse.getEntity)
+      assert(signinResponse.getStatusLine.getStatusCode < 400, "signin failed")
+
+      val get = new HttpGet(s"http://localhost:${server.port}$path")
+      val response = httpClient.execute(get)
+      EntityUtils.consume(response.getEntity)
+      response.getStatusLine.getStatusCode
+    }
+  }
+
+  test("GET /:userName/_danger_zone returns OK for a logged in user") {
+    Using.resource(new TestingGitBucketServer(19998)) { server =>
+      assert(getWeb(server, "/root/_danger_zone", "root", "root") == 200)
+    }
+  }
+
+  test("GET /:userName/_danger_zone behaves like /:userName/_edit when not authenticated") {
+    Using.resource(new TestingGitBucketServer(19998)) { server =>
+      val editStatus = server.getAnonymousApiStatus("/root/_edit")
+      val dangerZoneStatus = server.getAnonymousApiStatus("/root/_danger_zone")
+      assert(dangerZoneStatus == editStatus)
+    }
+  }
+}

--- a/src/test/scala/gitbucket/core/controller/AccountDeleteControllerSpec.scala
+++ b/src/test/scala/gitbucket/core/controller/AccountDeleteControllerSpec.scala
@@ -1,0 +1,54 @@
+package gitbucket.core.controller
+
+import gitbucket.core.TestingGitBucketServer
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.entity.UrlEncodedFormEntity
+import org.apache.http.client.methods.{HttpGet, HttpPost}
+import org.apache.http.impl.client.{BasicCookieStore, HttpClients}
+import org.apache.http.message.BasicNameValuePair
+import org.apache.http.util.EntityUtils
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.{Arrays => JArrays}
+import scala.util.Using
+
+/**
+ * Need to run `sbt package` before running this test.
+ */
+class AccountDeleteControllerSpec extends AnyFunSuite {
+
+  test("GET /:userName/_delete does not delete the last administrator on a fresh install") {
+    Using.resource(new TestingGitBucketServer(19996)) { server =>
+      Using.resource(HttpClients.custom().setDefaultCookieStore(new BasicCookieStore()).build()) { httpClient =>
+        val signin = new HttpPost(s"http://localhost:${server.port}/signin")
+        signin.setEntity(
+          new UrlEncodedFormEntity(
+            JArrays.asList(
+              new BasicNameValuePair("userName", "root"),
+              new BasicNameValuePair("password", "root")
+            )
+          )
+        )
+        val signinResponse = httpClient.execute(signin)
+        EntityUtils.consume(signinResponse.getEntity)
+        assert(signinResponse.getStatusLine.getStatusCode < 400, "signin failed")
+
+        val delete = new HttpGet(s"http://localhost:${server.port}/root/_delete")
+        delete.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build())
+        val deleteResponse = httpClient.execute(delete)
+        EntityUtils.consume(deleteResponse.getEntity)
+        // On a fresh install root is the only administrator, so the delete must be rejected
+        // and redirect back to the danger zone rather than invalidating the session.
+        assert(deleteResponse.getStatusLine.getStatusCode == 302)
+        val location = Option(deleteResponse.getFirstHeader("Location")).map(_.getValue).getOrElse("")
+        assert(location.endsWith("/root/_danger_zone"), s"expected redirect to /root/_danger_zone, got $location")
+
+        // root must still be authenticated - the account/session must not have been removed/invalidated.
+        val whoami = new HttpGet(s"http://localhost:${server.port}/root/_edit")
+        val whoamiResponse = httpClient.execute(whoami)
+        EntityUtils.consume(whoamiResponse.getEntity)
+        assert(whoamiResponse.getStatusLine.getStatusCode == 200, "root account should still exist and be logged in")
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [X] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

There is a check implemented to prevent the last administrator user from deleting or downgrading themselves, but it is defective - on a fresh install, the default `root` account can downgrade or delete itself. Fix that bug.

Also creates a new `Danger Zone` tab on the user profile edit page, which is similar to the tab by the same name for repositories, and moves the `Delete User` button to that tab.

A follow up pr will add a `Rename user` capability to the new danger zone tab, which is similar to the rename repository capability of the repository's danger zone tab.